### PR TITLE
fix: bind remote control and screen sharing sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,9 @@ src-tauri/WixTools
 config_mctier-*
 
 # Test files and reports
-tests/
+tests/*
+!tests/remote-control-service.test.mjs
+!tests/screen-share-auth.test.mjs
 *_TEST_REPORT.md
 *_DEBUG_GUIDE.md
 *_GUIDE.md

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/MctierRepository.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/MctierRepository.kt
@@ -155,6 +155,7 @@ class MctierRepository(private val context: Context) {
     private var reconnectNoticeJob: Job? = null
     private var lastShareSignalRequestAt: Long = 0L
     private val pendingPlayerLeaveJobs = mutableMapOf<String, Job>()
+    private val announcedScreenShares = mutableSetOf<String>()
     private var playersSnapshotVersion = 0L
 
     /** 是否正处于聊天室界面：在聊天室内收到消息不再播放提示音(对齐桌面端 __isInChatRoom__) */
@@ -207,6 +208,20 @@ class MctierRepository(private val context: Context) {
     // 暂存待接受的控制请求（用于 UI 拿到 MediaProjection 授权后调用 accept）
     private var pendingRcRequest: top.pmh13.mctier.data.RemoteControlRequest? = null
     private val appContext = context
+    private var screenCaptureStartJob: Job? = null
+    private var screenCaptureGeneration = 0L
+    private var remoteControlAcceptJob: Job? = null
+    private var remoteControlAcceptGeneration = 0L
+
+    private fun invalidatePendingRemoteControlAccept() {
+        remoteControlAcceptGeneration += 1
+        if (remoteControlAcceptJob != null) {
+            remoteControlAcceptJob?.cancel()
+            ScreenCaptureService.stop(appContext)
+        }
+        remoteControlAcceptJob = null
+        pendingRcRequest = null
+    }
 
     private val _state = MutableStateFlow(
         MctierUiState(
@@ -280,6 +295,8 @@ class MctierRepository(private val context: Context) {
                 if (connected) {
                     _state.update { it.copy(reconnecting = false) }
                 } else if (_state.value.state == AppConnectionState.InLobby) {
+                    invalidatePendingRemoteControlAccept()
+                    remoteControlController?.handleSignalingDisconnected()
                     reconnectNoticeJob = scope.launch {
                         delay(3500)
                         if (!signalingClient.connected.value && _state.value.state == AppConnectionState.InLobby) {
@@ -435,15 +452,20 @@ class MctierRepository(private val context: Context) {
                             })
                         }
                     }
+                    controller.onCaptureStopped = { shareId ->
+                        scope.launch { handleLocalCaptureStopped(shareId) }
+                    }
                 }
                 remoteControlController = top.pmh13.mctier.network.RemoteControlController(appContext, current.playerId) { signalingClient.send(it) }.also { rc ->
                     rc.onRequest = { sid, fromId, fromName ->
+                        invalidatePendingRemoteControlAccept()
                         _state.update { it.copy(remoteControlRequest = top.pmh13.mctier.data.RemoteControlRequest(sid, fromId, fromName)) }
                     }
                     rc.onActive = { name ->
                         _state.update { it.copy(remoteControlActiveBy = name, remoteControlRequest = null) }
                     }
                     rc.onEnded = {
+                        invalidatePendingRemoteControlAccept()
                         _state.update { it.copy(remoteControlActiveBy = null, remoteControlRequest = null, remoteControllingPeer = null) }
                     }
                     rc.onControllerActive = { name ->
@@ -500,8 +522,11 @@ class MctierRepository(private val context: Context) {
 
     fun leaveLobby() {
         val leaving = _state.value
+        invalidatePendingScreenCapture()
+        invalidatePendingRemoteControlAccept()
         pendingPlayerLeaveJobs.values.forEach { it.cancel() }
         pendingPlayerLeaveJobs.clear()
+        announcedScreenShares.clear()
         playersSnapshotVersion = 0L
         runCatching { signalingClient.send(SignalingEnvelope(type = "leave", clientId = leaving.playerId)) }
         _state.update {
@@ -1074,11 +1099,52 @@ class MctierRepository(private val context: Context) {
         _state.update { it.copy(viewingShareId = null) }
     }
 
+    private fun invalidatePendingScreenCapture() {
+        screenCaptureGeneration += 1
+        screenCaptureStartJob?.cancel()
+        screenCaptureStartJob = null
+    }
+
+    private fun isCurrentScreenCaptureStart(generation: Long, shareId: String, playerId: String): Boolean =
+        generation == screenCaptureGeneration &&
+            _state.value.state == AppConnectionState.InLobby &&
+            _state.value.screenShares.any { it.id == shareId && it.playerId == playerId }
+
+    private fun handleLocalCaptureStopped(shareId: String) {
+        val playerId = _state.value.playerId
+        if (!_state.value.screenShares.any { it.id == shareId && it.playerId == playerId } && shareId !in announcedScreenShares) return
+        invalidatePendingScreenCapture()
+        val shouldAnnounceStop = announcedScreenShares.remove(shareId)
+        if (shouldAnnounceStop) {
+            signalingClient.send(SignalingEnvelope(type = "screen-share-stop", from = playerId, shareId = shareId))
+        }
+        if (_state.value.viewingShareId == shareId) {
+            screenController?.stopViewing(notify = false)
+        }
+        ScreenCaptureService.stop(appContext)
+        _state.update { state ->
+            state.copy(
+                screenShares = state.screenShares.filterNot { it.id == shareId && it.playerId == playerId },
+                viewingShareId = state.viewingShareId?.takeUnless { it == shareId },
+            )
+        }
+    }
+
     /** 开始共享自己的屏幕（需传入 MediaProjection 授权数据） */
     fun startScreenCapture(data: Intent, requirePassword: Boolean, password: String?) {
+        if (requirePassword && password?.trim().isNullOrEmpty()) {
+            _state.update { it.copy(error = L("请设置屏幕共享密码", "Set a screen sharing password")) }
+            return
+        }
+        invalidatePendingScreenCapture()
+        val generation = screenCaptureGeneration
         val playerId = _state.value.playerId
         val playerName = _state.value.settings.playerName
         val shareId = "share-$playerId-${System.currentTimeMillis()}"
+        val previousShare = _state.value.screenShares.firstOrNull { it.playerId == playerId }
+        if (previousShare != null && announcedScreenShares.remove(previousShare.id)) {
+            signalingClient.send(SignalingEnvelope(type = "screen-share-stop", from = playerId, shareId = previousShare.id))
+        }
         // 先在本地显示"正在共享"
         val share = ScreenShareInfo(shareId, playerId, playerName, requirePassword)
         _state.update { it.copy(screenShares = it.screenShares.filterNot { s -> s.playerId == playerId } + share) }
@@ -1087,20 +1153,41 @@ class MctierRepository(private val context: Context) {
         // 【关键修复】前台服务是异步启动的，必须等它就绪后再获取 MediaProjection 采集，
         // 否则 Android 10+/14 会抛"需要 mediaProjection 前台服务"异常导致采集起不来、对方看不到画面。
         // 采集就绪后再向大厅通告，避免观看者过早发起 offer 时本机尚未在共享。
-        scope.launch {
-            delay(800)
-            screenController?.startSharing(shareId, data, password)
-            delay(400)
-            signalingClient.send(
-                SignalingEnvelope(
-                    type = "screen-share-start", from = playerId, shareId = shareId,
-                    playerName = playerName, hasPassword = requirePassword, password = password?.takeIf { it.isNotBlank() },
-                ),
-            )
+        screenCaptureStartJob = scope.launch {
+            try {
+                delay(800)
+                if (!isCurrentScreenCaptureStart(generation, shareId, playerId)) return@launch
+                val started = screenController?.startSharing(shareId, data, password) == true
+                if (!isCurrentScreenCaptureStart(generation, shareId, playerId)) return@launch
+                if (!started) {
+                    ScreenCaptureService.stop(appContext)
+                    announcedScreenShares.remove(shareId)
+                    _state.update { state -> state.copy(screenShares = state.screenShares.filterNot { it.id == shareId }) }
+                    return@launch
+                }
+                delay(400)
+                if (!isCurrentScreenCaptureStart(generation, shareId, playerId)) return@launch
+                if (screenController?.isSharing != true) {
+                    ScreenCaptureService.stop(appContext)
+                    announcedScreenShares.remove(shareId)
+                    _state.update { state -> state.copy(screenShares = state.screenShares.filterNot { it.id == shareId }) }
+                    return@launch
+                }
+                announcedScreenShares += shareId
+                signalingClient.send(
+                    SignalingEnvelope(
+                        type = "screen-share-start", from = playerId, shareId = shareId,
+                        playerName = playerName, hasPassword = requirePassword, password = password?.takeIf { it.isNotBlank() },
+                    ),
+                )
+            } finally {
+                if (screenCaptureGeneration == generation) screenCaptureStartJob = null
+            }
         }
     }
 
     fun stopScreenCapture() {
+        invalidatePendingScreenCapture()
         val playerId = _state.value.playerId
         val myShare = _state.value.screenShares.firstOrNull { it.playerId == playerId }
         if (myShare != null && _state.value.viewingShareId == myShare.id) {
@@ -1108,7 +1195,9 @@ class MctierRepository(private val context: Context) {
         }
         screenController?.stopSharing()
         ScreenCaptureService.stop(appContext)
-        if (myShare != null) signalingClient.send(SignalingEnvelope(type = "screen-share-stop", from = playerId, shareId = myShare.id))
+        if (myShare != null && announcedScreenShares.remove(myShare.id)) {
+            signalingClient.send(SignalingEnvelope(type = "screen-share-stop", from = playerId, shareId = myShare.id))
+        }
         _state.update {
             it.copy(
                 screenShares = it.screenShares.filterNot { share -> share.playerId == playerId },
@@ -1122,13 +1211,14 @@ class MctierRepository(private val context: Context) {
     fun rejectRemoteControl() {
         val req = _state.value.remoteControlRequest ?: pendingRcRequest ?: return
         remoteControlController?.reject(req.sessionId, req.fromId)
-        pendingRcRequest = null
+        invalidatePendingRemoteControlAccept()
         _state.update { it.copy(remoteControlRequest = null) }
     }
 
     /** 开始接受流程：暂存请求并关闭弹窗，返回请求供 UI 去申请 MediaProjection 授权 */
     fun beginAcceptRemoteControl(): top.pmh13.mctier.data.RemoteControlRequest? {
         val req = _state.value.remoteControlRequest ?: return null
+        invalidatePendingRemoteControlAccept()
         pendingRcRequest = req
         _state.update { it.copy(remoteControlRequest = null) }
         return req
@@ -1137,16 +1227,24 @@ class MctierRepository(private val context: Context) {
     /** 拿到 MediaProjection 授权后真正接受：启动前台服务→采集屏幕→发送 accept */
     fun acceptRemoteControl(projectionData: Intent) {
         val req = pendingRcRequest ?: return
-        pendingRcRequest = null
-        ScreenCaptureService.start(appContext)
-        scope.launch {
-            delay(800)
-            remoteControlController?.accept(projectionData, req.sessionId, req.fromId, req.fromName)
+        remoteControlAcceptJob?.cancel()
+        val generation = ++remoteControlAcceptGeneration
+        remoteControlAcceptJob = scope.launch {
+            try {
+                ScreenCaptureService.start(appContext)
+                delay(800)
+                if (generation != remoteControlAcceptGeneration || pendingRcRequest != req || _state.value.state != AppConnectionState.InLobby) return@launch
+                pendingRcRequest = null
+                remoteControlController?.accept(projectionData, req.sessionId, req.fromId, req.fromName)
+            } finally {
+                if (generation == remoteControlAcceptGeneration) remoteControlAcceptJob = null
+            }
         }
     }
 
     /** 停止被远程控制 */
     fun stopRemoteControl() {
+        invalidatePendingRemoteControlAccept()
         remoteControlController?.stop(notify = true)
         ScreenCaptureService.stop(appContext)
     }
@@ -1158,6 +1256,10 @@ class MctierRepository(private val context: Context) {
     }
 
     fun announceScreenShare(requirePassword: Boolean, password: String?) {
+        if (requirePassword && password?.trim().isNullOrEmpty()) {
+            _state.update { it.copy(error = L("请设置屏幕共享密码", "Set a screen sharing password")) }
+            return
+        }
         val current = _state.value
         val share = ScreenShareInfo("share-${current.playerId}-${System.currentTimeMillis()}", current.playerId, current.settings.playerName, requirePassword)
         _state.update { it.copy(screenShares = it.screenShares + share) }
@@ -1190,6 +1292,18 @@ class MctierRepository(private val context: Context) {
             ),
         )
     }
+
+    private fun isKnownLobbyPeer(playerId: String, state: MctierUiState = _state.value): Boolean =
+        playerId == state.playerId || state.players.any { it.id == playerId }
+
+    private fun isScreenShareMessageForLocal(message: SignalingEnvelope, state: MctierUiState = _state.value): Boolean =
+        message.to == state.playerId
+
+    private fun isValidScreenShareViewer(
+        ownerId: String,
+        viewerId: String?,
+        state: MctierUiState = _state.value,
+    ): Boolean = viewerId == null || (viewerId != ownerId && isKnownLobbyPeer(viewerId, state))
 
     private fun schedulePlayerLeaveConfirmation(playerId: String): Boolean {
         pendingPlayerLeaveJobs.remove(playerId)?.cancel()
@@ -1333,6 +1447,7 @@ class MctierRepository(private val context: Context) {
             }
             "player-left" -> {
                 val id = message.playerId ?: return
+                if (id != _state.value.playerId) remoteControlController?.handlePeerLeft(id)
                 if (id != _state.value.playerId && _state.value.players.any { it.id == id }) {
                     schedulePlayerLeaveConfirmation(id)
                 }
@@ -1364,55 +1479,101 @@ class MctierRepository(private val context: Context) {
             "lobby-options-changed" -> _state.update { it.copy(maxPlayers = message.maxPlayers, isPublicLobby = message.isPublic ?: it.isPublicLobby) }
             "screen-share-start" -> {
                 val from = message.from ?: return
-                if (from == _state.value.playerId) return
-                val share = ScreenShareInfo(message.shareId ?: return, from, message.playerName ?: L("未知玩家", "Unknown player"), message.hasPassword ?: false)
-                _state.update { it.copy(screenShares = it.screenShares.filterNot { s -> s.id == share.id } + share) }
+                val state = _state.value
+                val shareId = message.shareId?.takeIf { it.isNotBlank() } ?: return
+                if (from == state.playerId || !isKnownLobbyPeer(from, state)) return
+                val existing = state.screenShares.firstOrNull { it.id == shareId }
+                // A share id is owned by the first authenticated owner that
+                // announced it; another member cannot replace that owner.
+                if (existing != null && existing.playerId != from) return
+                val ownerName = state.players.firstOrNull { it.id == from }?.name
+                    ?: message.playerName
+                    ?: L("未知玩家", "Unknown player")
+                val share = ScreenShareInfo(shareId, from, ownerName, message.hasPassword ?: false)
+                _state.update { current ->
+                    if (current.screenShares.any { it.id == share.id && it.playerId != from }) current
+                    else current.copy(screenShares = current.screenShares.filterNot { it.playerId == from || it.id == share.id } + share)
+                }
             }
             "screen-share-list-request" -> {
                 val requesterId = message.from ?: return
-                if (requesterId != _state.value.playerId) sendMyScreenShareTo(requesterId)
+                val state = _state.value
+                if (requesterId != state.playerId && isKnownLobbyPeer(requesterId, state) &&
+                    (message.to == null || message.to == state.playerId)
+                ) {
+                    sendMyScreenShareTo(requesterId)
+                }
             }
             "screen-share-list-response" -> {
                 val ownerId = message.from ?: return
-                if (ownerId == _state.value.playerId) return
+                val state = _state.value
+                if (ownerId == state.playerId || !isScreenShareMessageForLocal(message, state) || !isKnownLobbyPeer(ownerId, state)) return
+                val shareId = message.shareId?.takeIf { it.isNotBlank() } ?: return
+                val existing = state.screenShares.firstOrNull { it.id == shareId }
+                if (existing != null && existing.playerId != ownerId) return
+                val viewerId = message.viewerId
+                if (!isValidScreenShareViewer(ownerId, viewerId, state)) return
+                val viewerCount = message.viewerCount ?: if (viewerId != null) 1 else 0
+                if (viewerCount < 0 || viewerCount > state.players.count { it.id != ownerId }) return
                 val share = ScreenShareInfo(
-                    id = message.shareId ?: return,
+                    id = shareId,
                     playerId = ownerId,
-                    playerName = message.playerName ?: L("未知玩家", "Unknown player"),
+                    playerName = state.players.firstOrNull { it.id == ownerId }?.name
+                        ?: message.playerName
+                        ?: L("未知玩家", "Unknown player"),
                     requirePassword = message.hasPassword ?: false,
-                    viewerId = message.viewerId,
-                    viewerName = message.viewerName,
-                    viewerCount = message.viewerCount ?: 0,
+                    viewerId = viewerId,
+                    viewerName = viewerId?.let { id -> state.players.firstOrNull { it.id == id }?.name ?: message.viewerName },
+                    viewerCount = viewerCount,
                 )
                 _state.update { state ->
-                    state.copy(screenShares = state.screenShares.filterNot { it.id == share.id || it.playerId == ownerId } + share)
+                    if (state.screenShares.any { it.id == share.id && it.playerId != ownerId }) state
+                    else state.copy(screenShares = state.screenShares.filterNot { it.id == share.id || it.playerId == ownerId } + share)
                 }
             }
             "screen-share-stop" -> {
-                _state.update { it.copy(screenShares = it.screenShares.filterNot { share -> share.id == message.shareId }) }
-                if (_state.value.viewingShareId == message.shareId) {
+                val state = _state.value
+                val shareId = message.shareId?.takeIf { it.isNotBlank() } ?: return
+                val ownerId = message.from ?: return
+                if (message.to != null && message.to != state.playerId) return
+                val share = state.screenShares.firstOrNull { it.id == shareId } ?: return
+                if (share.playerId != ownerId) return
+                _state.update { it.copy(screenShares = it.screenShares.filterNot { screen -> screen.id == shareId }) }
+                if (state.viewingShareId == shareId) {
                     screenController?.stopViewing(notify = false)
                     _state.update { it.copy(viewingShareId = null) }
                 }
             }
             "screen-share-answer", "screen-share-ice-candidate", "screen-share-offer", "screen-share-viewer-left", "screen-share-relay" -> screenController?.handleSignal(message)
             "screen-share-update" -> {
-                val shareId = message.shareId ?: return
-                _state.update { state ->
-                    state.copy(screenShares = state.screenShares.map { share ->
-                        if (share.id == shareId && share.playerId == message.from) {
-                            share.copy(
-                                viewerId = message.viewerId,
-                                viewerName = message.viewerName,
-                                viewerCount = message.viewerCount ?: if (message.viewerId != null) 1 else 0,
+                val state = _state.value
+                val shareId = message.shareId?.takeIf { it.isNotBlank() } ?: return
+                val ownerId = message.from ?: return
+                if (message.to != null && message.to != state.playerId) return
+                val share = state.screenShares.firstOrNull { it.id == shareId } ?: return
+                if (share.playerId != ownerId) return
+                val viewerId = message.viewerId
+                if (!isValidScreenShareViewer(ownerId, viewerId, state)) return
+                val viewerCount = message.viewerCount ?: if (viewerId != null) 1 else 0
+                if (viewerCount < 0 || viewerCount > state.players.count { it.id != ownerId }) return
+                _state.update { current ->
+                    current.copy(screenShares = current.screenShares.map { currentShare ->
+                        if (currentShare.id == shareId && currentShare.playerId == ownerId) {
+                            currentShare.copy(
+                                viewerId = viewerId,
+                                viewerName = viewerId?.let { id -> current.players.firstOrNull { it.id == id }?.name ?: message.viewerName },
+                                viewerCount = viewerCount,
                             )
-                        } else share
+                        } else currentShare
                     })
                 }
             }
             "remote-control-request", "remote-control-offer", "remote-control-ice", "remote-control-stop", "remote-control-accept", "remote-control-answer", "remote-control-reject" -> remoteControlController?.handleSignal(message)
             "screen-share-error" -> {
-                if (message.shareId != null && _state.value.viewingShareId == message.shareId) {
+                val state = _state.value
+                val shareId = message.shareId ?: return
+                val share = state.screenShares.firstOrNull { it.id == shareId } ?: return
+                if (isScreenShareMessageForLocal(message, state) && share.playerId == message.from && state.viewingShareId == shareId) {
                     screenController?.stopViewing(notify = false)
                     _state.update { it.copy(viewingShareId = null, error = message.error ?: L("无法观看该屏幕", "Cannot view this screen")) }
                 }

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/RemoteControlController.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/RemoteControlController.kt
@@ -25,6 +25,7 @@ import top.pmh13.mctier.data.SdpPayload
 import top.pmh13.mctier.data.SignalingEnvelope
 import top.pmh13.mctier.service.MctierAccessibilityService
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 
 /**
  * 远程控制（被控端 = 手机）。
@@ -39,6 +40,12 @@ class RemoteControlController(
     private val localPlayerId: String,
     private val sendSignal: (SignalingEnvelope) -> Unit,
 ) {
+    private data class PendingControlRequest(
+        val sessionId: String,
+        val controllerId: String,
+        val controllerName: String,
+    )
+
     val eglBase: EglBase = EglBase.create()
     private val factory: PeerConnectionFactory
 
@@ -51,6 +58,7 @@ class RemoteControlController(
     private var sessionId: String? = null
     private var controllerId: String? = null
     private var controllerName: String? = null
+    private var pendingRequest: PendingControlRequest? = null
 
     // 角色：idle / controlled(本机被控) / controller(本机去控制别人)
     private var role: String = "idle"
@@ -63,7 +71,7 @@ class RemoteControlController(
     var onControllerVideoTrack: ((VideoTrack?) -> Unit)? = null
     var onControllerActive: ((peerName: String) -> Unit)? = null
     var onRejected: ((reason: String) -> Unit)? = null
-    private val pendingIce = ArrayList<IceCandidate>()
+    private val pendingIce = linkedMapOf<String, MutableList<IceCandidate>>()
 
     // 真实屏幕尺寸（把归一化坐标 0..1 映射为像素）
     private var screenW = 1080f
@@ -83,6 +91,26 @@ class RemoteControlController(
         watchdog.postDelayed({ if (pc == null && sessionId != null) stop(notify = true) }, ms)
     }
     private fun cancelWatchdog() { watchdog.removeCallbacksAndMessages(null) }
+
+    private fun isCurrentPeerMessage(message: SignalingEnvelope): Boolean {
+        val expectedPeer = if (role == "controller") peerId else controllerId
+        return role != "idle"
+            && message.to == localPlayerId
+            && message.sessionId != null
+            && message.sessionId == sessionId
+            && message.from != null
+            && message.from == expectedPeer
+    }
+
+    private fun isCurrentConnection(expectedSessionId: String, expectedPeerId: String, expectedPc: PeerConnection): Boolean {
+        return role != "idle"
+            && sessionId == expectedSessionId
+            && (if (role == "controller") peerId else controllerId) == expectedPeerId
+            && pc === expectedPc
+    }
+
+    private fun pendingIceKey(expectedSessionId: String, expectedPeerId: String): String =
+        "$expectedSessionId|$expectedPeerId"
 
     var onRequest: ((sessionId: String, fromId: String, fromName: String) -> Unit)? = null
     var onActive: ((controllerName: String) -> Unit)? = null
@@ -135,14 +163,21 @@ class RemoteControlController(
     fun handleSignal(message: SignalingEnvelope) {
         when (message.type) {
             "remote-control-request" -> {
+                if (message.to != localPlayerId) return
                 val from = message.from ?: return
                 val sid = message.sessionId ?: return
+                if (from == localPlayerId || sid.isBlank()) return
                 val name = message.fromName ?: message.playerName ?: "玩家"
                 Log.i(TAG, "收到控制请求 from=$from active=$isActive")
                 if (isActive) {
                     sendSignal(SignalingEnvelope(type = "remote-control-reject", from = localPlayerId, to = from, sessionId = sid, reason = "busy"))
                     return
                 }
+                if (pendingRequest != null) {
+                    sendSignal(SignalingEnvelope(type = "remote-control-reject", from = localPlayerId, to = from, sessionId = sid, reason = "busy"))
+                    return
+                }
+                pendingRequest = PendingControlRequest(sid, from, name)
                 onRequest?.invoke(sid, from, name)
             }
             "remote-control-offer" -> {
@@ -150,52 +185,86 @@ class RemoteControlController(
                 val sid = message.sessionId ?: return
                 val offer = message.offer ?: return
                 Log.i(TAG, "收到 offer from=$from sid匹配=${sid == sessionId}")
-                if (sid != sessionId || from != controllerId) return
+                if (role != "controlled" || !isCurrentPeerMessage(message)) return
                 handleOffer(from, sid, offer.sdp)
             }
             "remote-control-accept" -> {
                 val sid = message.sessionId ?: return
                 Log.i(TAG, "收到 accept role=$role sid匹配=${sid == sessionId}")
-                if (role == "controller" && sid == sessionId) handleAccept(sid)
+                if (role == "controller" && isCurrentPeerMessage(message)) handleAccept(sid)
             }
             "remote-control-answer" -> {
                 val sid = message.sessionId ?: return
                 val answer = message.answer ?: return
-                if (role == "controller" && sid == sessionId) {
-                    pc?.setRemoteDescription(object : SimpleSdpObserver() {
-                        override fun onSetSuccess() { flushPendingIce() }
+                val expectedPeerId = message.from ?: return
+                val connection = pc ?: return
+                if (role == "controller" && isCurrentPeerMessage(message)
+                    && connection.signalingState == PeerConnection.SignalingState.HAVE_LOCAL_OFFER
+                    && isCurrentConnection(sid, expectedPeerId, connection)
+                ) {
+                    connection.setRemoteDescription(object : SimpleSdpObserver() {
+                        override fun onSetSuccess() {
+                            if (isCurrentConnection(sid, expectedPeerId, connection)) flushPendingIce(sid, expectedPeerId, connection)
+                        }
+
+                        override fun onSetFailure(error: String) {
+                            if (isCurrentConnection(sid, expectedPeerId, connection)) stop(notify = false)
+                        }
                     }, SessionDescription(SessionDescription.Type.ANSWER, answer.sdp))
                 }
             }
             "remote-control-reject" -> {
-                if (role == "controller" && message.sessionId == sessionId) {
+                if (role == "controller" && isCurrentPeerMessage(message)) {
                     onRejected?.invoke(message.reason ?: "rejected")
                     stop(notify = false)
                 }
             }
             "remote-control-ice" -> {
                 val c = message.candidate ?: return
+                if (!isCurrentPeerMessage(message)) return
                 val ice = IceCandidate(c.sdpMid, c.sdpMLineIndex ?: 0, c.candidate)
                 val conn = pc
-                if (conn?.remoteDescription != null) conn.addIceCandidate(ice) else pendingIce.add(ice)
+                val expectedPeerId = message.from ?: return
+                if (conn != null && isCurrentConnection(message.sessionId ?: return, expectedPeerId, conn) && conn.remoteDescription != null) {
+                    conn.addIceCandidate(ice)
+                } else {
+                    pendingIce.getOrPut(pendingIceKey(message.sessionId ?: return, expectedPeerId)) { mutableListOf() }.add(ice)
+                }
             }
-            "remote-control-stop" -> stop(notify = false)
+            "remote-control-stop" -> {
+                val pending = pendingRequest
+                if (role == "idle" && pending != null
+                    && message.to == localPlayerId
+                    && message.from == pending.controllerId
+                    && message.sessionId == pending.sessionId
+                ) {
+                    pendingRequest = null
+                    onEnded?.invoke()
+                } else if (isCurrentPeerMessage(message)) {
+                    stop(notify = false)
+                }
+            }
         }
     }
 
-    private fun flushPendingIce() {
-        val conn = pc ?: return
-        val list = ArrayList(pendingIce)
-        pendingIce.clear()
-        list.forEach { runCatching { conn.addIceCandidate(it) } }
+    private fun flushPendingIce(expectedSessionId: String, expectedPeerId: String, expectedPc: PeerConnection) {
+        if (!isCurrentConnection(expectedSessionId, expectedPeerId, expectedPc)) return
+        val key = pendingIceKey(expectedSessionId, expectedPeerId)
+        val list = pendingIce.remove(key) ?: return
+        list.forEach {
+            if (isCurrentConnection(expectedSessionId, expectedPeerId, expectedPc)) {
+                runCatching { expectedPc.addIceCandidate(it) }
+            }
+        }
     }
 
     // ========================= 控制端（本机去控制对方设备） =========================
     /** 发起远程控制请求 */
     fun requestControl(targetId: String, targetName: String) {
-        if (isActive) return
+        if (isActive || targetId.isBlank() || targetId == localPlayerId) return
+        val nextSessionId = "rc-$localPlayerId-${UUID.randomUUID()}"
         role = "controller"
-        sessionId = "rc-$localPlayerId-${System.currentTimeMillis()}"
+        sessionId = nextSessionId
         peerId = targetId
         peerName = targetName
         sendSignal(SignalingEnvelope(type = "remote-control-request", from = localPlayerId, to = targetId, sessionId = sessionId, fromName = localPlayerName))
@@ -204,31 +273,79 @@ class RemoteControlController(
 
     /** 控制端：对方接受后建立连接并发 offer（接收对方屏幕 + 建输入数据通道） */
     private fun handleAccept(sid: String) {
-        val target = peerId ?: return
+        val expectedSessionId = sid
+        val expectedPeerId = peerId ?: return
+        if (role != "controller" || sessionId != expectedSessionId || pc != null) return
+
+        var expectedPc: PeerConnection? = null
+        fun currentConnection(): PeerConnection? = expectedPc?.takeIf {
+            isCurrentConnection(expectedSessionId, expectedPeerId, it)
+        }
+
         val connection = factory.createPeerConnection(
             rtcConfig(),
             object : PeerConnection.Observer {
                 override fun onIceCandidate(candidate: IceCandidate) {
-                    sendSignal(SignalingEnvelope(type = "remote-control-ice", from = localPlayerId, to = target, sessionId = sid, candidate = IcePayload(candidate.sdp, candidate.sdpMLineIndex, candidate.sdpMid)))
+                    val callbackPc = currentConnection() ?: return
+                    sendSignal(SignalingEnvelope(type = "remote-control-ice", from = localPlayerId, to = expectedPeerId, sessionId = expectedSessionId, candidate = IcePayload(candidate.sdp, candidate.sdpMLineIndex, candidate.sdpMid)))
                 }
-                override fun onSignalingChange(s: PeerConnection.SignalingState) = Unit
+                override fun onSignalingChange(s: PeerConnection.SignalingState) {
+                    if (currentConnection() == null) return
+                }
                 override fun onIceConnectionChange(s: PeerConnection.IceConnectionState) {
+                    val callbackPc = currentConnection() ?: return
                     Log.i(TAG, "控制端 ICE: $s")
-                    if (s == PeerConnection.IceConnectionState.FAILED) watchdog.post { stop(notify = false) }
+                    if (s == PeerConnection.IceConnectionState.FAILED) {
+                        watchdog.post {
+                            if (isCurrentConnection(expectedSessionId, expectedPeerId, callbackPc)) {
+                                stop(notify = false)
+                            }
+                        }
+                    }
                 }
-                override fun onIceConnectionReceivingChange(b: Boolean) = Unit
-                override fun onIceGatheringChange(s: PeerConnection.IceGatheringState) = Unit
-                override fun onIceCandidatesRemoved(c: Array<out IceCandidate>) = Unit
-                override fun onAddStream(s: org.webrtc.MediaStream) = Unit
-                override fun onRemoveStream(s: org.webrtc.MediaStream) = Unit
-                override fun onRenegotiationNeeded() = Unit
-                override fun onDataChannel(d: DataChannel) = Unit
+                override fun onIceConnectionReceivingChange(b: Boolean) {
+                    if (currentConnection() == null) return
+                }
+                override fun onIceGatheringChange(s: PeerConnection.IceGatheringState) {
+                    if (currentConnection() == null) return
+                }
+                override fun onIceCandidatesRemoved(c: Array<out IceCandidate>) {
+                    if (currentConnection() == null) return
+                }
+                override fun onAddStream(s: org.webrtc.MediaStream) {
+                    if (currentConnection() == null) return
+                }
+                override fun onRemoveStream(s: org.webrtc.MediaStream) {
+                    if (currentConnection() == null) return
+                }
+                override fun onRenegotiationNeeded() {
+                    if (currentConnection() == null) return
+                }
+                override fun onDataChannel(d: DataChannel) {
+                    if (currentConnection() == null) {
+                        d.close()
+                        return
+                    }
+                    d.close()
+                }
                 override fun onAddTrack(receiver: org.webrtc.RtpReceiver, streams: Array<out org.webrtc.MediaStream>) {
+                    val callbackPc = currentConnection() ?: return
                     val track = receiver.track()
                     if (track is VideoTrack) onControllerVideoTrack?.invoke(track)
                 }
             },
         ) ?: return
+        expectedPc = connection
+        if (role != "controller" || sessionId != expectedSessionId || peerId != expectedPeerId || pc != null) {
+            connection.close()
+            return
+        }
+        pc = connection
+        if (currentConnection() == null) {
+            if (pc === connection) pc = null
+            connection.close()
+            return
+        }
         // 接收对方屏幕视频
         connection.addTransceiver(
             org.webrtc.MediaStreamTrack.MediaType.MEDIA_TYPE_VIDEO,
@@ -236,16 +353,48 @@ class RemoteControlController(
         )
         // 输入数据通道（控制端→被控端）
         val ch = connection.createDataChannel("rc-input", DataChannel.Init().apply { ordered = true })
+        if (currentConnection() == null) {
+            ch.close()
+            return
+        }
         inputChannelOut = ch
         connection.createOffer(object : SimpleSdpObserver() {
             override fun onCreateSuccess(desc: SessionDescription) {
-                connection.setLocalDescription(SimpleSdpObserver(), desc)
-                sendSignal(SignalingEnvelope(type = "remote-control-offer", from = localPlayerId, to = target, sessionId = sid, offer = SdpPayload(desc.type.canonicalForm(), desc.description)))
+                val callbackPc = currentConnection() ?: run {
+                    connection.close()
+                    return
+                }
+                callbackPc.setLocalDescription(object : SimpleSdpObserver() {
+                    override fun onSetSuccess() {
+                        if (!isCurrentConnection(expectedSessionId, expectedPeerId, callbackPc)) {
+                            callbackPc.close()
+                            return
+                        }
+                        sendSignal(SignalingEnvelope(type = "remote-control-offer", from = localPlayerId, to = expectedPeerId, sessionId = expectedSessionId, offer = SdpPayload(desc.type.canonicalForm(), desc.description)))
+                        if (!isCurrentConnection(expectedSessionId, expectedPeerId, callbackPc)) return
+                        onControllerActive?.invoke(peerName ?: "")
+                        if (isCurrentConnection(expectedSessionId, expectedPeerId, callbackPc)) cancelWatchdog()
+                    }
+
+                    override fun onSetFailure(error: String) {
+                        if (isCurrentConnection(expectedSessionId, expectedPeerId, callbackPc)) {
+                            stop(notify = false)
+                        } else {
+                            callbackPc.close()
+                        }
+                    }
+                }, desc)
+            }
+
+            override fun onCreateFailure(error: String) {
+                val callbackPc = expectedPc ?: return
+                if (isCurrentConnection(expectedSessionId, expectedPeerId, callbackPc)) {
+                    stop(notify = false)
+                } else {
+                    callbackPc.close()
+                }
             }
         }, MediaConstraints())
-        pc = connection
-        onControllerActive?.invoke(peerName ?: "")
-        cancelWatchdog()
     }
 
     /** 控制端：发送一批输入事件（归一化坐标） */
@@ -260,22 +409,32 @@ class RemoteControlController(
 
     /** 拒绝控制请求 */
     fun reject(sid: String, fromId: String) {
+        val pending = pendingRequest ?: return
+        if (pending.sessionId != sid || pending.controllerId != fromId) return
         sendSignal(SignalingEnvelope(type = "remote-control-reject", from = localPlayerId, to = fromId, sessionId = sid, reason = "rejected"))
+        pendingRequest = null
     }
 
     /** 用户接受（被控端）：启动屏幕采集并发送 accept，等待控制端 offer */
-    fun accept(projectionData: Intent, sid: String, fromId: String, fromName: String) {
+    fun accept(projectionData: Intent, sid: String, fromId: String, _fromName: String) {
+        val pending = pendingRequest ?: return
+        if (pending.sessionId != sid || pending.controllerId != fromId || role != "idle") return
+        pendingRequest = null
         role = "controlled"
         sessionId = sid
         controllerId = fromId
-        controllerName = fromName
+        controllerName = pending.controllerName
         updateScreenSize()
-        startCapture(projectionData)
+        startCapture(projectionData, sid)
+        if (localVideoTrack == null) {
+            stop(notify = true)
+            return
+        }
         sendSignal(SignalingEnvelope(type = "remote-control-accept", from = localPlayerId, to = fromId, sessionId = sid))
         armWatchdog(40000)
     }
 
-    private fun startCapture(permissionData: Intent) {
+    private fun startCapture(permissionData: Intent, expectedSessionId: String) {
         runCatching {
             val metrics = DisplayMetrics()
             @Suppress("DEPRECATION")
@@ -287,7 +446,10 @@ class RemoteControlController(
             val source = factory.createVideoSource(true)
             videoSource = source
             val cap = ScreenCapturerAndroid(permissionData, object : MediaProjection.Callback() {
-                override fun onStop() { Log.i(TAG, "MediaProjection 已停止") }
+                override fun onStop() {
+                    Log.i(TAG, "MediaProjection 已停止")
+                    if (role == "controlled" && sessionId == expectedSessionId) stop(notify = true)
+                }
             })
             capturer = cap
             cap.initialize(helper, context, source.capturerObserver)
@@ -298,50 +460,151 @@ class RemoteControlController(
     }
 
     private fun handleOffer(from: String, sid: String, sdp: String) {
+        val expectedSessionId = sid
+        val expectedControllerId = from
+        if (role != "controlled" || sessionId != expectedSessionId || controllerId != expectedControllerId || pc != null) return
         val track = localVideoTrack ?: run { Log.w(TAG, "无屏幕轨，无法应答"); return }
+
+        var expectedPc: PeerConnection? = null
+        fun currentConnection(): PeerConnection? = expectedPc?.takeIf {
+            isCurrentConnection(expectedSessionId, expectedControllerId, it)
+        }
+
         val connection = factory.createPeerConnection(
             rtcConfig(),
             object : PeerConnection.Observer {
                 override fun onIceCandidate(candidate: IceCandidate) {
-                    sendSignal(SignalingEnvelope(type = "remote-control-ice", from = localPlayerId, to = from, sessionId = sid, candidate = IcePayload(candidate.sdp, candidate.sdpMLineIndex, candidate.sdpMid)))
+                    val callbackPc = currentConnection() ?: return
+                    sendSignal(SignalingEnvelope(type = "remote-control-ice", from = localPlayerId, to = expectedControllerId, sessionId = expectedSessionId, candidate = IcePayload(candidate.sdp, candidate.sdpMLineIndex, candidate.sdpMid)))
                 }
-                override fun onSignalingChange(s: PeerConnection.SignalingState) = Unit
+                override fun onSignalingChange(s: PeerConnection.SignalingState) {
+                    if (currentConnection() == null) return
+                }
                 override fun onIceConnectionChange(s: PeerConnection.IceConnectionState) {
+                    val callbackPc = currentConnection() ?: return
                     Log.i(TAG, "被控端 ICE: $s")
-                    if (s == PeerConnection.IceConnectionState.FAILED) watchdog.post { stop(notify = false) }
+                    if (s == PeerConnection.IceConnectionState.FAILED) {
+                        watchdog.post {
+                            if (isCurrentConnection(expectedSessionId, expectedControllerId, callbackPc)) {
+                                stop(notify = false)
+                            }
+                        }
+                    }
                 }
-                override fun onIceConnectionReceivingChange(b: Boolean) = Unit
-                override fun onIceGatheringChange(s: PeerConnection.IceGatheringState) = Unit
-                override fun onIceCandidatesRemoved(c: Array<out IceCandidate>) = Unit
-                override fun onAddStream(s: org.webrtc.MediaStream) = Unit
-                override fun onRemoveStream(s: org.webrtc.MediaStream) = Unit
-                override fun onRenegotiationNeeded() = Unit
-                override fun onAddTrack(receiver: org.webrtc.RtpReceiver, streams: Array<out org.webrtc.MediaStream>) = Unit
+                override fun onIceConnectionReceivingChange(b: Boolean) {
+                    if (currentConnection() == null) return
+                }
+                override fun onIceGatheringChange(s: PeerConnection.IceGatheringState) {
+                    if (currentConnection() == null) return
+                }
+                override fun onIceCandidatesRemoved(c: Array<out IceCandidate>) {
+                    if (currentConnection() == null) return
+                }
+                override fun onAddStream(s: org.webrtc.MediaStream) {
+                    if (currentConnection() == null) return
+                }
+                override fun onRemoveStream(s: org.webrtc.MediaStream) {
+                    if (currentConnection() == null) return
+                }
+                override fun onRenegotiationNeeded() {
+                    if (currentConnection() == null) return
+                }
+                override fun onAddTrack(receiver: org.webrtc.RtpReceiver, streams: Array<out org.webrtc.MediaStream>) {
+                    if (currentConnection() == null) return
+                }
                 override fun onDataChannel(channel: DataChannel) {
-                    if (channel.label() == "rc-input") registerInputChannel(channel)
+                    val callbackPc = currentConnection() ?: run {
+                        channel.close()
+                        return
+                    }
+                    if (channel.label() == "rc-input") {
+                        registerInputChannel(channel, expectedSessionId, expectedControllerId, callbackPc)
+                    } else {
+                        channel.close()
+                    }
                 }
             },
         ) ?: return
+        expectedPc = connection
+        if (role != "controlled" || sessionId != expectedSessionId || controllerId != expectedControllerId || pc != null) {
+            connection.close()
+            return
+        }
+        pc = connection
+        if (currentConnection() == null) {
+            if (pc === connection) pc = null
+            connection.close()
+            return
+        }
         connection.addTrack(track, listOf("rc-stream-$localPlayerId"))
         connection.setRemoteDescription(object : SimpleSdpObserver() {
-            override fun onSetSuccess() { flushPendingIce() }
-        }, SessionDescription(SessionDescription.Type.OFFER, sdp))
-        connection.createAnswer(object : SimpleSdpObserver() {
-            override fun onCreateSuccess(desc: SessionDescription) {
-                connection.setLocalDescription(SimpleSdpObserver(), desc)
-                sendSignal(SignalingEnvelope(type = "remote-control-answer", from = localPlayerId, to = from, sessionId = sid, answer = SdpPayload(desc.type.canonicalForm(), desc.description)))
+            override fun onSetSuccess() {
+                val callbackPc = currentConnection() ?: run {
+                    connection.close()
+                    return
+                }
+                flushPendingIce(expectedSessionId, expectedControllerId, callbackPc)
+                if (!isCurrentConnection(expectedSessionId, expectedControllerId, callbackPc)) return
+                callbackPc.createAnswer(object : SimpleSdpObserver() {
+                    override fun onCreateSuccess(desc: SessionDescription) {
+                        if (!isCurrentConnection(expectedSessionId, expectedControllerId, callbackPc)) {
+                            callbackPc.close()
+                            return
+                        }
+                        callbackPc.setLocalDescription(object : SimpleSdpObserver() {
+                            override fun onSetSuccess() {
+                                if (!isCurrentConnection(expectedSessionId, expectedControllerId, callbackPc)) {
+                                    callbackPc.close()
+                                    return
+                                }
+                                sendSignal(SignalingEnvelope(type = "remote-control-answer", from = localPlayerId, to = expectedControllerId, sessionId = expectedSessionId, answer = SdpPayload(desc.type.canonicalForm(), desc.description)))
+                                if (!isCurrentConnection(expectedSessionId, expectedControllerId, callbackPc)) return
+                                onActive?.invoke(controllerName ?: "")
+                                if (isCurrentConnection(expectedSessionId, expectedControllerId, callbackPc)) cancelWatchdog()
+                            }
+
+                            override fun onSetFailure(error: String) {
+                                if (isCurrentConnection(expectedSessionId, expectedControllerId, callbackPc)) {
+                                    stop(notify = false)
+                                } else {
+                                    callbackPc.close()
+                                }
+                            }
+                        }, desc)
+                    }
+
+                    override fun onCreateFailure(error: String) {
+                        if (isCurrentConnection(expectedSessionId, expectedControllerId, callbackPc)) {
+                            stop(notify = false)
+                        } else {
+                            callbackPc.close()
+                        }
+                    }
+                }, MediaConstraints())
             }
-        }, MediaConstraints())
-        pc = connection
-        onActive?.invoke(controllerName ?: "")
-        cancelWatchdog()
+
+            override fun onSetFailure(error: String) {
+                val callbackPc = expectedPc ?: return
+                if (isCurrentConnection(expectedSessionId, expectedControllerId, callbackPc)) {
+                    stop(notify = false)
+                } else {
+                    callbackPc.close()
+                }
+            }
+        }, SessionDescription(SessionDescription.Type.OFFER, sdp))
     }
 
-    private fun registerInputChannel(channel: DataChannel) {
+    private fun registerInputChannel(
+        channel: DataChannel,
+        expectedSessionId: String,
+        expectedControllerId: String,
+        expectedPc: PeerConnection,
+    ) {
         channel.registerObserver(object : DataChannel.Observer {
             override fun onBufferedAmountChange(previousAmount: Long) = Unit
             override fun onStateChange() = Unit
             override fun onMessage(buffer: DataChannel.Buffer) {
+                if (!isCurrentConnection(expectedSessionId, expectedControllerId, expectedPc)) return
                 val bytes = ByteArray(buffer.data.remaining())
                 buffer.data.get(bytes)
                 val text = String(bytes, StandardCharsets.UTF_8)
@@ -352,6 +615,7 @@ class RemoteControlController(
 
     // ========================= 输入注入 =========================
     private fun handleInputBatch(json: String) {
+        if (json.length > 64 * 1024) return
         val arr = JSONArray(json)
         for (i in 0 until arr.length()) {
             val ev = arr.optJSONObject(i) ?: continue
@@ -461,12 +725,36 @@ class RemoteControlController(
         controllerName = null
         peerId = null
         peerName = null
+        pendingRequest = null
         role = "idle"
         pendingIce.clear()
         isDown = false
         pathPoints.clear()
         onEnded?.invoke()
         stopping = false
+    }
+
+    fun handlePeerLeft(playerId: String) {
+        var hadPending = false
+        if (pendingRequest?.controllerId == playerId) {
+            pendingRequest = null
+            hadPending = true
+        }
+        if (role != "idle" && (controllerId == playerId || peerId == playerId)) {
+            stop(notify = false)
+        } else if (hadPending) {
+            onEnded?.invoke()
+        }
+    }
+
+    fun handleSignalingDisconnected() {
+        val hadPending = pendingRequest != null
+        pendingRequest = null
+        if (isActive) {
+            stop(notify = false)
+        } else if (hadPending) {
+            onEnded?.invoke()
+        }
     }
 
     fun release() {

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/ScreenShareController.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/ScreenShareController.kt
@@ -81,6 +81,7 @@ class ScreenShareController(
             value?.invoke(remoteVideoTrack)
         }
     var onViewerCountChanged: ((String, Int) -> Unit)? = null
+    var onCaptureStopped: ((String) -> Unit)? = null
 
     private var screenCapturer: ScreenCapturerAndroid? = null
     private var videoSource: VideoSource? = null
@@ -263,9 +264,9 @@ class ScreenShareController(
                         if (previousUpstream != null && previousUpstream != upstreamId) {
                             inboundConnections.remove(peerKey(shareId, previousUpstream))?.close()
                         }
-                        if (requestedVersion == null && effectiveReadyVersion != null) {
+                        if (requestedVersion == null && effectiveReadyVersion != null && previousUpstream != null) {
                             currentOwnerId?.let { ownerId ->
-                                sendSignal(SignalingEnvelope(type = "screen-share-relay", action = "failure", from = localPlayerId, to = ownerId, shareId = shareId, routeVersion = effectiveReadyVersion, reason = "direct-fallback"))
+                                sendSignal(SignalingEnvelope(type = "screen-share-relay", action = "failure", from = localPlayerId, to = ownerId, shareId = shareId, upstreamId = previousUpstream, routeVersion = effectiveReadyVersion, reason = "direct-fallback"))
                             }
                         } else {
                             effectiveReadyVersion?.let { notifyReady(shareId, it) }
@@ -401,7 +402,8 @@ class ScreenShareController(
         currentPassword = null
     }
 
-    fun startSharing(shareId: String, permissionData: Intent, password: String? = null) {
+    fun startSharing(shareId: String, permissionData: Intent, password: String? = null): Boolean {
+        stopSharing()
         sharePassword = password?.takeIf { it.isNotBlank() }
         viewerOrder.clear()
         viewerNames.clear()
@@ -415,7 +417,7 @@ class ScreenShareController(
         relayRecoveryCheck?.let(mainHandler::removeCallbacks)
         relayRecoveryCheck = null
         routeVersion = 0
-        runCatching {
+        return runCatching {
             val metrics = DisplayMetrics()
             @Suppress("DEPRECATION")
             (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.getMetrics(metrics)
@@ -426,7 +428,14 @@ class ScreenShareController(
             val source = factory.createVideoSource(true)
             videoSource = source
             val capturer = ScreenCapturerAndroid(permissionData, object : MediaProjection.Callback() {
-                override fun onStop() { Log.i(TAG, "MediaProjection stopped") }
+                override fun onStop() {
+                    mainHandler.post {
+                        if (sharingShareId != shareId) return@post
+                        Log.i(TAG, "MediaProjection stopped")
+                        stopSharing()
+                        onCaptureStopped?.invoke(shareId)
+                    }
+                }
             })
             screenCapturer = capturer
             capturer.initialize(helper, context, source.capturerObserver)
@@ -437,20 +446,30 @@ class ScreenShareController(
             localFrameProbe = VideoSink { sourceFrameSequences.computeIfAbsent(shareId) { AtomicLong(0L) }.incrementAndGet() }.also { localVideoTrack?.addSink(it) }
             sharingShareId = shareId
             Log.i(TAG, "Screen capture started: ${width}x$height")
-        }.onFailure { Log.e(TAG, "Failed to start screen capture: ${it.message}", it) }
+            true
+        }.onFailure {
+            Log.e(TAG, "Failed to start screen capture: ${it.message}", it)
+            stopSharing()
+        }.getOrDefault(false)
     }
 
     private fun handleViewerOffer(message: SignalingEnvelope) {
         val from = message.from ?: return
         val shareId = message.shareId ?: return
         val offer = message.offer ?: return
+        if (message.to != localPlayerId || from == localPlayerId) return
         val isOwner = sharingShareId == shareId && localVideoTrack != null
         if (!isOwner && currentShareId != shareId) return
         val connectionKey = peerKey(shareId, from)
         val expectedVersion = expectedDownstreams[connectionKey]
         val legacyDirect = isOwner && message.routeVersion == null
+        // Only the sharing owner may accept the legacy direct offer. A relay
+        // viewer must wait for the owner's child assignment and route version;
+        // otherwise a member could dial an already-watching relay directly.
+        if (!isOwner && message.routeVersion == null) return
+        if (!legacyDirect && (message.routeVersion == null || message.routeVersion <= 0)) return
         if (!legacyDirect && expectedVersion != message.routeVersion) {
-            pendingOffers[connectionKey] = message
+            pendingOffers[relayOfferKey(shareId, from, message.routeVersion)] = message
             return
         }
         if (legacyDirect && sharePassword != null && message.password != sharePassword) {
@@ -464,7 +483,7 @@ class ScreenShareController(
         }
         val sourceTrack = if (isOwner) localVideoTrack else remoteVideoTrack
         if (sourceTrack == null) {
-            pendingOffers[connectionKey] = message
+            pendingOffers[relayOfferKey(shareId, from, message.routeVersion)] = message
             return
         }
 
@@ -488,7 +507,7 @@ class ScreenShareController(
         startOutboundHealthHeartbeat(shareId, from, message.routeVersion, connectionKey)
         pc.setRemoteDescription(object : SimpleSdpObserver() {
             override fun onSetSuccess() {
-                flushPendingIce(iceKey(shareId, "out", from), pc)
+                flushPendingIce(iceKey(shareId, "out", from, message.routeVersion), pc)
                 pc.createAnswer(object : SimpleSdpObserver() {
                     override fun onCreateSuccess(desc: SessionDescription) {
                         pc.setLocalDescription(object : SimpleSdpObserver() {
@@ -508,9 +527,16 @@ class ScreenShareController(
     }
 
     private fun processPendingOffers(shareId: String) {
-        val offers = pendingOffers.values.filter { it.shareId == shareId }.toList()
+        val offers = pendingOffers.values.filter { message ->
+            val from = message.from ?: return@filter false
+            if (message.routeVersion == null) {
+                sharingShareId == shareId
+            } else {
+                expectedDownstreams[peerKey(shareId, from)] == message.routeVersion
+            }
+        }.toList()
         offers.forEach { message ->
-            message.from?.let { pendingOffers.remove(peerKey(shareId, it)) }
+            message.from?.let { pendingOffers.remove(relayOfferKey(shareId, it, message.routeVersion)) }
             handleViewerOffer(message)
         }
     }
@@ -636,12 +662,13 @@ class ScreenShareController(
         localFrameProbe?.let { probe -> localVideoTrack?.removeSink(probe) }
         localVideoTrack?.dispose()
         localFrameProbe = null
-        sourceFrameSequences.remove(shareId)
+        shareId?.let(sourceFrameSequences::remove)
         localVideoTrack = null
         videoSource?.dispose()
         videoSource = null
         surfaceHelper?.dispose()
         surfaceHelper = null
+        sharePassword = null
     }
 
     fun handleSignal(message: SignalingEnvelope) {
@@ -652,15 +679,17 @@ class ScreenShareController(
                 val from = message.from ?: return
                 val answer = message.answer ?: return
                 val shareId = message.shareId ?: return
-                if (message.routeVersion != null && message.routeVersion != currentRouteVersion) return
+                if (message.to != localPlayerId || currentShareId != shareId || from != currentUpstreamId) return
+                if (message.routeVersion != currentRouteVersion) return
                 val pc = inboundConnections[peerKey(shareId, from)] ?: return
                 pc.setRemoteDescription(object : SimpleSdpObserver() {
-                    override fun onSetSuccess() { flushPendingIce(iceKey(shareId, "in", from), pc) }
+                    override fun onSetSuccess() { flushPendingIce(iceKey(shareId, "in", from, message.routeVersion), pc) }
                 }, SessionDescription(SessionDescription.Type.ANSWER, answer.sdp))
             }
             "screen-share-ice-candidate" -> handleIce(message)
             "screen-share-viewer-left" -> {
                 val shareId = message.shareId ?: return
+                if (message.to != null && message.to != localPlayerId) return
                 message.from?.let { handleViewerLeft(shareId, it) }
             }
         }
@@ -670,17 +699,24 @@ class ScreenShareController(
         val shareId = message.shareId ?: return
         if (sharingShareId != shareId && currentShareId != shareId) return
         val ownerId = if (sharingShareId == shareId) localPlayerId else currentOwnerId ?: return
-        if (message.action == "health" && message.to == localPlayerId) {
+        val action = message.action ?: return
+        if (message.to != localPlayerId) return
+        if (action == "health") {
+            if (sharingShareId == shareId || currentUpstreamId == null || message.from != currentUpstreamId) return
+            if (message.routeVersion != currentRouteVersion) return
+            val sourceSequence = message.sourceSequence ?: message.sequence ?: 0L
+            if (sourceSequence < upstreamHealthSequence) return
             upstreamHealthId = message.from
             upstreamHealthVersion = message.routeVersion
-            upstreamHealthSequence = message.sourceSequence ?: message.sequence ?: 0L
+            upstreamHealthSequence = sourceSequence
             upstreamHealthLimited = message.limited == true
             upstreamHealthAt = android.os.SystemClock.elapsedRealtime()
             return
         }
-        when (message.action) {
+        when (action) {
             "join" -> if (localPlayerId == ownerId && sharingShareId == shareId) {
                 val viewerId = message.from ?: return
+                if (viewerId == localPlayerId || message.routeVersion != null || message.upstreamId != null || message.downstreamId != null) return
                 if (sharePassword != null && message.password != sharePassword) {
                     sendSignal(
                         SignalingEnvelope(
@@ -702,7 +738,8 @@ class ScreenShareController(
             "ready" -> if (localPlayerId == ownerId && sharingShareId == shareId) {
                 val viewerId = message.from ?: return
                 if (viewerId !in viewerOrder) return
-                if (message.routeVersion != assignedRouteVersions[viewerId]) return
+                val assignedVersion = assignedRouteVersions[viewerId] ?: return
+                if (message.routeVersion != assignedVersion || message.upstreamId != null || message.downstreamId != null) return
                 readyViewers += viewerId
                 val oldUpstream = pendingDetachUpstreams.remove(viewerId)
                 val activeUpstream = assignedUpstreams[viewerId]
@@ -722,11 +759,10 @@ class ScreenShareController(
                 val viewerId = message.from ?: return
                 if (viewerId !in viewerOrder) return
                 val assignedUpstream = assignedUpstreams[viewerId]
-                if (message.upstreamId != null && assignedUpstream != null && message.upstreamId != assignedUpstream) return
-                if (message.routeVersion != null && message.routeVersion != assignedRouteVersions[viewerId]) return
-                val assignedVersion = assignedRouteVersions[viewerId]
-                val failedUpstream = message.upstreamId ?: assignedUpstream
-                if (failedUpstream != null) {
+                val assignedVersion = assignedRouteVersions[viewerId] ?: return
+                if (message.upstreamId != assignedUpstream || message.routeVersion != assignedVersion) return
+                if (assignedUpstream != null) {
+                    val failedUpstream = assignedUpstream
                     val count = (relayFailureCounts[failedUpstream] ?: 0) + 1
                     relayFailureCounts[failedUpstream] = count
                     val backoff = minOf(60_000L, 4_000L * (1L shl minOf(count - 1, 4)))
@@ -751,23 +787,39 @@ class ScreenShareController(
             }
             else -> {
                 if (message.from != ownerId) return
-                when (message.action) {
-                    "accepted" -> Unit
+                when (action) {
+                    "accepted" -> if (message.routeVersion == null && message.upstreamId == null && message.downstreamId == null) Unit
                     "route" -> {
                         val upstreamId = message.upstreamId ?: return
-                        connectUpstream(shareId, upstreamId, message.routeVersion ?: 0)
+                        if (upstreamId == localPlayerId) return
+                        val version = message.routeVersion ?: return
+                        if (version <= 0 || (currentRouteVersion != null && version < currentRouteVersion!!)) return
+                        if (currentRouteVersion == version && currentUpstreamId != null && currentUpstreamId != upstreamId) return
+                        connectUpstream(shareId, upstreamId, version)
                     }
                     "child" -> {
                         val downstreamId = message.downstreamId ?: return
-                        expectedDownstreams[peerKey(shareId, downstreamId)] = message.routeVersion ?: 0
-                        pendingOffers.remove(peerKey(shareId, downstreamId))?.let(::handleViewerOffer)
+                        if (downstreamId == localPlayerId) return
+                        val version = message.routeVersion ?: return
+                        if (version <= 0) return
+                        val key = peerKey(shareId, downstreamId)
+                        val previousVersion = expectedDownstreams[key]
+                        if (previousVersion != null && version < previousVersion) return
+                        expectedDownstreams[key] = version
+                        pendingOffers.remove(relayOfferKey(shareId, downstreamId, version))?.let(::handleViewerOffer)
+                        outboundConnections[key]?.let { pc ->
+                            if (pc.remoteDescription != null) flushPendingIce(iceKey(shareId, "out", downstreamId, version), pc)
+                        }
                     }
                     "detach" -> {
                         val downstreamId = message.downstreamId ?: return
-                        expectedDownstreams.remove(peerKey(shareId, downstreamId))
-                        stopOutboundHealthHeartbeat(peerKey(shareId, downstreamId))
-                        outboundConnections.remove(peerKey(shareId, downstreamId))?.close()
-                        outboundSenders.remove(peerKey(shareId, downstreamId))
+                        val key = peerKey(shareId, downstreamId)
+                        val expectedVersion = expectedDownstreams[key] ?: return
+                        if (message.routeVersion != expectedVersion) return
+                        expectedDownstreams.remove(key)
+                        stopOutboundHealthHeartbeat(key)
+                        outboundConnections.remove(key)?.close()
+                        outboundSenders.remove(key)
                     }
                 }
             }
@@ -779,17 +831,47 @@ class ScreenShareController(
         val shareId = message.shareId ?: return
         val payload = message.candidate ?: return
         val ice = IceCandidate(payload.sdpMid, payload.sdpMLineIndex ?: 0, payload.candidate)
+        if (message.to != localPlayerId) return
+        val ownerMode = sharingShareId == shareId && localVideoTrack != null
+        val viewerMode = currentShareId == shareId && currentOwnerId != null && !ownerMode
+        if (!ownerMode && !viewerMode) return
+        val routeVersion = message.routeVersion
+        if (routeVersion != null && routeVersion <= 0) return
+        val connectionKey = peerKey(shareId, from)
         val targetsInbound = when (message.connectionRole) {
-            "in" -> true
-            "out" -> false
-            else -> outboundConnections[peerKey(shareId, from)] == null && inboundConnections[peerKey(shareId, from)] != null
+            "in" -> {
+                if (!viewerMode) return
+                if (currentUpstreamId != null && from != currentUpstreamId) return
+                if (routeVersion == null && from != currentOwnerId) return
+                if (currentRouteVersion != null && routeVersion != currentRouteVersion) return
+                true
+            }
+            "out" -> {
+                if (routeVersion == null && !ownerMode) return
+                val expectedVersion = expectedDownstreams[connectionKey]
+                if (expectedVersion != null && routeVersion != expectedVersion) return
+                false
+            }
+            null -> when {
+                viewerMode && (from == currentUpstreamId || (currentUpstreamId == null && routeVersion != null)) -> {
+                    if (routeVersion == null && from != currentOwnerId) return
+                    if (currentRouteVersion != null && routeVersion != currentRouteVersion) return
+                    true
+                }
+                ownerMode -> {
+                    val expectedVersion = expectedDownstreams[connectionKey]
+                    if (expectedVersion != null && routeVersion != expectedVersion) return
+                    if (routeVersion == null && expectedVersion != null) return
+                    false
+                }
+                else -> return
+            }
+            else -> return
         }
-        val key = iceKey(shareId, if (targetsInbound) "in" else "out", from)
+        val key = iceKey(shareId, if (targetsInbound) "in" else "out", from, routeVersion)
         val pc = if (targetsInbound) inboundConnections[peerKey(shareId, from)] else outboundConnections[peerKey(shareId, from)]
-        if (message.routeVersion != null) {
-            val expectedVersion = if (targetsInbound) currentRouteVersion else expectedDownstreams[peerKey(shareId, from)]
-            if (expectedVersion != message.routeVersion) return
-        }
+        val expectedVersion = if (targetsInbound) currentRouteVersion else expectedDownstreams[connectionKey]
+        if (expectedVersion != null && routeVersion != expectedVersion) return
         if (pc?.remoteDescription != null) pc.addIceCandidate(ice) else pendingIce.getOrPut(key) { mutableListOf() }.add(ice)
     }
 
@@ -798,11 +880,20 @@ class ScreenShareController(
     }
 
     private fun handleViewerLeft(shareId: String, viewerId: String) {
-        stopOutboundHealthHeartbeat(peerKey(shareId, viewerId))
-        outboundConnections.remove(peerKey(shareId, viewerId))?.close()
-        outboundSenders.remove(peerKey(shareId, viewerId))
-        expectedDownstreams.remove(peerKey(shareId, viewerId))
-        if (sharingShareId == shareId) {
+        if (viewerId.isBlank() || viewerId == localPlayerId) return
+        val key = peerKey(shareId, viewerId)
+        val isOwner = sharingShareId == shareId && localVideoTrack != null
+        val isKnownViewer = isOwner && viewerId in viewerOrder
+        val isKnownDownstream = !isOwner && expectedDownstreams.containsKey(key)
+        if (!isKnownViewer && !isKnownDownstream) return
+
+        stopOutboundHealthHeartbeat(key)
+        outboundConnections.remove(key)?.close()
+        outboundSenders.remove(key)
+        expectedDownstreams.remove(key)
+        pendingOffers.keys.filter { it.startsWith("$shareId|$viewerId|") }.forEach(pendingOffers::remove)
+        clearPendingIceForPeer(shareId, "out", viewerId)
+        if (isOwner) {
             viewerOrder.remove(viewerId)
             viewerNames.remove(viewerId)
             readyViewers.remove(viewerId)
@@ -819,7 +910,7 @@ class ScreenShareController(
             sendSignal(
                 SignalingEnvelope(
                     type = "screen-share-relay", action = "failure", from = localPlayerId, to = currentOwnerId,
-                    shareId = currentShareId, upstreamId = playerId,
+                    shareId = currentShareId, upstreamId = playerId, routeVersion = currentRouteVersion,
                 ),
             )
         }
@@ -860,7 +951,16 @@ class ScreenShareController(
 
     private fun peerKey(shareId: String, playerId: String) = "$shareId|$playerId"
 
-    private fun iceKey(shareId: String, direction: String, playerId: String) = "$direction:$shareId|$playerId"
+    private fun relayOfferKey(shareId: String, playerId: String, routeVersion: Int?) =
+        "$shareId|$playerId|${routeVersion ?: "legacy"}"
+
+    private fun iceKey(shareId: String, direction: String, playerId: String, routeVersion: Int?) =
+        "$direction:$shareId|$playerId|${routeVersion ?: "legacy"}"
+
+    private fun clearPendingIceForPeer(shareId: String, direction: String, playerId: String) {
+        val prefix = "$direction:$shareId|$playerId|"
+        pendingIce.keys.filter { it.startsWith(prefix) }.forEach(pendingIce::remove)
+    }
 
     private fun closeConnectionsForShare(connections: MutableMap<String, PeerConnection>, shareId: String) {
         connections.keys.filter { it.startsWith("$shareId|") }.forEach { key ->

--- a/src/services/remoteControl/RemoteControlService.ts
+++ b/src/services/remoteControl/RemoteControlService.ts
@@ -19,6 +19,12 @@ export type RemoteInputEvent =
 
 type Role = 'idle' | 'controller' | 'controlled';
 
+type PendingControlRequest = {
+  sessionId: string;
+  from: string;
+  fromName: string;
+};
+
 const RTC_CONFIG: RTCConfiguration = {
   iceServers: [],
   iceTransportPolicy: 'all',
@@ -40,8 +46,9 @@ class RemoteControlService {
   private localStream: MediaStream | null = null;
   private pendingInput: RemoteInputEvent[] = [];
   private flushTimer: number | null = null;
-  private pendingIce: RTCIceCandidateInit[] = [];
+  private pendingIce: Array<{ sessionId: string; peerId: string; candidate: RTCIceCandidateInit }> = [];
   private requestTimer: number | null = null;
+  private pendingRequest: PendingControlRequest | null = null;
 
   initialize(playerId: string, playerName: string, ws: WebSocket): void {
     this.playerId = playerId;
@@ -67,13 +74,35 @@ class RemoteControlService {
     }
   }
 
+  private createSessionId(): string {
+    if (!globalThis.crypto?.randomUUID) {
+      throw new Error('当前运行环境不支持安全的远程控制会话 ID');
+    }
+    return `rc-${this.playerId}-${globalThis.crypto.randomUUID()}`;
+  }
+
+  private isCurrentPeerMessage(sessionId: string, from: string, to: string): boolean {
+    return this.isCurrentPeerSession(sessionId, from) && to === this.playerId;
+  }
+
+  private isCurrentPeerSession(sessionId: string, peerId: string, pc?: RTCPeerConnection | null): boolean {
+    return this.role !== 'idle'
+      && sessionId === this.sessionId
+      && peerId === this.peerId
+      && (pc === undefined || this.pc === pc);
+  }
+
   // ==================== 控制端：发起请求 ====================
   requestControl(targetId: string, targetName: string): void {
     if (this.role !== 'idle') {
       throw new Error('已有进行中的远程控制会话');
     }
+    if (!targetId || targetId === this.playerId) {
+      throw new Error('无效的远程控制目标');
+    }
+    const nextSessionId = this.createSessionId();
     this.role = 'controller';
-    this.sessionId = `rc-${this.playerId}-${Date.now()}`;
+    this.sessionId = nextSessionId;
     this.peerId = targetId;
     this.peerName = targetName;
     this.send({
@@ -85,42 +114,80 @@ class RemoteControlService {
     });
     // 90 秒内对方未接受则超时（首次需在手机上授予无障碍与录屏权限，留足时间）
     this.requestTimer = window.setTimeout(() => {
-      if (this.role === 'controller' && !this.pc) {
-        this.handleReject('timeout');
+      if (this.role === 'controller' && this.sessionId === nextSessionId && !this.pc) {
+        this.send({
+          type: 'remote-control-stop',
+          from: this.playerId,
+          to: targetId,
+          sessionId: nextSessionId,
+        });
+        this.finishReject('timeout');
       }
     }, 90000);
   }
 
   // ==================== 被控端：接受/拒绝 ====================
   async acceptControl(sessionId: string, controllerId: string, controllerName: string): Promise<void> {
+    const pending = this.pendingRequest;
+    if (!pending || pending.sessionId !== sessionId || pending.from !== controllerId || this.role !== 'idle') {
+      throw new Error('远程控制请求已失效');
+    }
     this.role = 'controlled';
     this.sessionId = sessionId;
     this.peerId = controllerId;
     this.peerName = controllerName;
-    // 在用户手势内采集屏幕（getDisplayMedia 需要用户激活）
-    this.localStream = await navigator.mediaDevices.getDisplayMedia({
-      video: {
-        frameRate: { ideal: 30, max: 60 },
-        width: { ideal: 1920, max: 3840 },
-        height: { ideal: 1080, max: 2160 },
-      } as any,
-      audio: false,
-    });
-    const vt = this.localStream.getVideoTracks()[0];
-    if (vt) {
-      vt.contentHint = 'motion';
-      vt.onended = () => this.stopControl();
+    this.pendingRequest = null;
+    try {
+      // 在用户手势内采集屏幕（getDisplayMedia 需要用户激活）。
+      // 先保存在局部变量，避免旧授权 Promise 覆盖后续新会话的 localStream。
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: {
+          frameRate: { ideal: 30, max: 60 },
+          width: { ideal: 1920, max: 3840 },
+          height: { ideal: 1080, max: 2160 },
+        } as any,
+        audio: false,
+      });
+      // 用户授权期间对端可能已经停止或会话被本地清理，不能把迟到的媒体流重新挂回旧会话。
+      if (!this.isCurrentPeerMessage(sessionId, controllerId, this.playerId)) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+      this.localStream = stream;
+      const vt = stream.getVideoTracks()[0];
+      if (vt) {
+        vt.contentHint = 'motion';
+        vt.onended = () => {
+          if (this.isCurrentPeerSession(sessionId, controllerId) && this.localStream === stream) this.stopControl();
+        };
+      }
+      this.send({
+        type: 'remote-control-accept',
+        from: this.playerId,
+        to: controllerId,
+        sessionId,
+      });
+      // 等待控制端发来的 offer（在 handleOffer 中应答）
+    } catch (error) {
+      // Permission denial and capture setup errors must not leave the service stuck in controlled.
+      if (!this.isCurrentPeerMessage(sessionId, controllerId, this.playerId)) return;
+      try {
+        this.send({
+          type: 'remote-control-reject',
+          from: this.playerId,
+          to: controllerId,
+          sessionId,
+          reason: 'capture-failed',
+        });
+      } catch { /* ignore signaling teardown races */ }
+      this.cleanup();
+      throw error;
     }
-    this.send({
-      type: 'remote-control-accept',
-      from: this.playerId,
-      to: controllerId,
-      sessionId,
-    });
-    // 等待控制端发来的 offer（在 handleOffer 中应答）
   }
 
   rejectControl(sessionId: string, controllerId: string): void {
+    const pending = this.pendingRequest;
+    if (!pending || pending.sessionId !== sessionId || pending.from !== controllerId) return;
     this.send({
       type: 'remote-control-reject',
       from: this.playerId,
@@ -128,6 +195,7 @@ class RemoteControlService {
       sessionId,
       reason: 'rejected',
     });
+    this.pendingRequest = null;
   }
 
   // ==================== 通用：停止 ====================
@@ -154,6 +222,8 @@ class RemoteControlService {
       this.flushTimer = null;
     }
     this.pendingInput = [];
+    this.pendingIce = [];
+    this.pendingRequest = null;
     if (this.inputChannel) {
       try { this.inputChannel.onmessage = null; this.inputChannel.close(); } catch { /* ignore */ }
       this.inputChannel = null;
@@ -181,122 +251,211 @@ class RemoteControlService {
   // ==================== 信令处理（由 WebRTCClient 调用） ====================
 
   /** 被控端收到控制请求 */
-  handleRequest(sessionId: string, from: string, fromName: string): void {
+  handleRequest(sessionId: string, from: string, fromName: string, to: string): void {
+    if (!sessionId || !from || from === this.playerId || to !== this.playerId) return;
     if (this.role !== 'idle') {
       // 忙：自动拒绝
       this.send({ type: 'remote-control-reject', from: this.playerId, to: from, sessionId, reason: 'busy' });
       return;
     }
+    if (this.pendingRequest) {
+      this.send({ type: 'remote-control-reject', from: this.playerId, to: from, sessionId, reason: 'busy' });
+      return;
+    }
+    this.pendingRequest = { sessionId, from, fromName };
     window.dispatchEvent(new CustomEvent('rc-incoming-request', { detail: { sessionId, from, fromName } }));
   }
 
   /** 控制端收到被控端接受 -> 建立连接并发 offer */
-  async handleAccept(sessionId: string): Promise<void> {
-    if (this.role !== 'controller' || sessionId !== this.sessionId) return;
+  async handleAccept(sessionId: string, from: string, to: string): Promise<void> {
+    if (this.role !== 'controller' || !this.isCurrentPeerMessage(sessionId, from, to) || this.pc) return;
+    const expectedSessionId = sessionId;
+    const expectedPeerId = from;
     if (this.requestTimer !== null) { clearTimeout(this.requestTimer); this.requestTimer = null; }
     const pc = new RTCPeerConnection(RTC_CONFIG);
     this.pc = pc;
 
     const ch = pc.createDataChannel('rc-input', { ordered: true });
     this.inputChannel = ch;
-    ch.onopen = () => this.startFlush();
+    ch.onopen = () => this.startFlush(expectedSessionId, expectedPeerId, pc, ch);
 
     pc.addTransceiver('video', { direction: 'recvonly' });
     pc.ontrack = (e) => {
-      if (e.streams && e.streams[0]) {
+      if (this.isCurrentPeerSession(expectedSessionId, expectedPeerId, pc) && e.streams && e.streams[0]) {
         window.dispatchEvent(new CustomEvent('rc-stream', { detail: { stream: e.streams[0], peerName: this.peerName } }));
       }
     };
-    pc.onicecandidate = (e) => { if (e.candidate) this.sendIce(e.candidate); };
+    pc.onicecandidate = (e) => {
+      if (e.candidate) this.sendIce(expectedSessionId, expectedPeerId, pc, e.candidate);
+    };
     pc.onconnectionstatechange = () => {
+      if (!this.isCurrentPeerSession(expectedSessionId, expectedPeerId, pc)) return;
       if (pc.connectionState === 'failed' || pc.connectionState === 'closed') this.stopControl(false);
     };
 
-    const offer = await pc.createOffer();
-    await pc.setLocalDescription(offer);
-    this.send({
-      type: 'remote-control-offer',
-      from: this.playerId, to: this.peerId, sessionId,
-      offer: { type: offer.type, sdp: offer.sdp },
-    });
+    try {
+      const offer = await pc.createOffer();
+      if (!this.isCurrentPeerSession(expectedSessionId, expectedPeerId, pc)) {
+        pc.close();
+        return;
+      }
+      await pc.setLocalDescription(offer);
+      if (!this.isCurrentPeerSession(expectedSessionId, expectedPeerId, pc)) {
+        pc.close();
+        return;
+      }
+      this.send({
+        type: 'remote-control-offer',
+        from: this.playerId, to: expectedPeerId, sessionId: expectedSessionId,
+        offer: { type: offer.type, sdp: offer.sdp },
+      });
+    } catch (error) {
+      if (this.isCurrentPeerSession(expectedSessionId, expectedPeerId, pc)) this.stopControl(false);
+      throw error;
+    }
   }
 
   /** 被控端收到 offer -> 加屏幕轨、建数据通道、应答 */
-  async handleOffer(sessionId: string, sdp: string): Promise<void> {
-    if (this.role !== 'controlled' || sessionId !== this.sessionId) return;
-    if (!this.localStream) {
-      // 兜底：理论上 acceptControl 已采集
-      this.localStream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false } as any);
-    }
-    const pc = new RTCPeerConnection(RTC_CONFIG);
-    this.pc = pc;
-    this.localStream.getTracks().forEach((t) => pc.addTrack(t, this.localStream!));
-
-    pc.ondatachannel = (e) => {
-      if (e.channel.label === 'rc-input') {
-        this.inputChannel = e.channel;
-        e.channel.onmessage = (ev) => this.onInputMessage(ev.data);
+  async handleOffer(sessionId: string, from: string, to: string, sdp: string): Promise<void> {
+    if (this.role !== 'controlled' || !this.isCurrentPeerMessage(sessionId, from, to) || this.pc) return;
+    const expectedSessionId = sessionId;
+    const expectedPeerId = from;
+    try {
+      let stream = this.localStream;
+      if (!stream) {
+        // 兜底：理论上 acceptControl 已采集
+        const capturedStream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false } as any);
+        if (!this.isCurrentPeerSession(expectedSessionId, expectedPeerId)) {
+          capturedStream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+        this.localStream = capturedStream;
+        stream = capturedStream;
       }
-    };
-    pc.onicecandidate = (e) => { if (e.candidate) this.sendIce(e.candidate); };
-    pc.onconnectionstatechange = () => {
-      if (pc.connectionState === 'failed' || pc.connectionState === 'closed') this.stopControl(false);
-    };
+      const pc = new RTCPeerConnection(RTC_CONFIG);
+      this.pc = pc;
+      stream.getTracks().forEach((track) => pc.addTrack(track, stream!));
 
-    await pc.setRemoteDescription({ type: 'offer', sdp });
-    await this.flushPendingIce();
-    const answer = await pc.createAnswer();
-    await pc.setLocalDescription(answer);
-    this.send({
-      type: 'remote-control-answer',
-      from: this.playerId, to: this.peerId, sessionId,
-      answer: { type: answer.type, sdp: answer.sdp },
-    });
-    window.dispatchEvent(new CustomEvent('rc-controlled-active', { detail: { peerName: this.peerName } }));
+      pc.ondatachannel = (e) => {
+        if (e.channel.label === 'rc-input' && this.isCurrentPeerSession(expectedSessionId, expectedPeerId, pc)) {
+          this.inputChannel = e.channel;
+          e.channel.onmessage = (ev) => this.onInputMessage(ev.data, expectedSessionId, expectedPeerId, pc, e.channel);
+        } else {
+          e.channel.close();
+        }
+      };
+      pc.onicecandidate = (e) => {
+        if (e.candidate) this.sendIce(expectedSessionId, expectedPeerId, pc, e.candidate);
+      };
+      pc.onconnectionstatechange = () => {
+        if (!this.isCurrentPeerSession(expectedSessionId, expectedPeerId, pc)) return;
+        if (pc.connectionState === 'failed' || pc.connectionState === 'closed') this.stopControl(false);
+      };
+
+      await pc.setRemoteDescription({ type: 'offer', sdp });
+      if (!this.isCurrentPeerSession(expectedSessionId, expectedPeerId, pc)) {
+        pc.close();
+        return;
+      }
+      await this.flushPendingIce(expectedSessionId, expectedPeerId, pc);
+      const answer = await pc.createAnswer();
+      if (!this.isCurrentPeerSession(expectedSessionId, expectedPeerId, pc)) {
+        pc.close();
+        return;
+      }
+      await pc.setLocalDescription(answer);
+      if (!this.isCurrentPeerSession(expectedSessionId, expectedPeerId, pc)) {
+        pc.close();
+        return;
+      }
+      this.send({
+        type: 'remote-control-answer',
+        from: this.playerId, to: expectedPeerId, sessionId: expectedSessionId,
+        answer: { type: answer.type, sdp: answer.sdp },
+      });
+      window.dispatchEvent(new CustomEvent('rc-controlled-active', { detail: { peerName: this.peerName } }));
+    } catch (error) {
+      if (this.isCurrentPeerSession(expectedSessionId, expectedPeerId)) this.stopControl(false);
+      throw error;
+    }
   }
 
   /** 控制端收到 answer */
-  async handleAnswer(sessionId: string, sdp: string): Promise<void> {
-    if (this.role !== 'controller' || sessionId !== this.sessionId || !this.pc) return;
-    if (this.pc.signalingState !== 'have-local-offer') return;
-    await this.pc.setRemoteDescription({ type: 'answer', sdp });
-    await this.flushPendingIce();
+  async handleAnswer(sessionId: string, from: string, to: string, sdp: string): Promise<void> {
+    if (this.role !== 'controller' || !this.isCurrentPeerMessage(sessionId, from, to) || !this.pc) return;
+    const pc = this.pc;
+    if (pc.signalingState !== 'have-local-offer' || !this.isCurrentPeerSession(sessionId, from, pc)) return;
+    try {
+      await pc.setRemoteDescription({ type: 'answer', sdp });
+      if (!this.isCurrentPeerSession(sessionId, from, pc)) return;
+      await this.flushPendingIce(sessionId, from, pc);
+    } catch (error) {
+      if (this.isCurrentPeerSession(sessionId, from, pc)) this.stopControl(false);
+      throw error;
+    }
   }
 
   /** 双方：收到对端 ICE */
-  async handleIce(candidate: RTCIceCandidateInit): Promise<void> {
-    if (!this.pc || !this.pc.remoteDescription) {
-      this.pendingIce.push(candidate);
+  async handleIce(sessionId: string, from: string, to: string, candidate: RTCIceCandidateInit): Promise<void> {
+    if (!this.isCurrentPeerMessage(sessionId, from, to)) return;
+    const pc = this.pc;
+    if (!pc || !pc.remoteDescription) {
+      this.pendingIce.push({ sessionId, peerId: from, candidate });
       return;
     }
-    try { await this.pc.addIceCandidate(new RTCIceCandidate(candidate)); } catch (e) { console.warn('rc ice 失败', e); }
+    if (!this.isCurrentPeerSession(sessionId, from, pc)) return;
+    try {
+      await pc.addIceCandidate(new RTCIceCandidate(candidate));
+    } catch (e) {
+      if (this.isCurrentPeerSession(sessionId, from, pc)) console.warn('rc ice 失败', e);
+    }
   }
 
   /** 控制端被拒绝 */
-  handleReject(reason: string): void {
+  private finishReject(reason: string): void {
     window.dispatchEvent(new CustomEvent('rc-rejected', { detail: { reason } }));
     this.cleanup();
   }
 
+  handleReject(sessionId: string, from: string, to: string, reason: string): void {
+    if (this.role !== 'controller' || !this.isCurrentPeerMessage(sessionId, from, to)) return;
+    this.finishReject(reason);
+  }
+
   /** 对端停止 */
-  handleStop(): void {
+  handleStop(sessionId: string, from: string, to: string): void {
+    if (this.role === 'idle') {
+      const pending = this.pendingRequest;
+      if (pending && pending.sessionId === sessionId && pending.from === from && to === this.playerId) {
+        this.pendingRequest = null;
+        window.dispatchEvent(new CustomEvent('rc-ended', { detail: { reason: 'peer-stopped' } }));
+      }
+      return;
+    }
+    if (!this.isCurrentPeerMessage(sessionId, from, to)) return;
     this.cleanup();
     window.dispatchEvent(new CustomEvent('rc-ended', { detail: {} }));
   }
 
-  private async flushPendingIce(): Promise<void> {
-    if (!this.pc || !this.pc.remoteDescription) return;
-    const list = this.pendingIce;
-    this.pendingIce = [];
-    for (const c of list) {
-      try { await this.pc.addIceCandidate(new RTCIceCandidate(c)); } catch (e) { console.warn('rc ice flush 失败', e); }
+  private async flushPendingIce(sessionId: string, peerId: string, pc: RTCPeerConnection): Promise<void> {
+    if (!pc.remoteDescription || !this.isCurrentPeerSession(sessionId, peerId, pc)) return;
+    const list = this.pendingIce.filter((item) => item.sessionId === sessionId && item.peerId === peerId);
+    this.pendingIce = this.pendingIce.filter((item) => item.sessionId !== sessionId || item.peerId !== peerId);
+    for (const item of list) {
+      if (!this.isCurrentPeerSession(sessionId, peerId, pc)) return;
+      try {
+        await pc.addIceCandidate(new RTCIceCandidate(item.candidate));
+      } catch (e) {
+        if (this.isCurrentPeerSession(sessionId, peerId, pc)) console.warn('rc ice flush 失败', e);
+      }
     }
   }
 
-  private sendIce(candidate: RTCIceCandidate): void {
+  private sendIce(sessionId: string, peerId: string, pc: RTCPeerConnection, candidate: RTCIceCandidate): void {
+    if (!this.isCurrentPeerSession(sessionId, peerId, pc)) return;
     this.send({
       type: 'remote-control-ice',
-      from: this.playerId, to: this.peerId, sessionId: this.sessionId,
+      from: this.playerId, to: peerId, sessionId,
       candidate: { candidate: candidate.candidate, sdpMLineIndex: candidate.sdpMLineIndex, sdpMid: candidate.sdpMid },
     });
   }
@@ -307,26 +466,59 @@ class RemoteControlService {
     this.pendingInput.push(ev);
   }
 
-  private startFlush(): void {
-    if (this.flushTimer !== null) return;
-    this.flushTimer = window.setInterval(() => {
-      if (!this.inputChannel || this.inputChannel.readyState !== 'open') return;
+  private startFlush(sessionId: string, peerId: string, pc: RTCPeerConnection, channel: RTCDataChannel): void {
+    if (!this.isCurrentPeerSession(sessionId, peerId, pc) || this.inputChannel !== channel || this.flushTimer !== null) return;
+    const timer = window.setInterval(() => {
+      if (!this.isCurrentPeerSession(sessionId, peerId, pc) || this.inputChannel !== channel || channel.readyState !== 'open') {
+        if (this.flushTimer === timer) {
+          clearInterval(timer);
+          this.flushTimer = null;
+        }
+        return;
+      }
       if (this.pendingInput.length === 0) return;
       const batch = this.pendingInput;
       this.pendingInput = [];
-      try { this.inputChannel.send(JSON.stringify(batch)); } catch { /* ignore */ }
+      try { channel.send(JSON.stringify(batch)); } catch { /* ignore */ }
     }, 16);
+    this.flushTimer = timer;
   }
 
-  private async onInputMessage(data: any): Promise<void> {
+  private async onInputMessage(
+    data: any,
+    sessionId: string,
+    peerId: string,
+    pc: RTCPeerConnection,
+    channel: RTCDataChannel,
+  ): Promise<void> {
+    if (this.role !== 'controlled' || this.inputChannel !== channel || channel.readyState !== 'open' || !this.isCurrentPeerSession(sessionId, peerId, pc)) return;
     try {
       const events = JSON.parse(typeof data === 'string' ? data : String(data));
-      if (Array.isArray(events) && events.length) {
+      if (Array.isArray(events) && events.length && this.isCurrentPeerSession(sessionId, peerId, pc)) {
         await invoke('remote_inject_input', { events });
       }
     } catch (e) {
       console.warn('注入输入失败', e);
     }
+  }
+
+  handlePeerLeft(peerId: string): void {
+    let ended = false;
+    if (this.pendingRequest?.from === peerId) {
+      this.pendingRequest = null;
+      ended = true;
+    }
+    if (this.role !== 'idle' && this.peerId === peerId) {
+      this.cleanup();
+      ended = true;
+    }
+    if (ended) window.dispatchEvent(new CustomEvent('rc-ended', { detail: { reason: 'peer-left' } }));
+  }
+
+  handleSignalingDisconnected(): void {
+    if (this.role === 'idle' && !this.pendingRequest) return;
+    this.cleanup();
+    window.dispatchEvent(new CustomEvent('rc-ended', { detail: { reason: 'signaling-disconnected' } }));
   }
 }
 

--- a/src/services/screenShare/ScreenShareService.ts
+++ b/src/services/screenShare/ScreenShareService.ts
@@ -88,6 +88,9 @@ class ScreenShareService {
    */
   async startSharing(requirePassword: boolean, password?: string): Promise<string> {
     try {
+      if (requirePassword && !password?.trim()) {
+        throw new Error('屏幕共享密码不能为空');
+      }
       console.log('🖥️ [ScreenShareService] 开始捕获屏幕...');
       
       // 捕获屏幕
@@ -261,12 +264,14 @@ class ScreenShareService {
           relayPc.close();
           this.peerConnections.delete(key);
         }
+        const previousUpstream = this.viewingUpstreams.get(shareId);
         this.viewingUpstreams.set(shareId, share.playerId);
         const routeVersion = this.viewingRouteVersions.get(shareId);
-        if (!isNullish(routeVersion)) {
+        if (!isNullish(routeVersion) && previousUpstream) {
           this.sendWebSocketMessage({
             type: 'screen-share-relay', action: 'failure', from: this.currentPlayerId,
-            to: share.playerId, shareId, routeVersion, reason: 'direct-fallback',
+            to: share.playerId, shareId, upstreamId: previousUpstream,
+            routeVersion, reason: 'direct-fallback',
           });
         }
         window.clearTimeout(pending.timer);
@@ -448,15 +453,15 @@ class ScreenShareService {
   /**
    * 停止查看屏幕（清理viewer的PeerConnection）
    */
-  stopViewingScreen(shareId: string): void {
+  stopViewingScreen(shareId: string, notify = true): void {
     console.log('🛑 [ScreenShareService] 停止查看屏幕:', shareId);
 
     const share = this.activeShares.get(shareId);
-    if (share?.playerId === this.currentPlayerId) {
+    if (notify && share?.playerId === this.currentPlayerId) {
       // 兼容旧版本曾把“自己看自己”加入观看者列表的状态。
       // 本地直出不应占用观看者名额，停止时主动清理并广播最新人数。
       this.handleViewerLeft(shareId, this.currentPlayerId);
-    } else if (share) {
+    } else if (notify && share) {
       this.sendWebSocketMessage({
         type: 'screen-share-viewer-left',
         from: this.currentPlayerId,
@@ -505,6 +510,15 @@ class ScreenShareService {
     }
 
     console.log('✅ [ScreenShareService] 已清理查看资源');
+  }
+
+  /** Apply a remote stop only when it is signed by the share owner. */
+  handleShareStop(shareId: string, senderId: string): boolean {
+    const share = this.activeShares.get(shareId);
+    if (!share || !senderId || share.playerId !== senderId) return false;
+    this.stopViewingScreen(shareId, false);
+    this.activeShares.delete(shareId);
+    return true;
   }
 
   /**
@@ -592,12 +606,14 @@ class ScreenShareService {
 
   /** 处理链式中继控制面。共享者是唯一拓扑协调者。 */
   async handleRelayControl(message: any): Promise<void> {
-    const shareId = message.shareId as string;
+    const shareId = typeof message.shareId === 'string' ? message.shareId : '';
+    const senderId = typeof message.from === 'string' ? message.from : '';
     const share = this.activeShares.get(shareId);
-    if (!share) return;
+    if (!share || !senderId) return;
     const ownerId = share.playerId;
 
     if (message.action === 'join' && this.currentPlayerId === ownerId) {
+      if (message.to !== this.currentPlayerId || senderId === this.currentPlayerId) return;
       if (share.requirePassword && message.password !== share.password) {
         this.sendWebSocketMessage({ type: 'screen-share-error', from: this.currentPlayerId, to: message.from, shareId, error: '密码错误' });
         return;
@@ -614,8 +630,12 @@ class ScreenShareService {
     }
 
     if (message.action === 'health' && message.to === this.currentPlayerId) {
+      const currentUpstream = this.viewingUpstreams.get(shareId);
+      const currentRouteVersion = this.viewingRouteVersions.get(shareId);
+      if (currentUpstream !== senderId) return;
+      if (!isNullish(message.routeVersion) && currentRouteVersion !== Number(message.routeVersion)) return;
       this.upstreamHealth.set(shareId, {
-        upstreamId: message.from,
+        upstreamId: senderId,
         routeVersion: isNullish(message.routeVersion) ? undefined : Number(message.routeVersion),
         sourceSequence: Number(message.sourceSequence ?? message.sequence ?? 0),
         sentSequence: Number(message.sentSequence ?? message.sequence ?? 0),
@@ -626,26 +646,26 @@ class ScreenShareService {
     }
 
     if (message.action === 'ready' && this.currentPlayerId === ownerId) {
-      if (!(this.viewerOrder.get(shareId) ?? []).includes(message.from)) return;
-      const assignedVersion = this.assignedRouteVersions.get(shareId)?.get(message.from);
+      if (message.to !== this.currentPlayerId || !(this.viewerOrder.get(shareId) ?? []).includes(senderId)) return;
+      const assignedVersion = this.assignedRouteVersions.get(shareId)?.get(senderId);
       if (isNullish(assignedVersion) || assignedVersion !== Number(message.routeVersion || 0)) return;
       const ready = this.readyViewers.get(shareId) ?? new Set<string>();
-      ready.add(message.from);
+      ready.add(senderId);
       this.readyViewers.set(shareId, ready);
-      const pendingDetach = this.pendingDetachUpstreams.get(shareId)?.get(message.from);
-      if (pendingDetach && pendingDetach !== this.assignedUpstreams.get(shareId)?.get(message.from)) {
+      const pendingDetach = this.pendingDetachUpstreams.get(shareId)?.get(senderId);
+      if (pendingDetach && pendingDetach !== this.assignedUpstreams.get(shareId)?.get(senderId)) {
         if (pendingDetach === this.currentPlayerId) {
-          const oldKey = shareId + '-out-' + message.from;
+          const oldKey = shareId + '-out-' + senderId;
           this.stopOutboundHealthHeartbeat(oldKey);
           this.peerConnections.get(oldKey)?.close();
           this.peerConnections.delete(oldKey);
-          this.expectedDownstreams.get(shareId)?.delete(message.from);
+          this.expectedDownstreams.get(shareId)?.delete(senderId);
         } else {
-          this.sendWebSocketMessage({ type: 'screen-share-relay', action: 'detach', from: this.currentPlayerId, to: pendingDetach, shareId, downstreamId: message.from, routeVersion: Number(message.routeVersion || 0) });
+          this.sendWebSocketMessage({ type: 'screen-share-relay', action: 'detach', from: this.currentPlayerId, to: pendingDetach, shareId, downstreamId: senderId, routeVersion: Number(message.routeVersion || 0) });
         }
-        this.pendingDetachUpstreams.get(shareId)?.delete(message.from);
+        this.pendingDetachUpstreams.get(shareId)?.delete(senderId);
       } else if (pendingDetach) {
-        this.pendingDetachUpstreams.get(shareId)?.delete(message.from);
+        this.pendingDetachUpstreams.get(shareId)?.delete(senderId);
       }
       this.rebuildRelayRoutes(shareId);
       return;
@@ -653,52 +673,67 @@ class ScreenShareService {
 
     if (message.action === 'failure' && this.currentPlayerId === ownerId) {
       const order = this.viewerOrder.get(shareId) ?? [];
-      if (!order.includes(message.from)) return;
-      const assignedUpstream = this.assignedUpstreams.get(shareId)?.get(message.from);
-      if (message.upstreamId && assignedUpstream && message.upstreamId !== assignedUpstream) return;
-      const assignedVersion = this.assignedRouteVersions.get(shareId)?.get(message.from);
-      if (!isNullish(message.routeVersion) && assignedVersion !== Number(message.routeVersion)) return;
-      this.markRelayFailure(shareId, message.from, assignedUpstream, message.reason || 'connection');
+      if (message.to !== this.currentPlayerId || !order.includes(senderId)) return;
+      const assignedUpstream = this.assignedUpstreams.get(shareId)?.get(senderId);
+      if (isNullish(message.upstreamId) || isNullish(message.routeVersion)) return;
+      if (!assignedUpstream || message.upstreamId !== assignedUpstream) return;
+      const assignedVersion = this.assignedRouteVersions.get(shareId)?.get(senderId);
+      if (isNullish(assignedVersion) || Number(message.routeVersion) !== assignedVersion) return;
+      this.markRelayFailure(shareId, senderId, assignedUpstream, message.reason || 'connection');
       if (assignedUpstream === this.currentPlayerId) {
-        const oldKey = shareId + '-out-' + message.from;
+        const oldKey = shareId + '-out-' + senderId;
         this.stopOutboundHealthHeartbeat(oldKey);
         this.peerConnections.get(oldKey)?.close();
         this.peerConnections.delete(oldKey);
-        this.expectedDownstreams.get(shareId)?.delete(message.from);
+        this.expectedDownstreams.get(shareId)?.delete(senderId);
       } else if (assignedUpstream) {
-        this.sendWebSocketMessage({ type: 'screen-share-relay', action: 'detach', from: this.currentPlayerId, to: assignedUpstream, shareId, downstreamId: message.from, routeVersion: assignedVersion });
+        this.sendWebSocketMessage({ type: 'screen-share-relay', action: 'detach', from: this.currentPlayerId, to: assignedUpstream, shareId, downstreamId: senderId, routeVersion: assignedVersion });
       }
       // The failed edge is removed from the assignment before rebuilding;
       // healthy replacement routes are confirmed with a real decoded frame.
-      this.readyViewers.get(shareId)?.delete(message.from);
-      this.assignedUpstreams.get(shareId)?.delete(message.from);
-      this.assignedRouteVersions.get(shareId)?.delete(message.from);
+      this.readyViewers.get(shareId)?.delete(senderId);
+      this.assignedUpstreams.get(shareId)?.delete(senderId);
+      this.assignedRouteVersions.get(shareId)?.delete(senderId);
       this.rebuildRelayRoutes(shareId);
       return;
     }
 
-    if (message.from !== ownerId) return;
+    if (senderId !== ownerId || message.to !== this.currentPlayerId) return;
 
-    if (message.action === 'accepted' && message.to === this.currentPlayerId) {
+    if (message.action === 'accepted' && message.to === this.currentPlayerId && isNullish(message.routeVersion) && isNullish(message.upstreamId) && isNullish(message.downstreamId)) {
       this.relayProtocolConfirmed.add(shareId);
       return;
     }
 
     if (message.action === 'route' && message.to === this.currentPlayerId && message.upstreamId) {
+      const routeVersion = Number(message.routeVersion);
+      if (!Number.isInteger(routeVersion) || routeVersion <= 0 || message.upstreamId === this.currentPlayerId) return;
+      const currentRouteVersion = this.viewingRouteVersions.get(shareId);
+      const currentUpstream = this.viewingUpstreams.get(shareId);
+      if (!isNullish(currentRouteVersion) && routeVersion < currentRouteVersion) return;
+      if (currentRouteVersion === routeVersion && currentUpstream && currentUpstream !== message.upstreamId) return;
       this.relayProtocolConfirmed.add(shareId);
-      await this.connectRelayUpstream(shareId, message.upstreamId, Number(message.routeVersion || 0));
+      await this.connectRelayUpstream(shareId, message.upstreamId, routeVersion);
       return;
     }
 
     if (message.action === 'child' && message.to === this.currentPlayerId && message.downstreamId) {
       const expected = this.expectedDownstreams.get(shareId) ?? new Map<string, number>();
-      expected.set(message.downstreamId, Number(message.routeVersion || 0));
+      const routeVersion = Number(message.routeVersion);
+      if (!Number.isInteger(routeVersion) || routeVersion <= 0) return;
+      const previousVersion = expected.get(message.downstreamId);
+      if (!isNullish(previousVersion) && routeVersion < previousVersion) return;
+      expected.set(message.downstreamId, routeVersion);
       this.expectedDownstreams.set(shareId, expected);
-      const pendingKey = shareId + ':' + message.downstreamId;
+      const pendingKey = this.relayOfferKey(shareId, message.downstreamId, routeVersion);
       const pending = this.pendingRelayOffers.get(pendingKey);
       if (pending) {
         this.pendingRelayOffers.delete(pendingKey);
         await this.handleOffer(pending);
+      }
+      const pc = this.peerConnections.get(shareId + '-out-' + message.downstreamId);
+      if (pc?.remoteDescription) {
+        await this.flushPendingIce(this.iceKey(shareId, 'out', message.downstreamId, routeVersion), pc);
       }
       return;
     }
@@ -709,6 +744,7 @@ class ScreenShareService {
       this.stopOutboundHealthHeartbeat(key);
       this.peerConnections.get(key)?.close();
       this.peerConnections.delete(key);
+      this.clearPendingIceForPeer(shareId, 'out', message.downstreamId);
     }
   }
 
@@ -948,8 +984,8 @@ class ScreenShareService {
         this.startViewingHealthMonitor(shareId, pc, track, upstreamId, routeVersion);
 
         const expected = this.expectedDownstreams.get(shareId) ?? new Map<string, number>();
-        for (const downstreamId of expected.keys()) {
-          const pendingKey = shareId + ':' + downstreamId;
+        for (const [downstreamId, expectedVersion] of expected.entries()) {
+          const pendingKey = this.relayOfferKey(shareId, downstreamId, expectedVersion);
           const pendingOffer = this.pendingRelayOffers.get(pendingKey);
           if (pendingOffer) {
             this.pendingRelayOffers.delete(pendingKey);
@@ -1128,8 +1164,16 @@ class ScreenShareService {
       const isOwner = share.playerId === this.currentPlayerId;
       const expectedVersion = this.expectedDownstreams.get(offer.shareId)?.get(offer.playerId);
       const isLegacyDirectOffer = isOwner && isNullish(offer.routeVersion);
+      // Only the owner may use the legacy password-gated direct path. A relay
+      // viewer must have an owner-issued child route before it can accept an
+      // offer, otherwise a member can bypass the owner's password by dialing
+      // an already-watching relay directly.
+      if (!isOwner && isNullish(offer.routeVersion)) return;
+      if (!isLegacyDirectOffer && (!Number.isInteger(offer.routeVersion) || Number(offer.routeVersion) <= 0)) return;
       if (!isLegacyDirectOffer && (isNullish(expectedVersion) || expectedVersion !== Number(offer.routeVersion || 0))) {
-        this.pendingRelayOffers.set(offer.shareId + ':' + offer.playerId, offer);
+        if (!isOwner && Number.isInteger(offer.routeVersion) && Number(offer.routeVersion) > 0) {
+          this.pendingRelayOffers.set(this.relayOfferKey(offer.shareId, offer.playerId, Number(offer.routeVersion)), offer);
+        }
         return;
       }
       if (isLegacyDirectOffer && share.requirePassword && offer.password !== share.password) {
@@ -1139,7 +1183,7 @@ class ScreenShareService {
 
       const sourceStream = isOwner ? this.localStream : this.remoteStreams.get(offer.shareId);
       if (!sourceStream || sourceStream.getVideoTracks().length === 0) {
-        this.pendingRelayOffers.set(offer.shareId + ':' + offer.playerId, offer);
+        this.pendingRelayOffers.set(this.relayOfferKey(offer.shareId, offer.playerId, offer.routeVersion), offer);
         return;
       }
 
@@ -1213,7 +1257,7 @@ class ScreenShareService {
         type: 'offer',
         sdp: offer.sdp,
       });
-      await this.flushPendingIce(connectionKey, pc);
+      await this.flushPendingIce(this.iceKey(offer.shareId, 'out', offer.playerId, offer.routeVersion), pc);
 
       // 创建Answer
       const answer = await pc.createAnswer();
@@ -1271,7 +1315,7 @@ class ScreenShareService {
         type: 'answer',
         sdp: answer.sdp,
       });
-      await this.flushPendingIce(connectionKey, foundPc);
+      await this.flushPendingIce(this.iceKey(answer.shareId, 'in', upstreamPlayerId, answer.routeVersion), foundPc);
 
       console.log('✅ [ScreenShareService] Answer已设置');
     } catch (error) {
@@ -1285,29 +1329,48 @@ class ScreenShareService {
    */
   async handleIceCandidate(shareId: string, candidate: RTCIceCandidateInit, remotePlayerId: string, connectionRole?: 'in' | 'out', routeVersion?: number): Promise<void> {
     try {
+      const share = this.activeShares.get(shareId);
+      if (!share || !remotePlayerId) return;
+      const normalizedRouteVersion = isNullish(routeVersion) ? undefined : Number(routeVersion);
+      if (!isNullish(normalizedRouteVersion) && (!Number.isInteger(normalizedRouteVersion) || normalizedRouteVersion <= 0)) return;
       const outboundKey = `${shareId}-out-${remotePlayerId}`;
       const inboundKey = `${shareId}-in-${remotePlayerId}`;
       const legacyViewerKey = Array.from(this.peerConnections.keys()).find((key) => key.startsWith(`${shareId}-viewer-`));
-      const connectionKey = connectionRole === 'in'
-        ? isNullish(routeVersion) && legacyViewerKey
-          ? legacyViewerKey
-          : inboundKey
-        : connectionRole === 'out'
-          ? outboundKey
-          : this.peerConnections.has(outboundKey)
-            ? outboundKey
-            : this.peerConnections.has(inboundKey)
-              ? inboundKey
-              : legacyViewerKey ?? inboundKey;
-      if (!isNullish(routeVersion)) {
-        if (connectionKey === inboundKey && this.viewingRouteVersions.get(shareId) !== routeVersion) return;
-        if (connectionKey === outboundKey && this.expectedDownstreams.get(shareId)?.get(remotePlayerId) !== routeVersion) return;
+      const isOwner = share.playerId === this.currentPlayerId;
+      let direction: 'in' | 'out';
+      if (connectionRole === 'in') {
+        // Upstream ICE is accepted only for the current owner-issued route.
+        // Before route creation, retain it by routeVersion for later flush.
+        if (isNullish(normalizedRouteVersion) && remotePlayerId !== share.playerId) return;
+        const currentRoute = this.viewingRouteVersions.get(shareId);
+        if (!isNullish(currentRoute) && normalizedRouteVersion !== currentRoute) return;
+        direction = 'in';
+      } else if (connectionRole === 'out') {
+        // Legacy no-route ICE is valid only on the owner's direct path.
+        if (isNullish(normalizedRouteVersion) && !isOwner) return;
+        const expectedRoute = this.expectedDownstreams.get(shareId)?.get(remotePlayerId);
+        if (!isNullish(expectedRoute) && normalizedRouteVersion !== expectedRoute) return;
+        direction = 'out';
+      } else if (this.peerConnections.has(outboundKey) || this.expectedDownstreams.get(shareId)?.has(remotePlayerId)) {
+        direction = 'out';
+      } else if (this.peerConnections.has(inboundKey) || remotePlayerId === this.viewingUpstreams.get(shareId) || remotePlayerId === share.playerId) {
+        direction = 'in';
+      } else if (legacyViewerKey) {
+        direction = 'in';
+      } else {
+        return;
       }
+      const connectionKey = direction === 'in' && isNullish(normalizedRouteVersion) && legacyViewerKey ? legacyViewerKey : direction === 'in' ? inboundKey : outboundKey;
+      const expectedRoute = direction === 'in'
+        ? this.viewingRouteVersions.get(shareId)
+        : this.expectedDownstreams.get(shareId)?.get(remotePlayerId);
+      if (!isNullish(expectedRoute) && normalizedRouteVersion !== expectedRoute) return;
       const pc = this.peerConnections.get(connectionKey);
       if (!pc || !pc.remoteDescription) {
-        const pending = this.pendingIceCandidates.get(connectionKey) ?? [];
+        const pendingKey = this.iceKey(shareId, direction, remotePlayerId, normalizedRouteVersion);
+        const pending = this.pendingIceCandidates.get(pendingKey) ?? [];
         pending.push(candidate);
-        this.pendingIceCandidates.set(connectionKey, pending);
+        this.pendingIceCandidates.set(pendingKey, pending);
         return;
       }
       await pc.addIceCandidate(new RTCIceCandidate(candidate));
@@ -1325,13 +1388,21 @@ class ScreenShareService {
     
     const share = this.activeShares.get(shareId);
     if (!share) return;
+    const isOwner = share.playerId === this.currentPlayerId;
+    const isKnownViewer = (this.viewerOrder.get(shareId) ?? []).includes(viewerId);
+    const isKnownDownstream = this.expectedDownstreams.get(shareId)?.has(viewerId) ?? false;
+    if ((isOwner && !isKnownViewer && viewerId !== this.currentPlayerId) || (!isOwner && !isKnownDownstream)) return;
     const outKey = `${shareId}-out-${viewerId}`;
     this.stopOutboundHealthHeartbeat(outKey);
     this.peerConnections.get(outKey)?.close();
     this.peerConnections.delete(outKey);
     this.expectedDownstreams.get(shareId)?.delete(viewerId);
+    for (const key of this.pendingRelayOffers.keys()) {
+      if (key.startsWith(`${shareId}:${viewerId}:`)) this.pendingRelayOffers.delete(key);
+    }
+    this.clearPendingIceForPeer(shareId, 'out', viewerId);
 
-    if (share.playerId === this.currentPlayerId) {
+    if (isOwner) {
       const order = this.viewerOrder.get(shareId) ?? [];
       const nextOrder = order.filter((id) => id !== viewerId);
       this.viewerOrder.set(shareId, nextOrder);
@@ -1355,7 +1426,7 @@ class ScreenShareService {
       if (this.viewingUpstreams.get(share.id) === playerId) {
         this.sendWebSocketMessage({
           type: 'screen-share-relay', action: 'failure', from: this.currentPlayerId, to: share.playerId,
-          shareId: share.id, upstreamId: playerId,
+          shareId: share.id, upstreamId: playerId, routeVersion: this.viewingRouteVersions.get(share.id),
         });
       }
       if (share.playerId === this.currentPlayerId || this.expectedDownstreams.get(share.id)?.has(playerId)) {
@@ -1367,20 +1438,35 @@ class ScreenShareService {
   /**
    * 处理共享状态更新
    */
-  handleShareUpdate(shareId: string, viewerId?: string, viewerName?: string, viewerCount?: number): void {
+  handleShareUpdate(shareId: string, viewerId?: string, viewerName?: string, viewerCount?: number, senderId?: string): void {
     const share = this.activeShares.get(shareId);
-    if (!share) return;
+    if (!share || (senderId !== undefined && share.playerId !== senderId)) return;
     share.viewerId = viewerId;
     share.viewerName = viewerName;
     share.viewerCount = viewerCount ?? (viewerId ? 1 : 0);
     this.activeShares.set(shareId, share);
   }
 
-  private async flushPendingIce(connectionKey: string, pc: RTCPeerConnection): Promise<void> {
-    const candidates = this.pendingIceCandidates.get(connectionKey) ?? [];
-    this.pendingIceCandidates.delete(connectionKey);
+  private async flushPendingIce(pendingKey: string, pc: RTCPeerConnection): Promise<void> {
+    const candidates = this.pendingIceCandidates.get(pendingKey) ?? [];
+    this.pendingIceCandidates.delete(pendingKey);
     for (const candidate of candidates) {
       await pc.addIceCandidate(new RTCIceCandidate(candidate));
+    }
+  }
+
+  private iceKey(shareId: string, direction: 'in' | 'out', peerId: string, routeVersion?: number): string {
+    return `${shareId}-${direction}-${peerId}-${isNullish(routeVersion) ? 'legacy' : routeVersion}`;
+  }
+
+  private relayOfferKey(shareId: string, peerId: string, routeVersion?: number): string {
+    return `${shareId}:${peerId}:${isNullish(routeVersion) ? 'legacy' : routeVersion}`;
+  }
+
+  private clearPendingIceForPeer(shareId: string, direction: 'in' | 'out', peerId: string): void {
+    const prefix = `${shareId}-${direction}-${peerId}-`;
+    for (const key of this.pendingIceCandidates.keys()) {
+      if (key.startsWith(prefix)) this.pendingIceCandidates.delete(key);
     }
   }
 

--- a/src/services/webrtc/WebRTCClient.ts
+++ b/src/services/webrtc/WebRTCClient.ts
@@ -353,6 +353,7 @@ export class WebRTCClient {
         this.websocket.onclose = () => {
           if (this.websocket !== socket) return;
           this.websocket = null;
+          this.resetRemoteControlOnSignalingDisconnect();
           if (this.websocketStableTimer !== null) {
             clearTimeout(this.websocketStableTimer);
             this.websocketStableTimer = null;
@@ -416,6 +417,7 @@ export class WebRTCClient {
       
       // 清理旧的WebSocket连接
       if (this.websocket) {
+        this.resetRemoteControlOnSignalingDisconnect();
         this.websocket.onopen = null;
         this.websocket.onmessage = null;
         this.websocket.onerror = null;
@@ -529,6 +531,7 @@ export class WebRTCClient {
     if (!this.knownPlayers.has(playerId)) return;
 
     this.clearPendingPlayerLeave(playerId);
+    this.resetRemoteControlForPeer(playerId);
     try {
       const { audioService } = await import('../audio/AudioService');
       await audioService.play('userLeft');
@@ -573,6 +576,18 @@ export class WebRTCClient {
     const rtcError = (error as { error?: { message?: string } }).error;
     const message = rtcError?.message || '';
     return message.includes('User-Initiated Abort') || message.includes('on-close called');
+  }
+
+  private resetRemoteControlOnSignalingDisconnect(): void {
+    void import('../remoteControl/RemoteControlService')
+      .then(({ remoteControlService }) => remoteControlService.handleSignalingDisconnected())
+      .catch((error) => console.error('清理信令断线后的远程控制会话失败:', error));
+  }
+
+  private resetRemoteControlForPeer(peerId: string): void {
+    void import('../remoteControl/RemoteControlService')
+      .then(({ remoteControlService }) => remoteControlService.handlePeerLeft(peerId))
+      .catch((error) => console.error(`清理离线玩家 ${peerId} 的远程控制会话失败:`, error));
   }
 
   /**
@@ -898,6 +913,8 @@ export class WebRTCClient {
             break;
           }
 
+          this.resetRemoteControlForPeer(message.playerId);
+
           if (this.schedulePlayerLeaveConfirmation(message.playerId)) {
             break;
           }
@@ -1090,6 +1107,14 @@ export class WebRTCClient {
         case 'screen-share-error':
           // 收到屏幕共享错误（例如密码错误）
           console.log(`❌ 收到屏幕共享错误: ${message.error}`);
+          if (message.to !== this.localPlayerId || typeof message.from !== 'string' || typeof message.shareId !== 'string') {
+            break;
+          }
+          {
+            const { screenShareService } = await import('../screenShare/ScreenShareService');
+            const share = screenShareService.getActiveShares().find((item) => item.id === message.shareId);
+            if (!share || share.playerId !== message.from) break;
+          }
           // 这里可以通过事件通知前端显示错误
           window.dispatchEvent(new CustomEvent('screen-share-error', { 
             detail: { 
@@ -1104,8 +1129,9 @@ export class WebRTCClient {
           console.log(`🖥️ 收到屏幕共享停止通知, shareId: ${message.shareId}`);
           try {
             const { screenShareService } = await import('../screenShare/ScreenShareService');
-            // 从本地列表移除
-            (screenShareService as any).activeShares.delete(message.shareId);
+            if (typeof message.from !== 'string' || typeof message.shareId !== 'string' || !screenShareService.handleShareStop(message.shareId, message.from)) {
+              break;
+            }
             console.log(`✅ 屏幕共享已从列表移除`);
             
             // 【事件驱动】触发自定义事件通知UI更新
@@ -1122,6 +1148,7 @@ export class WebRTCClient {
         case 'screen-share-offer':
           // 收到屏幕共享Offer
           console.log(`🖥️ 收到屏幕共享Offer from ${message.from}, playerName: ${message.playerName}`);
+          if (message.to !== this.localPlayerId || typeof message.from !== 'string' || typeof message.shareId !== 'string' || !message.offer?.sdp) break;
           try {
             const { screenShareService } = await import('../screenShare/ScreenShareService');
             await screenShareService.handleOffer({
@@ -1140,6 +1167,7 @@ export class WebRTCClient {
           break;
           
         case 'screen-share-answer':
+          if (message.to !== this.localPlayerId || typeof message.from !== 'string' || typeof message.shareId !== 'string' || !message.answer?.sdp) break;
           // 收到屏幕共享Answer
           console.log(`🖥️ 收到屏幕共享Answer from ${message.from}`);
           try {
@@ -1156,6 +1184,7 @@ export class WebRTCClient {
           break;
           
         case 'screen-share-ice-candidate':
+          if (message.to !== this.localPlayerId || typeof message.from !== 'string' || typeof message.shareId !== 'string' || !message.candidate) break;
           // 收到屏幕共享ICE候选
           console.log(`🖥️ 收到屏幕共享ICE候选 from ${message.from}`);
           try {
@@ -1179,6 +1208,7 @@ export class WebRTCClient {
         case 'screen-share-viewer-left':
           // 收到查看者离开通知
           console.log(`👋 收到查看者离开通知, shareId: ${message.shareId}, from: ${message.from}`);
+          if (typeof message.from !== 'string' || typeof message.shareId !== 'string') break;
           try {
             const { screenShareService } = await import('../screenShare/ScreenShareService');
             screenShareService.handleViewerLeft(message.shareId, message.from);
@@ -1271,7 +1301,7 @@ export class WebRTCClient {
               share.viewerName = message.viewerName;
               share.viewerCount = message.viewerCount ?? (message.viewerId ? 1 : 0);
               (screenShareService as any).activeShares.set(message.shareId, share);
-              screenShareService.handleShareUpdate(message.shareId, message.viewerId, message.viewerName, message.viewerCount);
+               screenShareService.handleShareUpdate(message.shareId, message.viewerId, message.viewerName, message.viewerCount, message.from);
               console.log(`✅ 共享状态已更新:`, { viewerId: message.viewerId, viewerName: message.viewerName });
               
               // 【事件驱动】触发自定义事件通知UI更新
@@ -1297,28 +1327,34 @@ export class WebRTCClient {
         case 'remote-control-ice':
         case 'remote-control-stop':
           try {
+            if (typeof message.from !== 'string' || typeof message.to !== 'string' || message.to !== this.localPlayerId) {
+              break;
+            }
             const { remoteControlService } = await import('../remoteControl/RemoteControlService');
             switch (message.type) {
               case 'remote-control-request':
-                remoteControlService.handleRequest(message.sessionId, message.from, message.fromName || '玩家');
+                remoteControlService.handleRequest(message.sessionId, message.from, message.fromName || '玩家', message.to);
                 break;
               case 'remote-control-accept':
-                await remoteControlService.handleAccept(message.sessionId);
+                await remoteControlService.handleAccept(message.sessionId, message.from, message.to);
                 break;
               case 'remote-control-reject':
-                remoteControlService.handleReject(message.reason || 'rejected');
+                remoteControlService.handleReject(message.sessionId, message.from, message.to, message.reason || 'rejected');
                 break;
               case 'remote-control-offer':
-                await remoteControlService.handleOffer(message.sessionId, message.offer.sdp);
+                if (!message.offer || typeof message.offer.sdp !== 'string') break;
+                await remoteControlService.handleOffer(message.sessionId, message.from, message.to, message.offer.sdp);
                 break;
               case 'remote-control-answer':
-                await remoteControlService.handleAnswer(message.sessionId, message.answer.sdp);
+                if (!message.answer || typeof message.answer.sdp !== 'string') break;
+                await remoteControlService.handleAnswer(message.sessionId, message.from, message.to, message.answer.sdp);
                 break;
               case 'remote-control-ice':
-                await remoteControlService.handleIce(message.candidate);
+                if (!message.candidate || typeof message.candidate.candidate !== 'string') break;
+                await remoteControlService.handleIce(message.sessionId, message.from, message.to, message.candidate);
                 break;
               case 'remote-control-stop':
-                remoteControlService.handleStop();
+                remoteControlService.handleStop(message.sessionId, message.from, message.to);
                 break;
             }
           } catch (error) {
@@ -3053,6 +3089,13 @@ export class WebRTCClient {
       
       // 标记为主动断开，防止自动重连
       this.isIntentionalDisconnect = true;
+
+      try {
+        const { remoteControlService } = await import('../remoteControl/RemoteControlService');
+        remoteControlService.handleSignalingDisconnected();
+      } catch (error) {
+        console.error('清理远程控制会话失败:', error);
+      }
       
       // 清理重连定时器
       if (this.reconnectTimeout) {
@@ -3202,6 +3245,3 @@ export class WebRTCClient {
 
 // 导出单例实例
 export const webrtcClient = new WebRTCClient();
-
-
-

--- a/tests/remote-control-service.test.mjs
+++ b/tests/remote-control-service.test.mjs
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const sourceFile = fileURLToPath(new URL('../src/services/remoteControl/RemoteControlService.ts', import.meta.url));
+const serviceSource = fs.readFileSync(sourceFile, 'utf8');
+const androidRepository = fs.readFileSync(new URL('../MCTier-Android/app/src/main/java/top/pmh13/mctier/MctierRepository.kt', import.meta.url), 'utf8');
+let moduleVersion = 0;
+
+async function loadService() {
+  const result = await build({
+    entryPoints: [sourceFile],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    write: false,
+    plugins: [{
+      name: 'tauri-core-stub',
+      setup(pluginBuild) {
+        pluginBuild.onResolve({ filter: /^@tauri-apps\/api\/core$/ }, () => ({ path: 'tauri-core', namespace: 'stub' }));
+        pluginBuild.onLoad({ filter: /.*/, namespace: 'stub' }, () => ({
+          contents: 'export const invoke = async () => undefined;',
+          loader: 'js',
+        }));
+      },
+    }],
+  });
+  const version = ++moduleVersion;
+  return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(result.outputFiles[0].text)}#test-${version}`);
+}
+
+function installBrowserMocks({ capture, randomUUID = () => 'test-uuid', peerConnections = [] } = {}) {
+  const events = [];
+  const sent = [];
+  const captureFn = capture || (async () => ({ getVideoTracks: () => [], getTracks: () => [] }));
+  Object.defineProperty(globalThis, 'WebSocket', {
+    configurable: true,
+    value: class MockWebSocket {},
+  });
+  globalThis.WebSocket.OPEN = 1;
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      setTimeout,
+      clearTimeout,
+      setInterval,
+      clearInterval,
+      dispatchEvent(event) { events.push(event); },
+    },
+  });
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { mediaDevices: { getDisplayMedia: (...args) => captureFn(...args) } },
+  });
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    value: { randomUUID },
+  });
+  if (peerConnections) {
+    Object.defineProperty(globalThis, 'RTCPeerConnection', {
+      configurable: true,
+      value: class MockPeerConnection {
+        constructor() {
+          this.connectionState = 'new';
+          this.signalingState = 'stable';
+          this.remoteDescription = null;
+          peerConnections.push(this);
+        }
+
+        createDataChannel() {
+          return {
+            readyState: 'connecting',
+            send() {},
+            close() { this.readyState = 'closed'; },
+          };
+        }
+
+        addTransceiver() {}
+
+        async createOffer() {
+          return { type: 'offer', sdp: `offer-${peerConnections.length}` };
+        }
+
+        async setLocalDescription(description) {
+          this.localDescription = description;
+          this.signalingState = 'have-local-offer';
+        }
+
+        close() {
+          this.connectionState = 'closed';
+        }
+      },
+    });
+  }
+  return {
+    events,
+    sent,
+    websocket: {
+      readyState: globalThis.WebSocket.OPEN,
+      send(raw) { sent.push(JSON.parse(raw)); },
+    },
+  };
+}
+
+test('capture denial rolls back and allows a later request', async () => {
+  const tracks = [{ contentHint: '', onended: null, stopped: false, stop() { this.stopped = true; } }];
+  let capture = async () => { throw new Error('permission denied'); };
+  const mocks = installBrowserMocks({ capture: (...args) => capture(...args) });
+  const { remoteControlService } = await loadService();
+  remoteControlService.initialize('local', 'Local', mocks.websocket);
+
+  remoteControlService.handleRequest('sid-1', 'controller', 'Controller', 'local');
+  await assert.rejects(
+    remoteControlService.acceptControl('sid-1', 'controller', 'Controller'),
+    /permission denied/,
+  );
+  assert.equal(remoteControlService.getRole(), 'idle');
+  assert.deepEqual(mocks.sent.at(-1), {
+    type: 'remote-control-reject',
+    from: 'local',
+    to: 'controller',
+    sessionId: 'sid-1',
+    reason: 'capture-failed',
+  });
+
+  capture = async () => ({ getVideoTracks: () => tracks, getTracks: () => tracks });
+  remoteControlService.handleRequest('sid-2', 'controller', 'Controller', 'local');
+  await remoteControlService.acceptControl('sid-2', 'controller', 'Controller');
+  assert.equal(remoteControlService.getRole(), 'controlled');
+  assert.equal(mocks.sent.at(-1).type, 'remote-control-accept');
+  assert.equal(mocks.sent.at(-1).sessionId, 'sid-2');
+  remoteControlService.stopControl(false);
+  assert.equal(remoteControlService.getRole(), 'idle');
+  assert.equal(mocks.events.filter((event) => event.type === 'rc-incoming-request').length, 2);
+});
+
+test('pending request stop invalidates delayed accept', async () => {
+  const mocks = installBrowserMocks();
+  const { remoteControlService } = await loadService();
+  remoteControlService.initialize('local', 'Local', mocks.websocket);
+
+  remoteControlService.handleRequest('sid-stop', 'controller', 'Controller', 'local');
+  remoteControlService.handleStop('sid-stop', 'controller', 'local');
+  await assert.rejects(
+    remoteControlService.acceptControl('sid-stop', 'controller', 'Controller'),
+    /请求已失效/,
+  );
+  assert.equal(remoteControlService.getRole(), 'idle');
+  assert.equal(mocks.sent.length, 0);
+});
+
+test('old PC callbacks cannot stop or signal a second session', async () => {
+  const peerConnections = [];
+  const uuids = ['session-one', 'session-two'];
+  const mocks = installBrowserMocks({ randomUUID: () => uuids.shift(), peerConnections });
+  const { remoteControlService } = await loadService();
+  remoteControlService.initialize('local', 'Local', mocks.websocket);
+
+  remoteControlService.requestControl('peer', 'Peer');
+  const firstSession = mocks.sent.at(-1).sessionId;
+  await remoteControlService.handleAccept(firstSession, 'peer', 'local');
+  const firstPc = peerConnections[0];
+  const staleConnectionState = firstPc.onconnectionstatechange;
+  const staleIce = firstPc.onicecandidate;
+  remoteControlService.stopControl(false);
+
+  remoteControlService.requestControl('peer', 'Peer');
+  const secondSession = mocks.sent.at(-1).sessionId;
+  await remoteControlService.handleAccept(secondSession, 'peer', 'local');
+  const sentBeforeStaleCallbacks = mocks.sent.length;
+
+  firstPc.connectionState = 'failed';
+  staleConnectionState();
+  staleIce({ candidate: { candidate: 'stale', sdpMLineIndex: 0, sdpMid: '0' } });
+
+  assert.equal(remoteControlService.getRole(), 'controller');
+  assert.equal(mocks.sent.length, sentBeforeStaleCallbacks);
+  assert.equal(mocks.sent.at(-1).sessionId, secondSession);
+});
+
+test('randomUUID failure leaves request state idle', async () => {
+  const mocks = installBrowserMocks({ randomUUID: () => { throw new Error('uuid unavailable'); } });
+  const { remoteControlService } = await loadService();
+  remoteControlService.initialize('local', 'Local', mocks.websocket);
+
+  assert.throws(() => remoteControlService.requestControl('peer', 'Peer'), /uuid unavailable/);
+  assert.equal(remoteControlService.getRole(), 'idle');
+  assert.equal(remoteControlService.isActive(), false);
+  assert.equal(mocks.sent.length, 0);
+});
+
+test('request timeout notifies the pending peer before local cleanup', () => {
+  const timerBlock = serviceSource.slice(
+    serviceSource.indexOf('this.requestTimer = window.setTimeout'),
+    serviceSource.indexOf('// ==================== 被控端'),
+  );
+  assert.match(timerBlock, /type: 'remote-control-stop'/);
+  assert.match(timerBlock, /sessionId: nextSessionId/);
+  assert.ok(timerBlock.indexOf("type: 'remote-control-stop'") < timerBlock.indexOf("this.finishReject('timeout')"));
+});
+
+test('Android delayed accept is invalidated across lobby lifecycle changes', () => {
+  const acceptBlock = androidRepository.slice(
+    androidRepository.indexOf('fun acceptRemoteControl'),
+    androidRepository.indexOf('/** 停止被远程控制'),
+  );
+  assert.match(androidRepository, /private var remoteControlAcceptJob: Job\? = null/);
+  assert.match(androidRepository, /private var remoteControlAcceptGeneration = 0L/);
+  assert.match(androidRepository, /private fun invalidatePendingRemoteControlAccept\(\)/);
+  assert.match(acceptBlock, /val generation = \+\+remoteControlAcceptGeneration/);
+  assert.match(acceptBlock, /generation != remoteControlAcceptGeneration/);
+  assert.match(acceptBlock, /pendingRcRequest != req/);
+  assert.match(acceptBlock, /_state\.value\.state != AppConnectionState\.InLobby/);
+  const leaveBlock = androidRepository.slice(androidRepository.indexOf('fun leaveLobby'), androidRepository.indexOf('fun reloadLobby'));
+  assert.match(leaveBlock, /invalidatePendingRemoteControlAccept\(\)/);
+});

--- a/tests/screen-share-auth.test.mjs
+++ b/tests/screen-share-auth.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const desktop = fs.readFileSync(new URL('../src/services/screenShare/ScreenShareService.ts', import.meta.url), 'utf8');
+const androidController = fs.readFileSync(new URL('../MCTier-Android/app/src/main/java/top/pmh13/mctier/network/ScreenShareController.kt', import.meta.url), 'utf8');
+const androidRepository = fs.readFileSync(new URL('../MCTier-Android/app/src/main/java/top/pmh13/mctier/MctierRepository.kt', import.meta.url), 'utf8');
+
+test('relay viewers cannot use a legacy or unassigned offer', () => {
+  const desktopOffer = desktop.slice(desktop.indexOf('async handleOffer'), desktop.indexOf('async handleAnswer'));
+  const mismatch = desktopOffer.slice(
+    desktopOffer.indexOf('if (!isLegacyDirectOffer && (isNullish(expectedVersion)'),
+    desktopOffer.indexOf('if (isLegacyDirectOffer && share.requirePassword'),
+  );
+  const androidOffer = androidController.slice(
+    androidController.indexOf('private fun handleViewerOffer'),
+    androidController.indexOf('private fun processPendingOffers'),
+  );
+
+  assert.match(desktopOffer, /if \(!isOwner && isNullish\(offer\.routeVersion\)\) return;/);
+  assert.match(mismatch, /return;/);
+  assert.match(mismatch, /pendingRelayOffers\.set\(this\.relayOfferKey\(/);
+  assert.match(androidOffer, /if \(!isOwner && message\.routeVersion == null\) return/);
+});
+
+test('ICE buffering is partitioned by direction, peer, and route version', () => {
+  assert.match(desktop, /private iceKey\(shareId: string, direction: 'in' \| 'out', peerId: string, routeVersion\?: number\)/);
+  assert.match(androidController, /private fun iceKey\(shareId: String, direction: String, playerId: String, routeVersion: Int\?\)/);
+  assert.match(desktop, /flushPendingIce\(this\.iceKey\(offer\.shareId, 'out', offer\.playerId, offer\.routeVersion\), pc\)/);
+  assert.match(androidController, /flushPendingIce\(iceKey\(shareId, "out", from, message\.routeVersion\), pc\)/);
+});
+
+test('Android capture announcement is gated on capture success and stop callback', () => {
+  assert.match(androidController, /fun startSharing\(shareId: String, permissionData: Intent, password: String\? = null\): Boolean/);
+  assert.match(androidController, /onCaptureStopped\?\.invoke\(shareId\)/);
+  assert.match(androidRepository, /val started = screenController\?\.startSharing\(shareId, data, password\) == true/);
+  assert.match(androidRepository, /announcedScreenShares \+= shareId/);
+});
+
+test('Android delayed capture starts are invalidated across lifecycle changes', () => {
+  const startBlock = androidRepository.slice(
+    androidRepository.indexOf('fun startScreenCapture'),
+    androidRepository.indexOf('fun stopScreenCapture'),
+  );
+  assert.match(androidRepository, /private var screenCaptureStartJob: Job\? = null/);
+  assert.match(androidRepository, /private var screenCaptureGeneration = 0L/);
+  assert.match(androidRepository, /private fun invalidatePendingScreenCapture\(\)/);
+  assert.match(androidRepository, /private fun isCurrentScreenCaptureStart\(/);
+  assert.match(startBlock, /invalidatePendingScreenCapture\(\)/);
+  assert.match(startBlock, /val generation = screenCaptureGeneration/);
+  assert.match(startBlock, /if \(!isCurrentScreenCaptureStart\(generation, shareId, playerId\)\) return@launch/);
+  assert.equal((startBlock.match(/isCurrentScreenCaptureStart\(generation, shareId, playerId\)/g) ?? []).length, 3);
+  assert.match(startBlock, /if \(screenCaptureGeneration == generation\) screenCaptureStartJob = null/);
+  assert.match(androidRepository.slice(androidRepository.indexOf('fun leaveLobby'), androidRepository.indexOf('fun reloadLobby')), /invalidatePendingScreenCapture\(\)/);
+  assert.match(androidRepository.slice(androidRepository.indexOf('private fun handleLocalCaptureStopped'), androidRepository.indexOf('/** 开始共享自己的屏幕')), /invalidatePendingScreenCapture\(\)/);
+  assert.match(androidRepository.slice(androidRepository.indexOf('fun stopScreenCapture'), androidRepository.indexOf('// ========================= 远程控制')), /invalidatePendingScreenCapture\(\)/);
+});
+
+test('Android rejects a required screen-share password before mutating capture state', () => {
+  const startBlock = androidRepository.slice(
+    androidRepository.indexOf('fun startScreenCapture'),
+    androidRepository.indexOf('fun stopScreenCapture'),
+  );
+  assert.match(startBlock, /if \(requirePassword && password\?\.trim\(\)\.isNullOrEmpty\(\)\)/);
+  assert.match(startBlock, /error = L\("请设置屏幕共享密码", "Set a screen sharing password"\)/);
+  assert.ok(startBlock.indexOf('password?.trim().isNullOrEmpty()') < startBlock.indexOf('invalidatePendingScreenCapture()'));
+  assert.doesNotMatch(startBlock.slice(0, startBlock.indexOf('invalidatePendingScreenCapture()')), /screen-share-start/);
+});
+
+test('Relay offers are keyed and resumed by their exact route version', () => {
+  assert.match(desktop, /private relayOfferKey\(shareId: string, peerId: string, routeVersion\?: number\)/);
+  assert.match(androidController, /private fun relayOfferKey\(shareId: String, playerId: String, routeVersion: Int\?\)/);
+  assert.match(desktop, /this\.pendingRelayOffers\.set\(this\.relayOfferKey\(offer\.shareId, offer\.playerId, Number\(offer\.routeVersion\)\), offer\)/);
+  assert.match(androidController, /pendingOffers\[relayOfferKey\(shareId, from, message\.routeVersion\)\] = message/);
+  assert.match(desktop, /const pendingKey = this\.relayOfferKey\(shareId, message\.downstreamId, routeVersion\)/);
+  assert.match(androidController, /pendingOffers\.remove\(relayOfferKey\(shareId, downstreamId, version\)\)/);
+  assert.match(desktop, /for \(const \[downstreamId, expectedVersion\] of expected\.entries\(\)\)/);
+  assert.match(androidController, /expectedDownstreams\[peerKey\(shareId, from\)\] == message\.routeVersion/);
+});
+
+test('Desktop child assignments ignore older route versions', () => {
+  const childBlock = desktop.slice(desktop.indexOf("message.action === 'child'"), desktop.indexOf("message.action === 'detach'", desktop.indexOf("message.action === 'child'")));
+  assert.match(childBlock, /const previousVersion = expected\.get\(message\.downstreamId\)/);
+  assert.match(childBlock, /if \(!isNullish\(previousVersion\) && routeVersion < previousVersion\) return;/);
+});
+
+test('Desktop owner accepts relay failure only for the assigned edge and version', () => {
+  const failureBlock = desktop.slice(desktop.indexOf("message.action === 'failure'"), desktop.indexOf("// The failed edge is removed", desktop.indexOf("message.action === 'failure'")));
+  assert.match(failureBlock, /if \(isNullish\(message\.upstreamId\) \|\| isNullish\(message\.routeVersion\)\) return;/);
+  assert.match(failureBlock, /if \(!assignedUpstream \|\| message\.upstreamId !== assignedUpstream\) return;/);
+  assert.match(failureBlock, /if \(isNullish\(assignedVersion\) \|\| Number\(message\.routeVersion\) !== assignedVersion\) return;/);
+});
+
+test('required screen-share passwords cannot be empty on either platform', () => {
+  const desktopStart = desktop.slice(desktop.indexOf('async startSharing'), desktop.indexOf('async stopSharing'));
+  const androidAnnounce = androidRepository.slice(androidRepository.indexOf('fun announceScreenShare'), androidRepository.indexOf('// ========================= 文件夹共享'));
+  assert.match(desktopStart, /if \(requirePassword && !password\?\.trim\(\)\)/);
+  assert.ok(desktopStart.indexOf('!password?.trim()') < desktopStart.indexOf('getDisplayMedia'));
+  assert.match(androidAnnounce, /if \(requirePassword && password\?\.trim\(\)\.isNullOrEmpty\(\)\)/);
+});
+
+test('direct fallback failure identifies the previously assigned upstream', () => {
+  const desktopFallback = desktop.slice(desktop.indexOf('const previousUpstream = this.viewingUpstreams.get'), desktop.indexOf('pending.resolve(stream)'));
+  const androidFallback = androidController.slice(androidController.indexOf('if (requestedVersion == null && effectiveReadyVersion != null'), androidController.indexOf('processPendingOffers(shareId)'));
+  assert.match(desktopFallback, /upstreamId: previousUpstream/);
+  assert.match(androidFallback, /previousUpstream != null/);
+  assert.match(androidFallback, /upstreamId = previousUpstream/);
+});


### PR DESCRIPTION
## 问题

远程控制和屏幕共享信令此前主要依赖消息体中的 `from/to/sessionId/shareId`，客户端状态机没有完整绑定当前授权会话。同大厅攻击者可伪造 stop/reject/offer/answer/ICE，干扰或劫持已批准的远控；旧 PeerConnection/ICE 回调还能污染后续会话。屏幕共享的 relay 控制面也允许伪造 stop/viewer-left/update/failure，存在密码绕过、路由回退和多跳竞态。

## 修复

### 远程控制

- 会话 ID 使用 `crypto.randomUUID()` / UUID，并绑定 `sessionId + from + to + role + PeerConnection`
- pending 请求只能被对应控制方接受/拒绝/停止
- 所有 SDP、ICE、DataChannel、track 和连接状态回调校验当前 session/peer/PC identity
- 旧 PC 与旧 ICE 不再影响第二会话
- 录屏授权拒绝、MediaProjection 停止、peer-left、信令断线和请求超时统一清理
- Android 延迟 accept 使用 generation/job，离开大厅或请求失效后不会复活

### 屏幕共享

- stop、viewer-left、update、relay 控制、offer/answer/ICE 绑定 owner/viewer/share/from/to/routeVersion
- relay viewer 无 owner 分配 route 时不能接收 offer，防止绕过共享密码
- route-before-child 的合法 Offer 与乱序 ICE 按精确 routeVersion 暂存并恢复
- child routeVersion 单调，旧控制消息不能回退拓扑
- failure 必须精确匹配已分配 edge/version；direct fallback 携带原 upstream
- 要求密码时拒绝空密码
- Android 仅采集成功后广播共享开始，MediaProjection 停止和延迟启动均有生命周期失效保护

## 验证

- `npm test`：16 passed
- `npm run build`：通过
- `git diff --check`：通过
- Android Gradle 编译未运行成功：本机 NDK `27.0.12077973` 安装不完整，缺少 `source.properties`；未为测试修改项目构建配置

测试覆盖录屏拒绝回滚、pending stop、旧 PC 回调隔离、UUID 失败、远控超时通知、Android 延迟 accept、relay 无 route 拒绝、ICE 分桶、capture 门控、route-before-child、版本单调、failure edge 校验、空密码门控和 direct fallback 字段一致性。