### PR TITLE
fix share info disclosure

### DIFF
--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/FileShareHttpServer.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/FileShareHttpServer.kt
@@ -136,13 +136,12 @@ class FileShareHttpServer(
     @Serializable
     private data class ShareListResponse(val shares: List<ShareDto>)
 
-    /** 与桌面端 Rust SharedFolder 结构体字段严格一致(snake_case + path)，否则桌面端解析报 missing field */
+    /** 仅包含远程浏览所需的公开元数据，禁止泄漏 SAF URI 或共享密码。 */
     @Serializable
     private data class ShareDto(
         val id: String,
         val name: String,
-        val path: String,
-        val password: String? = null,
+        @kotlinx.serialization.SerialName("has_password") val hasPassword: Boolean,
         @kotlinx.serialization.SerialName("expire_time") val expireTime: Long? = null,
         @kotlinx.serialization.SerialName("compress_before_send") val compressBeforeSend: Boolean? = false,
         @kotlinx.serialization.SerialName("owner_id") val ownerId: String,
@@ -152,8 +151,7 @@ class FileShareHttpServer(
     private fun SharedFolder.toDto(): ShareDto = ShareDto(
         id = id,
         name = name,
-        path = name, // 桌面端仅展示 name、用 id 调 API，path 仅占位
-        password = password,
+        hasPassword = !password.isNullOrBlank(),
         expireTime = expireAt?.let { it / 1000 },
         compressBeforeSend = compressBeforeSend,
         ownerId = ownerId,

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/RemoteFileClient.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/RemoteFileClient.kt
@@ -40,7 +40,7 @@ class RemoteFileClient(private val context: Context) {
                     shareId = it.id,
                     shareName = it.name,
                     playerName = "",
-                    hasPassword = !it.password.isNullOrBlank(),
+                    hasPassword = it.hasPassword || !it.legacyPassword.isNullOrBlank(),
                 )
             }
         }
@@ -132,8 +132,9 @@ class RemoteFileClient(private val context: Context) {
     private data class RemoteShareDto(
         val id: String,
         val name: String,
-        val path: String? = null,
-        val password: String? = null,
+        @SerialName("has_password") val hasPassword: Boolean = false,
+        // 仅用于兼容尚未升级的旧节点；不会继续暴露给 UI 或其他接口。
+        @SerialName("password") val legacyPassword: String? = null,
         @SerialName("owner_id") val ownerId: String? = null,
     )
 }

--- a/src-tauri/src/modules/file_transfer.rs
+++ b/src-tauri/src/modules/file_transfer.rs
@@ -42,6 +42,38 @@ pub struct SharedFolder {
     pub created_at: u64,
 }
 
+/// 可安全暴露给远程节点的共享摘要。
+///
+/// 本地文件系统路径和共享密码只保留在服务端，绝不能通过 HTTP API 序列化。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SharedFolderSummary {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub has_password: bool,
+    pub expire_time: Option<u64>,
+    pub compress_before_send: Option<bool>,
+    pub owner_id: String,
+    pub created_at: u64,
+}
+
+impl From<&SharedFolder> for SharedFolderSummary {
+    fn from(share: &SharedFolder) -> Self {
+        Self {
+            id: share.id.clone(),
+            name: share.name.clone(),
+            has_password: share
+                .password
+                .as_deref()
+                .is_some_and(|password| !password.is_empty()),
+            expire_time: share.expire_time,
+            compress_before_send: share.compress_before_send,
+            owner_id: share.owner_id.clone(),
+            created_at: share.created_at,
+        }
+    }
+}
+
 /// 文件信息
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileInfo {
@@ -55,7 +87,7 @@ pub struct FileInfo {
 /// 共享列表响应
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ShareListResponse {
-    pub shares: Vec<SharedFolder>,
+    pub shares: Vec<SharedFolderSummary>,
 }
 
 /// 文件列表响应
@@ -386,15 +418,56 @@ fn safe_join(base: &Path, rel: &str) -> Option<PathBuf> {
 
 /// 获取共享列表
 async fn list_shares(State(state): State<AppState>) -> Json<ShareListResponse> {
-    let shares: Vec<SharedFolder> = state
+    let shares: Vec<SharedFolderSummary> = state
         .shared_folders
         .iter()
-        .map(|entry| entry.value().clone())
+        .map(|entry| SharedFolderSummary::from(entry.value()))
         .collect();
 
     log::debug!("📋 收到获取共享列表请求，返回 {} 个共享", shares.len());
 
     Json(ShareListResponse { shares })
+}
+
+#[cfg(test)]
+mod share_list_response_tests {
+    use super::{ShareListResponse, SharedFolder, SharedFolderSummary};
+
+    fn protected_share() -> SharedFolder {
+        SharedFolder {
+            id: "share-1".to_string(),
+            name: "Test share".to_string(),
+            path: r"C:\Users\test\private".to_string(),
+            password: Some("secret-password".to_string()),
+            expire_time: Some(1_900_000_000),
+            compress_before_send: Some(true),
+            owner_id: "owner-1".to_string(),
+            created_at: 1_800_000_000,
+        }
+    }
+
+    #[test]
+    fn public_share_summary_omits_path_and_password() {
+        let response = ShareListResponse {
+            shares: vec![SharedFolderSummary::from(&protected_share())],
+        };
+        let json = serde_json::to_value(response).expect("serialize share list response");
+        let share = &json["shares"][0];
+
+        assert_eq!(share["has_password"], true);
+        assert!(share.get("path").is_none());
+        assert!(share.get("password").is_none());
+        assert!(!json.to_string().contains("secret-password"));
+        assert!(!json.to_string().contains(r"C:\Users\test\private"));
+    }
+
+    #[test]
+    fn empty_password_is_reported_as_unprotected() {
+        let mut share = protected_share();
+        share.password = Some(String::new());
+
+        assert!(!SharedFolderSummary::from(&share).has_password);
+    }
 }
 
 /// 获取文件列表
@@ -816,6 +889,5 @@ async fn batch_download(
             StatusCode::INTERNAL_SERVER_ERROR
         })
 }
-
 
 

--- a/src-tauri/src/modules/tauri_commands.rs
+++ b/src-tauri/src/modules/tauri_commands.rs
@@ -2276,7 +2276,9 @@ pub async fn open_folder(path: String) -> Result<(), String> {
 
 // ==================== HTTP 文件共享命令 ====================
 
-use crate::modules::file_transfer::{SharedFolder, FileInfo as FileTransferFileInfo};
+use crate::modules::file_transfer::{
+    FileInfo as FileTransferFileInfo, SharedFolder, SharedFolderSummary,
+};
 
 /// 启动HTTP文件服务器
 #[tauri::command]
@@ -2416,7 +2418,7 @@ pub async fn cleanup_expired_shares(state: State<'_, AppState>) -> Result<(), St
 
 /// 获取远程共享列表（通过HTTP API）
 #[tauri::command]
-pub async fn get_remote_shares(peer_ip: String) -> Result<Vec<SharedFolder>, String> {
+pub async fn get_remote_shares(peer_ip: String) -> Result<Vec<SharedFolderSummary>, String> {
     log::debug!("📡 正在获取远程共享列表: {}", peer_ip);
     
     let url = format!("http://{}:14539/api/shares", peer_ip);
@@ -2443,10 +2445,8 @@ pub async fn get_remote_shares(peer_ip: String) -> Result<Vec<SharedFolder>, Str
             
             match response.json::<serde_json::Value>().await {
                 Ok(json) => {
-                    log::info!("📦 响应JSON: {}", json);
-                    
                     if let Some(shares) = json.get("shares") {
-                        match serde_json::from_value::<Vec<SharedFolder>>(shares.clone()) {
+                        match serde_json::from_value::<Vec<SharedFolderSummary>>(shares.clone()) {
                             Ok(shares_vec) => {
                                 log::debug!("✅ 成功获取 {} 个共享", shares_vec.len());
                                 for (i, share) in shares_vec.iter().enumerate() {

--- a/src/components/FileShareManager/FileShareManagerNew.tsx
+++ b/src/components/FileShareManager/FileShareManagerNew.tsx
@@ -10,7 +10,7 @@ import { Modal, Button, Input, Switch, message, Checkbox, Progress } from 'antd'
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { useAppStore } from '../../stores/appStore';
-import type { SharedFolder, FileInfo } from '../../types/fileShare';
+import type { SharedFolder, SharedFolderSummary, FileInfo } from '../../types/fileShare';
 import { FolderIcon, DownloadIcon, ShareIcon, CloseIcon, BackIcon, TrashIcon } from '../icons';
 import { useTranslation } from 'react-i18next';
 import { tl } from '../../i18n';
@@ -18,7 +18,7 @@ import './FileShareManager.css';
 
 // 简化的远程共享类型
 interface SimpleRemoteShare {
-  share: SharedFolder;
+  share: SharedFolderSummary;
   ownerName: string;
   ownerIp: string;
 }
@@ -116,7 +116,7 @@ export const FileShareManagerNew: React.FC = () => {
     // 1. 加载自己的共享
     if (lobby?.virtualIp) {
       try {
-        const shares = await invoke<SharedFolder[]>('get_remote_shares', { peerIp: lobby.virtualIp });
+        const shares = await invoke<SharedFolderSummary[]>('get_remote_shares', { peerIp: lobby.virtualIp });
         
         shares.forEach(share => {
           // 过滤掉过期的共享
@@ -137,7 +137,7 @@ export const FileShareManagerNew: React.FC = () => {
     for (const player of players) {
       if (player.virtualIp) {
         try {
-          const shares = await invoke<SharedFolder[]>('get_remote_shares', { peerIp: player.virtualIp });
+          const shares = await invoke<SharedFolderSummary[]>('get_remote_shares', { peerIp: player.virtualIp });
           
           shares.forEach(share => {
             // 过滤掉过期的共享
@@ -200,8 +200,7 @@ export const FileShareManagerNew: React.FC = () => {
         share: {
           id: shareId,
           name: shareName,
-          path: '',
-          password: hasPassword ? 'protected' : undefined,
+          has_password: Boolean(hasPassword),
           expire_time: undefined,
           compress_before_send: false,
           owner_id: playerId,
@@ -345,7 +344,7 @@ export const FileShareManagerNew: React.FC = () => {
   const handleBrowseShare = async (remoteShare: SimpleRemoteShare) => {
     pendingBrowsePathRef.current = '';
 
-    if (remoteShare.share.password) {
+    if (remoteShare.share.has_password) {
       setPendingShare(remoteShare);
       setShowPasswordModal(true);
       return;
@@ -359,7 +358,7 @@ export const FileShareManagerNew: React.FC = () => {
       const targetPath = pendingBrowsePathRef.current || '';
       let verifiedPassword: string | undefined;
 
-      if (remoteShare.share.password) {
+      if (remoteShare.share.has_password) {
         const passwordToVerify = password ?? sharePasswordMap[getShareKey(remoteShare.ownerIp, remoteShare.share.id)] ?? '';
         const valid = await invoke<boolean>('verify_share_password', {
           peerIp: remoteShare.ownerIp,
@@ -959,7 +958,7 @@ export const FileShareManagerNew: React.FC = () => {
                           </div>
                           {/* 右上角状态图标 */}
                           <div className="share-status-icons">
-                            {remoteShare.share.password && (
+                            {remoteShare.share.has_password && (
                               <div className="status-icon lock-icon" title={tl('需要密码', 'Password required')}>🔒</div>
                             )}
                             {remoteShare.share.compress_before_send && (
@@ -1339,7 +1338,6 @@ const AddShareDialog: React.FC<AddShareDialogProps> = ({ visible, onClose, onSuc
     </Modal>
   );
 };
-
 
 
 

--- a/src/services/fileShare/FileShareService.ts
+++ b/src/services/fileShare/FileShareService.ts
@@ -4,7 +4,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
-import { SharedFolder, FileInfo, PlayerShare } from '../../types/fileShare';
+import { SharedFolder, SharedFolderSummary, FileInfo, PlayerShare } from '../../types/fileShare';
 
 class FileShareService {
   private localShares: SharedFolder[] = [];
@@ -98,13 +98,13 @@ class FileShareService {
   /**
    * 获取远程玩家的共享列表
    */
-  async getRemoteShares(peerIp: string): Promise<SharedFolder[]> {
+  async getRemoteShares(peerIp: string): Promise<SharedFolderSummary[]> {
     try {
       console.log(`📡 [FileShareService] 正在获取远程共享: ${peerIp}`);
       console.log(`📡 [FileShareService] 调用 invoke('get_remote_shares', { peerIp: '${peerIp}' })`);
       
       // Tauri会自动将驼峰命名peerIp转换为Rust的下划线命名peer_ip
-      const shares = await invoke<SharedFolder[]>('get_remote_shares', { peerIp });
+      const shares = await invoke<SharedFolderSummary[]>('get_remote_shares', { peerIp });
       
       console.log(`✅ [FileShareService] 成功获取 ${shares.length} 个共享`);
       if (shares.length > 0) {

--- a/src/types/fileShare.ts
+++ b/src/types/fileShare.ts
@@ -18,6 +18,19 @@ export interface SharedFolder {
 }
 
 /**
+ * 远程共享摘要。服务端不会向远程节点暴露本地路径或共享密码。
+ */
+export interface SharedFolderSummary {
+  id: string;
+  name: string;
+  has_password: boolean;
+  expire_time?: number;
+  compress_before_send?: boolean;
+  owner_id: string;
+  created_at: number;
+}
+
+/**
  * 文件信息
  */
 export interface FileInfo {
@@ -55,14 +68,14 @@ export interface PlayerShare {
   player_id: string;
   player_name: string;
   virtual_ip: string;
-  shares: SharedFolder[];
+  shares: SharedFolderSummary[];
 }
 
 /**
  * 远程共享（包含所有者信息）
  */
 export interface RemoteShare {
-  share: SharedFolder;
+  share: SharedFolderSummary;
   owner_name: string;
   owner_ip: string;
 }


### PR DESCRIPTION
当前版本共享文件存在密码泄露问题（同时影响安卓和windows），同一大厅用户只需要访问 `目标用户ip:14539/api/shares` ，即可得到目标用户分享的文件**以及访问密码**
此pr修复内容由 gpt 5.6sol 生成，该修复改变了共享列表协议，旧版客户端可能无法解析新版响应，应当谨慎处理该漏洞
<img width="648" height="509" alt="image" src="https://github.com/user-attachments/assets/954fd546-e5f0-4d2c-b018-3c5f66ff8baf" />

同时：
1. 不建议将 信令服务器房间认证凭据、EasyTier 整个三层网络的根密钥 与 大厅密码设为相同值
2. 大厅名称取消固定格式，建议使用随机生成的 room_id
3. 存在大量密码明文问题，包括但不限于日志、命令行、WebView localStorage
4. tauri 存在漏洞 CVE-2026-42184，影响版本 `>= 2.0 且 <= 2.11.0`，建议升级tauri