### PR TITLE
fix(security): harden cross-platform trust boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,12 @@ jobs:
     name: Frontend (lint / typecheck / test)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      # Pin third-party actions to immutable commits; release tags are mutable.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           # 需要 Node 22+：`node --test tests/*.test.mjs` 依赖 Node 自身的 glob 展开
           # （cmd.exe 不做展开），Node 20 会报 "Could not find 'tests\*.test.mjs'"。
@@ -51,13 +54,15 @@ jobs:
     name: Rust (fmt / clippy / check)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
         with:
           workspaces: src-tauri
 
@@ -87,14 +92,16 @@ jobs:
     name: Android (assembleDebug)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: 17
 
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Assemble debug APK
         working-directory: MCTier-Android
@@ -104,7 +111,9 @@ jobs:
     name: License compliance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Verify third-party notice files exist
         run: |
@@ -133,12 +142,16 @@ jobs:
     name: Rust dependency audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Install cargo-audit and cargo-deny
-        run: cargo install cargo-audit cargo-deny --locked
+        run: |
+          cargo install cargo-audit --version 0.22.2 --locked
+          cargo install cargo-deny --version 0.20.2 --locked
 
       - name: cargo audit
         working-directory: src-tauri

--- a/MCTier-Android/app/src/main/AndroidManifest.xml
+++ b/MCTier-Android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
@@ -21,6 +21,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="false"
         android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.MCTier">
         <activity
@@ -52,7 +53,7 @@
         <service
             android:name="com.easytier.jni.EasyTierVpnService"
             android:exported="false"
-            android:foregroundServiceType="dataSync"
+            android:foregroundServiceType="systemExempted"
             android:permission="android.permission.BIND_VPN_SERVICE">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
@@ -73,7 +74,7 @@
         <!-- 无障碍服务：用于"电脑远程控制手机"时注入触摸手势（需用户在系统设置中开启） -->
         <service
             android:name=".service.MctierAccessibilityService"
-            android:exported="false"
+            android:exported="true"
             android:label="MCTier 远程控制"
             android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
             <intent-filter>
@@ -84,14 +85,5 @@
                 android:resource="@xml/accessibility_service_config" />
         </service>
 
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths" />
-        </provider>
     </application>
 </manifest>

--- a/MCTier-Android/app/src/main/java/com/easytier/jni/EasyTierVpnService.kt
+++ b/MCTier-Android/app/src/main/java/com/easytier/jni/EasyTierVpnService.kt
@@ -5,6 +5,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.net.VpnService
 import android.os.Build
 import android.os.ParcelFileDescriptor
@@ -53,13 +54,24 @@ class EasyTierVpnService : VpnService() {
             stopSelf()
             return START_NOT_STICKY
         }
+        val ipv4Address = intent?.getStringExtra(EXTRA_IPV4)
+        val routes = intent?.getStringArrayListExtra(EXTRA_ROUTES)
+        val instanceName = intent?.getStringExtra(EXTRA_INSTANCE)
+        if (ipv4Address == null || routes.isNullOrEmpty() || routes.size > MAX_ROUTE_COUNT ||
+            instanceName == null || !INSTANCE_NAME_PATTERN.matches(instanceName) ||
+            !isValidCidr(ipv4Address) || routes.any { !isValidCidr(it) }
+        ) {
+            Log.w(TAG, "Rejecting invalid VPN start request")
+            stopSelfResult(startId)
+            return START_NOT_STICKY
+        }
         // 前台服务保活：常驻通知，避免系统在后台杀掉组网
-        startAsForeground()
+        if (!startAsForeground()) {
+            stopSelfResult(startId)
+            return START_NOT_STICKY
+        }
         acquireLocks()
-        val ipv4Address = intent?.getStringExtra(EXTRA_IPV4) ?: return START_STICKY
-        val routes = intent.getStringArrayListExtra(EXTRA_ROUTES) ?: arrayListOf("10.0.0.0/8")
-        val instanceName = intent.getStringExtra(EXTRA_INSTANCE) ?: return START_STICKY
-        val magicDns = intent.getBooleanExtra(EXTRA_MAGIC_DNS, false)
+        val magicDns = intent?.getBooleanExtra(EXTRA_MAGIC_DNS, false) == true
 
         thread(name = "mctier-easytier-vpn") {
             runCatching {
@@ -72,7 +84,7 @@ class EasyTierVpnService : VpnService() {
         return START_STICKY
     }
 
-    private fun startAsForeground() {
+    private fun startAsForeground(): Boolean = runCatching {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val mgr = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             if (mgr.getNotificationChannel(CHANNEL_ID) == null) {
@@ -87,8 +99,14 @@ class EasyTierVpnService : VpnService() {
             .setSmallIcon(android.R.drawable.stat_sys_data_bluetooth)
             .setOngoing(true)
             .build()
-        runCatching { startForeground(NOTIFICATION_ID, notification) }
-    }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED)
+        } else {
+            // systemExempted was introduced in Android 14. Use the legacy overload on
+            // older releases rather than passing an unknown foreground-service bit.
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }.onFailure { Log.e(TAG, "Failed to start VPN foreground service", it) }.isSuccess
 
     override fun onDestroy() {
         running = false
@@ -117,12 +135,8 @@ class EasyTierVpnService : VpnService() {
             .addDnsServer("114.114.114.114")
 
         routes.forEach { cidr ->
-            runCatching {
-                val (routeIp, routePrefix) = parseCidr(cidr)
-                builder.addRoute(routeIp, routePrefix)
-            }.onFailure {
-                Log.w(TAG, "Skip invalid route $cidr", it)
-            }
+            val (routeIp, routePrefix) = parseCidr(cidr)
+            builder.addRoute(routeIp, routePrefix)
         }
 
         vpnInterface = builder.establish() ?: error("VpnService.Builder.establish returned null")
@@ -139,15 +153,25 @@ class EasyTierVpnService : VpnService() {
     }
 
     private fun parseCidr(value: String): Pair<String, Int> {
-        val parts = value.split("/")
+        val parts = value.trim().split("/", limit = 2)
         require(parts.size == 2) { "Invalid CIDR: $value" }
-        return parts[0] to parts[1].toInt()
+        val octets = parts[0].split('.')
+        require(octets.size == 4 && octets.all { it.isNotEmpty() && (it.toIntOrNull() ?: -1) in 0..255 }) {
+            "Invalid IPv4 address: ${parts[0]}"
+        }
+        val prefix = parts[1].toIntOrNull() ?: error("Invalid CIDR prefix: ${parts[1]}")
+        require(prefix in 1..32) { "Invalid CIDR prefix: $prefix" }
+        return octets.joinToString(".") to prefix
     }
+
+    private fun isValidCidr(value: String): Boolean = runCatching { parseCidr(value) }.isSuccess
 
     companion object {
         private const val TAG = "MCTierEasyTierVpn"
         private const val CHANNEL_ID = "mctier_vpn_keepalive"
         private const val NOTIFICATION_ID = 4541
+        private const val MAX_ROUTE_COUNT = 32
+        private val INSTANCE_NAME_PATTERN = Regex("[A-Za-z0-9_.-]{1,128}")
         const val EXTRA_IPV4 = "ipv4_address"
         const val EXTRA_ROUTES = "proxy_cidrs"
         const val EXTRA_INSTANCE = "instance_name"

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/MainActivity.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/MainActivity.kt
@@ -70,16 +70,34 @@ class MainActivity : ComponentActivity() {
     /** 解析邀请链接并预填加入表单（仅填表，不自动连接；非法参数安全忽略） */
     private fun handleDeepLink(intent: Intent?) {
         val data = intent?.data ?: return
-        if (data.scheme != "mctier") return
-        runCatching {
-            LobbyInviteCodec.parse(data.toString())?.let { invite ->
-                MctierRepository.get(applicationContext).applyDeepLink(
-                    invite.name,
-                    invite.password,
-                    invite.serverNode,
-                    invite.signalingServer,
-                )
+        try {
+            // Only browser VIEW intents for the exact registered host are accepted.  Keeping
+            // this check at the exported activity boundary prevents arbitrary callers from
+            // smuggling config values through an explicit Intent.
+            if (intent?.action != Intent.ACTION_VIEW ||
+                !data.scheme.equals("mctier", ignoreCase = true) ||
+                !data.host.equals("join", ignoreCase = true) ||
+                data.path.orEmpty() !in setOf("", "/") ||
+                data.fragment != null ||
+                data.toString().length > 4096
+            ) return
+
+            runCatching { LobbyInviteCodec.parse(data.toString()) }.getOrNull()?.let { invite ->
+                val name = invite.name.trim()
+                val password = invite.password.trim()
+                val node = invite.serverNode?.trim()
+                val signaling = invite.signalingServer?.trim()
+                if (!LobbyInviteCodec.isValidLobbyName(name) ||
+                    !LobbyInviteCodec.isValidLobbyPassword(password) ||
+                    (node != null && !LobbyInviteCodec.isValidEasyTierNode(node)) ||
+                    (signaling != null && !LobbyInviteCodec.isValidSignalingServer(signaling))
+                ) return@let
+                MctierRepository.get(applicationContext).applyDeepLink(name, password, node, signaling)
             }
+        } finally {
+            // The URI contains the lobby password.  Do not retain it in the Activity's
+            // launch Intent or process it again after a configuration change.
+            intent?.let { if (it.data == data) it.data = null }
         }
     }
 }

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/MctierRepository.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/MctierRepository.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import top.pmh13.mctier.data.AppConnectionState
 import top.pmh13.mctier.data.ChatMessage
+import top.pmh13.mctier.data.ChatPeerIdentity
+import top.pmh13.mctier.data.ChatTokenHexLength
 import top.pmh13.mctier.data.ChatWireMessage
 import top.pmh13.mctier.data.AppClientVersion
 import top.pmh13.mctier.data.AvailableUpdate
@@ -42,6 +44,7 @@ import top.pmh13.mctier.network.FileShareHttpServer
 import top.pmh13.mctier.network.NetworkController
 import top.pmh13.mctier.network.RemoteFileClient
 import top.pmh13.mctier.network.ScreenShareController
+import top.pmh13.mctier.network.LobbyInviteCodec
 import top.pmh13.mctier.service.ScreenCaptureService
 import top.pmh13.mctier.network.SignalingClient
 import top.pmh13.mctier.data.FileShareWire
@@ -122,6 +125,12 @@ class MctierRepository(private val context: Context) {
         private const val TAG = "MctierRepository"
         private const val MaxPlayerNameLength = 8
         private const val RecallWindowMs = 2 * 60 * 1000L
+        private const val SecureAutoLobbyPasswordKey = "secure_autoLobbyPassword"
+        private const val SecureFavoritesKey = "secure_favorites"
+        private const val SecureRecentLobbiesKey = "secure_recentLobbies"
+        private const val LegacyAutoLobbyPasswordKey = "autoLobbyPassword"
+        private const val LegacyFavoritesKey = "favorites"
+        private const val LegacyRecentLobbiesKey = "recentLobbies"
 
         private fun normalizePlayerName(name: String): String =
             name.replace(Regex("\\s+"), "").take(MaxPlayerNameLength)
@@ -139,11 +148,15 @@ class MctierRepository(private val context: Context) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val prefs = context.getSharedPreferences("mctier", Context.MODE_PRIVATE)
+    private val securePrefs = SecurePreferenceStore(prefs)
     private val networkController = NetworkController(context)
     private val signalingClient = SignalingClient()
     private val rtcController = AndroidRtcController(context)
     private var fileServer: FileShareHttpServer? = null
     private var chatClient: ChatP2PClient? = null
+    private var chatLobbyId: String? = null
+    private var chatToken: String? = null
+    private var chatTokenEpoch: Long = 0L
     private val pendingChatRecalls = mutableMapOf<String, String>()
     private val remoteFileClient = RemoteFileClient(context)
     private val downloadJobs = ConcurrentHashMap<String, Job>()
@@ -341,6 +354,7 @@ class MctierRepository(private val context: Context) {
 
     fun updateSettings(settings: UserSettings) {
         val normalizedSettings = settings.copy(playerName = normalizePlayerName(settings.playerName))
+        saveSecurePreference(SecureAutoLobbyPasswordKey, LegacyAutoLobbyPasswordKey, normalizedSettings.autoLobbyPassword)
         prefs.edit {
             putString("playerName", normalizedSettings.playerName)
             putString("avatarData", normalizedSettings.avatarData)
@@ -351,7 +365,6 @@ class MctierRepository(private val context: Context) {
             putString("virtualDomain", settings.virtualDomain)
             putBoolean("autoLobbyEnabled", settings.autoLobbyEnabled)
             putString("autoLobbyName", settings.autoLobbyName)
-            putString("autoLobbyPassword", settings.autoLobbyPassword)
             putBoolean("enableExitNode", settings.enableExitNode)
             putBoolean("enableAsExitNode", settings.enableAsExitNode)
             putString("proxyCidrs", settings.proxyCidrs)
@@ -458,15 +471,25 @@ class MctierRepository(private val context: Context) {
         nodeOverride: String? = null,
         signalingOverride: String? = null,
     ) {
+        val safeLobbyName = lobbyName.trim()
+        val safePassword = password.trim()
+        if (!LobbyInviteCodec.isValidLobbyName(lobbyName) || !LobbyInviteCodec.isValidLobbyPassword(password)) {
+            _state.update { it.copy(error = L("大厅名称或密码格式无效", "Invalid lobby name or password")) }
+            return
+        }
         val current = _state.value
         val settings = current.settings
         val effectiveNode = nodeOverride?.takeIf { it.isNotBlank() } ?: settings.preferredServer
         val effectiveSignaling = signalingOverride?.takeIf { it.isNotBlank() } ?: settings.signalingServer.ifBlank { DefaultSignalingServer }
+        if (!LobbyInviteCodec.isValidEasyTierNode(effectiveNode) || !LobbyInviteCodec.isValidSignalingServer(effectiveSignaling)) {
+            _state.update { it.copy(error = L("节点或信令服务器地址无效", "Invalid node or signaling server address")) }
+            return
+        }
         scope.launch {
             _state.update { it.copy(state = AppConnectionState.Connecting, error = null) }
             runCatching {
                 val session = networkController.startEasyTier(
-                    lobbyName.trim(), password, settings.playerName, effectiveNode,
+                    safeLobbyName, safePassword, settings.playerName, effectiveNode,
                     mtu = settings.mtu.takeIf { it in 500..1500 } ?: 1420,
                     latencyFirst = settings.latencyFirst,
                     proxyCidrs = settings.proxyCidrs.split('\n', ',').map { it.trim() }.filter { it.isNotBlank() },
@@ -485,8 +508,8 @@ class MctierRepository(private val context: Context) {
                 )
                 val lobby = Lobby(
                     id = UUID.randomUUID().toString(),
-                    name = lobbyName.trim(),
-                    password = password,
+                    name = safeLobbyName,
+                    password = safePassword,
                     createdAt = System.currentTimeMillis(),
                     virtualIp = session.virtualIp,
                     virtualDomain = settings.virtualDomain.ifBlank { "${settings.playerName}.mct.net" },
@@ -496,7 +519,7 @@ class MctierRepository(private val context: Context) {
                 )
                 fileServer = FileShareHttpServer(context, current.playerId, session.virtualIp).also { it.start(5_000, false) }
                 // 启动 P2P 聊天（与桌面端 14540 互通）
-                chatClient = ChatP2PClient(current.playerId, ioScope, session.virtualIp) { wire -> onIncomingChat(wire) }.also { it.start() }
+                chatClient = ChatP2PClient(current.playerId, ioScope, session.virtualIp) { wire -> onIncomingChat(wire) }
                 screenController = ScreenShareController(appContext, current.playerId) { signalingClient.send(it) }.also { controller ->
                     controller.onViewerCountChanged = { shareId, count ->
                         _state.update { state ->
@@ -577,6 +600,14 @@ class MctierRepository(private val context: Context) {
         val leaving = _state.value
         invalidatePendingScreenCapture()
         invalidatePendingRemoteControlAccept()
+        val leavingChatClient = chatClient
+        fileServer?.clearLobbyToken()
+        chatClient = null
+        chatLobbyId = null
+        chatToken = null
+        chatTokenEpoch = 0L
+        pendingChatRecalls.clear()
+        runCatching { leavingChatClient?.stop() }
         pendingPlayerLeaveJobs.values.forEach { it.cancel() }
         pendingPlayerLeaveJobs.clear()
         announcedScreenShares.clear()
@@ -607,8 +638,6 @@ class MctierRepository(private val context: Context) {
             runCatching { rtcController.cleanup() }
             runCatching { top.pmh13.mctier.service.VoiceForegroundService.stop(appContext) }
             runCatching { top.pmh13.mctier.ui.MicKeepAliveOverlay.hide() }
-            runCatching { chatClient?.stop() }
-            chatClient = null
             runCatching { screenController?.release() }
             screenController = null
             runCatching { remoteControlController?.release() }
@@ -731,7 +760,7 @@ class MctierRepository(private val context: Context) {
         if (trimmed.isEmpty()) return
         val current = _state.value
         val client = chatClient ?: return
-        val wire = client.sendText(current.settings.playerName, trimmed)
+        val wire = client.sendText(current.settings.playerName, trimmed) ?: return
         val message = ChatMessage(wire.id, current.playerId, current.settings.playerName, trimmed, wire.timestamp * 1000, mine = true)
         _state.update { it.copy(chatMessages = (it.chatMessages + message).takeLast(500)) }
     }
@@ -769,7 +798,7 @@ class MctierRepository(private val context: Context) {
                 bitmap.compress(android.graphics.Bitmap.CompressFormat.JPEG, 70, baos)
                 val bytes = baos.toByteArray()
                 val intList = bytes.map { it.toInt() and 0xFF }
-                val wire = client.sendImage(current.settings.playerName, intList)
+                val wire = client.sendImage(current.settings.playerName, intList) ?: return@runCatching
                 val base64 = "data:image/jpeg;base64," + Base64.encodeToString(bytes, Base64.NO_WRAP)
                 val message = ChatMessage(wire.id, current.playerId, current.settings.playerName, "[图片]", wire.timestamp * 1000, mine = true, type = "image", imageBase64 = base64)
                 _state.update { it.copy(chatMessages = (it.chatMessages + message).takeLast(500)) }
@@ -886,38 +915,6 @@ class MctierRepository(private val context: Context) {
         broadcastMyShares()
     }
 
-    /**
-     * 同步 P2P 聊天的 peer 列表与身份名册，并同步文件共享的可访问成员。
-     *
-     * 名册为 playerId -> 虚拟IP（含自己），聊天服务器据此校验收到的消息是否
-     * 真的来自其自称的玩家，避免同大厅成员冒用他人身份发言；文件共享服务据同一
-     * 份成员表拒绝已被移出大厅但仍留在虚拟网内的节点访问共享内容。
-     */
-    private fun syncChatPeers() {
-        val players = _state.value.players
-        val selfId = _state.value.playerId
-        val roster = players
-            .filter { it.id.isNotBlank() && !it.virtualIp.isNullOrBlank() }
-            .associate { it.id to it.virtualIp!! }
-
-        // 仅在"每个成员的虚拟IP都已就绪"时才启用来源校验：玩家虚拟IP 是异步补齐的
-        // （这也是 backfillRemoteShareIps 存在的原因），名单不完整时无法区分
-        // "非成员"与"IP 尚未同步的合法成员"，此时下发空名单放行，避免共享/聊天历史
-        // 重新退化成"有时有有时无"。
-        //
-        // 注意 Android 的 players 含自己（加入大厅时即写入本机条目），因此 roster
-        // 已覆盖本机地址，无需额外补。
-        val rosterComplete = players.isNotEmpty() && roster.size == players.size
-        val memberIps = if (rosterComplete) roster.values else emptyList()
-
-        chatClient?.let { client ->
-            client.setPeers(players.filter { it.id != selfId }.mapNotNull { it.virtualIp })
-            client.setPeerRoster(roster)
-            client.setAllowedReaders(memberIps)
-        }
-        fileServer?.setAllowedPeers(memberIps)
-    }
-
     /** 玩家列表更新后，回填此前 ownerIp 为空的远端共享（修“共享时有时无”） */
     private fun backfillRemoteShareIps() {
         val players = _state.value.players
@@ -952,13 +949,18 @@ class MctierRepository(private val context: Context) {
 
     private fun refreshRemoteSharesByHttp() {
         val cur = _state.value
+        val lobbyToken = chatToken ?: return
         val peers = cur.players.filter { it.id != cur.playerId && !it.virtualIp.isNullOrBlank() }
         if (peers.isEmpty()) return
         ioScope.launch {
+            val routedPeers = runCatching { networkController.peerConnectionTypes().keys }.getOrDefault(emptySet())
             val entries = mutableListOf<RemoteShareEntry>()
             val successOwners = mutableSetOf<String>()
-            peers.forEach { p ->
-                runCatching { remoteFileClient.listShares(p.virtualIp!!) }
+            peers.filter { p ->
+                val ip = p.virtualIp.orEmpty()
+                ip in routedPeers && chatClient?.isAuthoritativePeer(p.id, ip) == true
+            }.forEach { p ->
+                runCatching { remoteFileClient.listShares(p.virtualIp!!, lobbyToken) }
                     .onSuccess { shares ->
                         successOwners += p.id
                         entries += shares.map { w ->
@@ -1049,7 +1051,16 @@ class MctierRepository(private val context: Context) {
         onError: (String) -> Unit,
     ) {
         ioScope.launch {
-            runCatching { remoteFileClient.listFiles(entry.ownerIp, entry.shareId, path, password) }
+            if (!isAuthorizedRemoteShare(entry)) {
+                scope.launch { onError(L("目标已不在当前大厅", "The target is no longer in the current lobby")) }
+                return@launch
+            }
+            val lobbyToken = chatToken
+            if (lobbyToken == null) {
+                scope.launch { onError(L("文件认证会话尚未就绪", "File authentication session is not ready")) }
+                return@launch
+            }
+            runCatching { remoteFileClient.listFiles(entry.ownerIp, entry.shareId, path, password, lobbyToken) }
                 .onSuccess { files -> scope.launch { onResult(files) } }
                 .onFailure { e -> scope.launch { onError(e.message ?: L("浏览失败", "Browse failed")) } }
         }
@@ -1117,8 +1128,15 @@ class MctierRepository(private val context: Context) {
 
         val job = ioScope.launch {
             runCatching {
+                if (!isAuthorizedRemoteShare(entry)) {
+                    error(L("目标已不在当前大厅", "The target is no longer in the current lobby"))
+                }
+                val lobbyToken = chatToken
+                    ?: error(L("文件认证会话尚未就绪", "File authentication session is not ready"))
                 remoteFileClient.download(entry.ownerIp, entry.shareId, file.path, file.name, password,
+                    lobbyToken = lobbyToken,
                     downloadTreeUri = _state.value.settings.fileShareDownloadTreeUri,
+                    expectedSize = file.size,
                     onProgress = { downloaded, total ->
                     val pct = if (total > 0) ((downloaded * 100) / total).toInt().coerceIn(0, 100) else -1
                     scope.launch { _state.update { it.copy(downloadProgress = it.downloadProgress + (key to pct)) } }
@@ -1430,6 +1448,48 @@ class MctierRepository(private val context: Context) {
         return true
     }
 
+    private fun currentChatPeers(excludedIds: Set<String> = emptySet()): List<ChatPeerIdentity> {
+        val state = _state.value
+        return state.players.asSequence()
+            .filter { player ->
+                player.id != state.playerId && player.id !in excludedIds && !player.virtualIp.isNullOrBlank()
+            }
+            .map { player -> ChatPeerIdentity(player.id, player.name, player.virtualIp!!.trim()) }
+            .distinctBy { it.playerId }
+            .toList()
+    }
+
+    private fun isAuthorizedRemoteShare(entry: RemoteShareEntry): Boolean {
+        val player = _state.value.players.singleOrNull { it.id == entry.ownerId } ?: return false
+        val ip = player.virtualIp?.takeIf { it == entry.ownerIp } ?: return false
+        if (chatClient?.isAuthoritativePeer(entry.ownerId, ip) != true) return false
+        return runCatching { ip in networkController.peerConnectionTypes() }.getOrDefault(false)
+    }
+
+    private fun isValidChatToken(token: String?): Boolean {
+        val value = token ?: return false
+        return value.length == ChatTokenHexLength && value.all { it.isDigit() || it.lowercaseChar() in 'a'..'f' }
+    }
+
+    private fun configureAuthenticatedChat(): Boolean {
+        val client = chatClient ?: return false
+        val token = chatToken ?: return false
+        val epoch = chatTokenEpoch
+        if (epoch <= 0L) return false
+        val state = _state.value
+        if (!client.setPeers(currentChatPeers())) return false
+        if (!client.configureSession(token, epoch, state.settings.playerName, state.hostId)) return false
+        if (!client.start()) return false
+        client.sendAvatar(state.settings.avatarData)
+        return true
+    }
+
+    private fun rejectChatProtocol(reason: String) {
+        Log.e("MctierRepository", "Rejecting chat protocol state: $reason")
+        _state.update { it.copy(error = reason) }
+        scope.launch { leaveLobby() }
+    }
+
     private fun handleSignal(message: SignalingEnvelope) {
         // player-left 必须先由权威成员快照确认，避免旧信令连接的延迟事件拆掉已恢复的语音链路。
         if (message.type != "player-left") rtcController.handleSignal(message)
@@ -1445,10 +1505,63 @@ class MctierRepository(private val context: Context) {
                 scope.launch { runCatching { leaveLobby() } }
             }
             "register-success" -> {
+                val lobbyId = message.lobbyId
+                val token = message.chatToken
+                val epoch = message.chatTokenEpoch ?: 0L
+                if (lobbyId.isNullOrBlank() || !isValidChatToken(token) || epoch <= 0L) {
+                    rejectChatProtocol(L("聊天认证信息无效", "Invalid chat authentication state"))
+                    return
+                }
+                if (chatLobbyId != null && chatLobbyId != lobbyId) {
+                    rejectChatProtocol(L("聊天大厅身份发生冲突", "Chat lobby identity conflict"))
+                    return
+                }
+                if (epoch < chatTokenEpoch || (epoch == chatTokenEpoch && chatToken != null && chatToken != token)) {
+                    rejectChatProtocol(L("聊天令牌版本发生冲突", "Chat token epoch conflict"))
+                    return
+                }
+                chatLobbyId = lobbyId
+                chatToken = token
+                chatTokenEpoch = epoch
+                if (fileServer?.configureLobbyToken(token!!, epoch) != true) {
+                    rejectChatProtocol(L("无法配置文件认证凭据", "Unable to configure file authentication token"))
+                    return
+                }
                 _state.update { it.copy(hostId = message.hostId, maxPlayers = message.maxPlayers, isPublicLobby = message.isPublic ?: false, mutedPlayers = message.mutedPlayers?.toSet() ?: it.mutedPlayers) }
+                if (message.hostId == _state.value.playerId && !configureAuthenticatedChat()) {
+                    rejectChatProtocol(L("无法启动认证聊天服务", "Unable to start authenticated chat service"))
+                    return
+                }
                 // 请求大厅内其他玩家的文件共享列表
                 refreshRemoteSharesByHttp()
                 signalingClient.send(SignalingEnvelope(type = "screen-share-list-request", from = _state.value.playerId))
+            }
+            "chat-token-rotated" -> {
+                val lobbyId = message.lobbyId
+                val token = message.chatToken
+                val epoch = message.chatTokenEpoch ?: 0L
+                if (lobbyId != chatLobbyId || !isValidChatToken(token) || epoch <= 0L) {
+                    rejectChatProtocol(L("聊天令牌轮换信息无效", "Invalid chat token rotation"))
+                    return
+                }
+                if (epoch < chatTokenEpoch) return
+                if (epoch == chatTokenEpoch) {
+                    if (token != chatToken) {
+                        rejectChatProtocol(L("同一聊天版本收到不同令牌", "Conflicting token for the same chat epoch"))
+                    }
+                    return
+                }
+                val client = chatClient
+                if (client?.isReady() == true && !client.rotateToken(token!!, epoch)) {
+                    rejectChatProtocol(L("聊天令牌轮换被拒绝", "Chat token rotation was rejected"))
+                    return
+                }
+                if (fileServer?.configureLobbyToken(token!!, epoch) != true) {
+                    rejectChatProtocol(L("文件认证凭据轮换被拒绝", "File authentication token rotation was rejected"))
+                    return
+                }
+                chatToken = token
+                chatTokenEpoch = epoch
             }
             "players-list" -> {
                 val selfId = _state.value.playerId
@@ -1489,8 +1602,10 @@ class MctierRepository(private val context: Context) {
                 val others = remotes.map { it.id }.filter { it != selfId }
                 rtcController.connectToPlayers(others)
                 // 更新 P2P 聊天 peer 列表
-                syncChatPeers()
-                chatClient?.sendAvatar(_state.value.settings.avatarData)
+                if (!configureAuthenticatedChat()) {
+                    rejectChatProtocol(L("无法应用聊天成员快照", "Unable to apply chat member snapshot"))
+                    return
+                }
                 // 玩家列表变化后，主动重发一次自己的共享，确保新加入/刚获取 IP 的玩家能看到
                 if (_state.value.sharedFolders.isNotEmpty()) broadcastMyShares()
             }
@@ -1505,7 +1620,10 @@ class MctierRepository(private val context: Context) {
                 if (alreadyKnown) {
                     if (id != _state.value.playerId) rtcController.connectToPlayer(id)
                     backfillRemoteShareIps()
-                    syncChatPeers()
+                    if (chatClient?.isReady() == true && chatClient?.setPeers(currentChatPeers()) != true) {
+                        rejectChatProtocol(L("聊天成员身份无效", "Invalid chat member identity"))
+                        return
+                    }
                     chatClient?.sendAvatar(_state.value.settings.avatarData)
                     return
                 }
@@ -1515,7 +1633,10 @@ class MctierRepository(private val context: Context) {
                     rtcController.connectToPlayer(id)
                 }
                 backfillRemoteShareIps()
-                syncChatPeers()
+                if (chatClient?.isReady() == true && chatClient?.setPeers(currentChatPeers()) != true) {
+                    rejectChatProtocol(L("聊天成员身份无效", "Invalid chat member identity"))
+                    return
+                }
                 if (id != _state.value.playerId) {
                     soundManager.playerJoin()
                     // 有新玩家加入时，把自己的文件共享列表推送给对方，确保对方能看到我的共享
@@ -1550,6 +1671,13 @@ class MctierRepository(private val context: Context) {
             "player-left" -> {
                 val id = message.playerId ?: return
                 if (id != _state.value.playerId) remoteControlController?.handlePeerLeft(id)
+                if (chatClient?.isReady() == true) {
+                    if (_state.value.hostId == id) chatClient?.updateHostId(null)
+                    if (chatClient?.setPeers(currentChatPeers(setOf(id))) != true) {
+                        rejectChatProtocol(L("无法撤销离开玩家的聊天权限", "Unable to revoke the leaving chat peer"))
+                        return
+                    }
+                }
                 if (id != _state.value.playerId && _state.value.players.any { it.id == id }) {
                     schedulePlayerLeaveConfirmation(id)
                 }
@@ -1561,7 +1689,14 @@ class MctierRepository(private val context: Context) {
             "chat-message" -> {
                 // 已废弃：聊天改为 P2P（14540）传输，不再走信令
             }
-            "host-changed" -> _state.update { it.copy(hostId = message.hostId) }
+            "host-changed" -> {
+                val hostId = message.hostId ?: return
+                _state.update { it.copy(hostId = hostId) }
+                val client = chatClient
+                if (client?.isReady() == true && !client.updateHostId(hostId) && !configureAuthenticatedChat()) {
+                    rejectChatProtocol(L("无法更新聊天房主身份", "Unable to update chat host identity"))
+                }
+            }
             "player-mute-changed" -> {
                 val id = message.playerId ?: return
                 val muted = message.muted ?: false
@@ -1798,7 +1933,16 @@ class MctierRepository(private val context: Context) {
         )
     }
 
-    fun setLobbyOptions(maxPlayers: Int?, isPublic: Boolean, description: String, publicPassword: String?) {
+    fun setLobbyOptions(maxPlayers: Int?, isPublic: Boolean, description: String) {
+        if (isPublic && !_state.value.lobby?.password.isNullOrEmpty()) {
+            _state.update {
+                it.copy(
+                    isPublicLobby = false,
+                    error = L("公开大厅必须不设密码", "Public lobbies must not have a password"),
+                )
+            }
+            return
+        }
         signalingClient.send(
             SignalingEnvelope(
                 type = "set-lobby-options",
@@ -1806,7 +1950,6 @@ class MctierRepository(private val context: Context) {
                 maxPlayers = maxPlayers,
                 isPublic = isPublic,
                 description = description.ifBlank { null },
-                password = publicPassword?.takeIf { it.isNotBlank() },
                 // 公开时附带房主使用的节点地址，供广场加入者自动同步
                 serverNode = if (isPublic) _state.value.lobby?.serverNode?.takeIf { it.isNotBlank() } else null,
             ),
@@ -1870,19 +2013,29 @@ class MctierRepository(private val context: Context) {
     }
 
     private fun loadFavorites(): List<FavoriteLobby> = runCatching {
-        prefs.getString("favorites", null)?.let { MctierJson.decodeFromString(ListSerializer(FavoriteLobby.serializer()), it) }
+        readSecurePreference(SecureFavoritesKey, LegacyFavoritesKey)
+            ?.let { MctierJson.decodeFromString(ListSerializer(FavoriteLobby.serializer()), it) }
     }.getOrNull().orEmpty()
 
     private fun saveFavorites(list: List<FavoriteLobby>) {
-        prefs.edit { putString("favorites", MctierJson.encodeToString(ListSerializer(FavoriteLobby.serializer()), list)) }
+        saveSecurePreference(
+            SecureFavoritesKey,
+            LegacyFavoritesKey,
+            MctierJson.encodeToString(ListSerializer(FavoriteLobby.serializer()), list),
+        )
     }
 
     private fun loadRecentLobbies(): List<RecentLobby> = runCatching {
-        prefs.getString("recentLobbies", null)?.let { MctierJson.decodeFromString(ListSerializer(RecentLobby.serializer()), it) }
+        readSecurePreference(SecureRecentLobbiesKey, LegacyRecentLobbiesKey)
+            ?.let { MctierJson.decodeFromString(ListSerializer(RecentLobby.serializer()), it) }
     }.getOrNull().orEmpty()
 
     private fun saveRecentLobbies(list: List<RecentLobby>) {
-        prefs.edit { putString("recentLobbies", MctierJson.encodeToString(ListSerializer(RecentLobby.serializer()), list)) }
+        saveSecurePreference(
+            SecureRecentLobbiesKey,
+            LegacyRecentLobbiesKey,
+            MctierJson.encodeToString(ListSerializer(RecentLobby.serializer()), list),
+        )
     }
 
     private fun loadRecentPlayers(): List<RecentPlayer> = runCatching {
@@ -1891,6 +2044,26 @@ class MctierRepository(private val context: Context) {
 
     private fun saveRecentPlayers(list: List<RecentPlayer>) {
         prefs.edit { putString("recentPlayers", MctierJson.encodeToString(ListSerializer(RecentPlayer.serializer()), list)) }
+    }
+
+    /** Read a protected value and migrate the legacy plaintext value once, if present. */
+    private fun readSecurePreference(secureKey: String, legacyKey: String): String? {
+        securePrefs.getString(secureKey)?.let { return it }
+        val legacy = prefs.getString(legacyKey, null) ?: return null
+        if (securePrefs.putStringRemoving(secureKey, legacy, legacyKey)) {
+            return legacy
+        }
+        Log.w(TAG, "Secure preference migration failed")
+        securePrefs.remove(legacyKey)
+        return null
+    }
+
+    /** Never write a new credential in plaintext; discard legacy plaintext after migration. */
+    private fun saveSecurePreference(secureKey: String, legacyKey: String, value: String) {
+        if (!securePrefs.putStringRemoving(secureKey, value, legacyKey)) {
+            Log.w(TAG, "Secure preference write failed")
+            securePrefs.remove(secureKey, legacyKey)
+        }
     }
 
     // ==================== 收藏队友（本地存储，按名字） ====================
@@ -2133,7 +2306,7 @@ class MctierRepository(private val context: Context) {
         virtualDomain = prefs.getString("virtualDomain", null).orEmpty(),
         autoLobbyEnabled = prefs.getBoolean("autoLobbyEnabled", false),
         autoLobbyName = prefs.getString("autoLobbyName", null).orEmpty(),
-        autoLobbyPassword = prefs.getString("autoLobbyPassword", null).orEmpty(),
+        autoLobbyPassword = readSecurePreference(SecureAutoLobbyPasswordKey, LegacyAutoLobbyPasswordKey).orEmpty(),
         enableExitNode = prefs.getBoolean("enableExitNode", false),
         enableAsExitNode = prefs.getBoolean("enableAsExitNode", false),
         proxyCidrs = prefs.getString("proxyCidrs", null).orEmpty(),

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/SecurePreferenceStore.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/SecurePreferenceStore.kt
@@ -1,0 +1,82 @@
+package top.pmh13.mctier
+
+import android.content.SharedPreferences
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.nio.charset.StandardCharsets
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/** Small AES-GCM wrapper for values that must not be kept as plaintext preferences. */
+internal class SecurePreferenceStore(private val preferences: SharedPreferences) {
+    companion object {
+        private const val KeyStoreName = "AndroidKeyStore"
+        private const val KeyAlias = "top.pmh13.mctier.secure-preferences"
+        private const val Transformation = "AES/GCM/NoPadding"
+        private const val IvLengthBytes = 12
+        private const val TagLengthBits = 128
+    }
+
+    fun getString(key: String): String? {
+        val encoded = preferences.getString(key, null) ?: return null
+        return runCatching {
+            val packed = Base64.decode(encoded, Base64.DEFAULT)
+            require(packed.size > IvLengthBytes)
+            val iv = packed.copyOfRange(0, IvLengthBytes)
+            val ciphertext = packed.copyOfRange(IvLengthBytes, packed.size)
+            Cipher.getInstance(Transformation).apply {
+                init(Cipher.DECRYPT_MODE, getOrCreateKey(), GCMParameterSpec(TagLengthBits, iv))
+                updateAAD(key.toByteArray(StandardCharsets.UTF_8))
+            }.doFinal(ciphertext).let { String(it, StandardCharsets.UTF_8) }
+        }.getOrNull()
+    }
+
+    fun putStringRemoving(key: String, value: String, legacyKey: String): Boolean {
+        val encoded = encodeString(key, value) ?: return false
+        return preferences.edit()
+            .putString(key, encoded)
+            .remove(legacyKey)
+            .commit()
+    }
+
+    fun remove(vararg keys: String): Boolean {
+        val editor = preferences.edit()
+        keys.forEach(editor::remove)
+        return editor.commit()
+    }
+
+    private fun encodeString(key: String, value: String): String? = runCatching {
+        val cipher = Cipher.getInstance(Transformation).apply {
+            init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+            updateAAD(key.toByteArray(StandardCharsets.UTF_8))
+        }
+        val ciphertext = cipher.doFinal(value.toByteArray(StandardCharsets.UTF_8))
+        val packed = ByteArray(cipher.iv.size + ciphertext.size)
+        cipher.iv.copyInto(packed)
+        ciphertext.copyInto(packed, cipher.iv.size)
+        Base64.encodeToString(packed, Base64.NO_WRAP)
+    }.getOrNull()
+
+    @Synchronized
+    private fun getOrCreateKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(KeyStoreName).apply { load(null) }
+        (keyStore.getKey(KeyAlias, null) as? SecretKey)?.let { return it }
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KeyStoreName).apply {
+            init(
+                KeyGenParameterSpec.Builder(
+                    KeyAlias,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                )
+                    .setKeySize(256)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setRandomizedEncryptionRequired(true)
+                    .build(),
+            )
+        }.generateKey()
+    }
+}

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/data/Models.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/data/Models.kt
@@ -8,6 +8,11 @@ const val RemovedQingyunNode = "wss://mctiers.pmhs.top"
 const val DefaultSignalingServer = "wss://mctier.pmhs.top/signaling"
 const val FileSharePort = 14539
 const val ChatServerPort = 14540
+const val ChatTokenHeader = "x-mctier-chat-token"
+const val ChatTokenHexLength = 64
+const val ChatMaxHistoryMessages = 1000
+const val ChatMaxHistoryBytes = 4 * 1024 * 1024
+const val ChatMaxHttpBodyBytes = 2 * 1024 * 1024
 const val AppClientVersion = "2.8.0"
 
 enum class AppConnectionState { Idle, Connecting, InLobby, Error }
@@ -154,6 +159,9 @@ data class UserSettings(
 @Serializable
 data class SignalingEnvelope(
     val type: String,
+    val lobbyId: String? = null,
+    val chatToken: String? = null,
+    val chatTokenEpoch: Long? = null,
     val from: String? = null,
     val to: String? = null,
     val clientId: String? = null,
@@ -244,6 +252,13 @@ data class ChatWireMessage(
     @SerialName("image_data") val imageData: List<Int>? = null, // 图片字节(0~255)
 )
 
+/** 权威聊天身份：playerId/name 来自已认证信令快照，virtualIp 用于 TCP 源地址绑定。 */
+data class ChatPeerIdentity(
+    val playerId: String,
+    val playerName: String,
+    val virtualIp: String,
+)
+
 /** P2P 聊天发送请求体（与桌面端 SendMessageRequest 对齐） */
 @Serializable
 data class ChatSendRequest(
@@ -297,7 +312,6 @@ data class PublicLobbyWire(
     @SerialName("maxPlayers") val maxPlayers: Int? = null,
     @SerialName("hostName") val hostName: String = "",
     val description: String = "",
-    val password: String = "",
     @SerialName("serverNode") val serverNode: String = "",
 )
 

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/ChatHttpServer.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/ChatHttpServer.kt
@@ -2,189 +2,316 @@ package top.pmh13.mctier.network
 
 import android.util.Log
 import fi.iki.elonen.NanoHTTPD
+import top.pmh13.mctier.data.ChatMaxHistoryBytes
+import top.pmh13.mctier.data.ChatMaxHistoryMessages
+import top.pmh13.mctier.data.ChatMaxHttpBodyBytes
+import top.pmh13.mctier.data.ChatPeerIdentity
 import top.pmh13.mctier.data.ChatSendRequest
 import top.pmh13.mctier.data.ChatServerPort
+import top.pmh13.mctier.data.ChatTokenHeader
+import top.pmh13.mctier.data.ChatTokenHexLength
 import top.pmh13.mctier.data.ChatWireMessage
 import top.pmh13.mctier.data.MctierJson
-import java.util.concurrent.CopyOnWriteArrayList
+import java.net.InetAddress
+import java.net.Inet4Address
+import java.security.MessageDigest
+import java.util.ArrayDeque
+import java.util.HashMap
+import java.util.LinkedHashMap
+import java.util.Locale
+import java.util.UUID
 
 /**
- * P2P 聊天服务器（与桌面端 chat_service.rs 完全互通）
+ * P2P chat HTTP server.
  *
- * - POST /api/chat/send      接收其他玩家推送来的消息（存储 + 回调通知 UI）
- * - GET  /api/chat/messages  返回本机存储的消息（支持 ?since=秒 过滤），供他人对账拉取
- *
- * 发送方会把自己发的消息也存进本机，所以任何 peer 都能从发送方拉到完整历史。
+ * Every request needs the signaling-issued token and a TCP source IP present in
+ * the current signaling identity snapshot. Request-body identity fields are
+ * retained only for wire compatibility and are never used for attribution.
  */
 class ChatHttpServer(
     private val ownerId: String,
-    bindIp: String = DEFAULT_BIND_IP,
-) : NanoHTTPD(bindIp.ifBlank { DEFAULT_BIND_IP }, ChatServerPort) {
+    bindIp: String,
+) : NanoHTTPD(requireBindIp(bindIp), ChatServerPort) {
 
-    private val messages = CopyOnWriteArrayList<ChatWireMessage>()
+    private val boundIp = requireBindIp(bindIp)
+    private val sessionLock = Any()
+    private val historyLock = Any()
+    private val rateLimitLock = Any()
+    private val messages = ArrayDeque<ChatWireMessage>()
+    private var historyBytes = 0
+    private var authSession: AuthSession? = null
+    private val requestTimes = HashMap<RateLimitKey, ArrayDeque<Long>>()
+
     /** 收到他人 POST 的新消息时回调（用于推送到 UI） */
     var onMessageReceived: ((ChatWireMessage) -> Unit)? = null
 
     /**
-     * 大厅身份名册：playerId -> 虚拟 IP。
-     *
-     * 用于校验 `/api/chat/send` 里自称的 `playerId` 是否与其真实来源 IP 相符，
-     * 与桌面端 `chat_service.rs` 的判定规则保持一致。
+     * Install the current signaling session. A lower epoch or a different
+     * token at the same epoch is rejected so stale callbacks cannot reopen the
+     * HTTP boundary.
      */
-    @Volatile
-    private var peerRoster: Map<String, String> = emptyMap()
-
-    /** 更新身份名册（只保留同时具备 ID 与 IP 的条目） */
-    fun setPeerRoster(roster: Map<String, String>) {
-        peerRoster = roster.filter { it.key.isNotBlank() && it.value.isNotBlank() }
+    fun configureSession(
+        token: String,
+        tokenEpoch: Long,
+        local: ChatPeerIdentity,
+        peers: List<ChatPeerIdentity>,
+        hostId: String?,
+    ): Boolean {
+        if (!isValidChatToken(token) || tokenEpoch <= 0L || local.playerId != ownerId) return false
+        val normalizedLocal = normalizeIdentity(local) ?: return false
+        if (normalizedLocal.virtualIp != boundIp) return false
+        val identities = buildIdentityMap(normalizedLocal, peers) ?: return false
+        synchronized(sessionLock) {
+            val current = authSession
+            if (current != null) {
+                if (current.local != normalizedLocal) return false
+                if (tokenEpoch < current.tokenEpoch) return false
+                if (tokenEpoch == current.tokenEpoch && current.token != token) return false
+            }
+            if (!isValidHostId(hostId, identities)) return false
+            authSession = AuthSession(token, tokenEpoch, normalizedLocal, hostId, identities)
+        }
+        return true
     }
 
-    /**
-     * 允许读取本机聊天记录的成员 IP 集合。
-     *
-     * 读取类接口（`/api/chat/messages`）不携带 playerId，只能按来源 IP 判断，
-     * 因此与发送侧的名册分开维护。集合为空时放行（尚未下发或对端为旧版本）。
-     */
-    @Volatile
-    private var allowedReaders: Set<String> = emptySet()
-
-    /** 更新可读取聊天记录的成员 IP 集合 */
-    fun setAllowedReaders(ips: Collection<String>) {
-        allowedReaders = ips.filter { it.isNotBlank() }.toSet()
+    /** Rotate only the credential while retaining the authoritative peer map. */
+    fun rotateToken(token: String, tokenEpoch: Long): Boolean {
+        if (!isValidChatToken(token) || tokenEpoch <= 0L) return false
+        synchronized(sessionLock) {
+            val current = authSession ?: return false
+            if (tokenEpoch < current.tokenEpoch) return false
+            if (tokenEpoch == current.tokenEpoch) return current.token == token
+            authSession = current.copy(token = token, tokenEpoch = tokenEpoch)
+        }
+        return true
     }
 
-    /** 判断调用方是否有权读取本机聊天记录 */
-    internal fun isAllowedReader(remoteIp: String?): Boolean {
-        val allowed = allowedReaders
-        if (allowed.isEmpty()) return true
-        if (remoteIp.isNullOrBlank()) return true
-        return allowed.contains(normalizeIp(remoteIp))
+    /** Replace peer identities after an authenticated signaling snapshot. */
+    fun updatePeers(peers: List<ChatPeerIdentity>): Boolean {
+        synchronized(sessionLock) {
+            val current = authSession ?: return false
+            val identities = buildIdentityMap(current.local, peers) ?: return false
+            if (!isValidHostId(current.hostId, identities)) return false
+            authSession = current.copy(identities = identities)
+        }
+        return true
     }
 
-    /** 把本机发送的消息加入存储（供他人拉取） */
-    fun addLocal(message: ChatWireMessage) {
-        messages.add(message)
-        trim()
+    fun updateHostId(hostId: String?): Boolean {
+        synchronized(sessionLock) {
+            val current = authSession ?: return false
+            if (!isValidHostId(hostId, current.identities)) return false
+            authSession = current.copy(hostId = hostId)
+        }
+        return true
     }
 
-    fun clear() {
-        messages.clear()
-        peerRoster = emptyMap()
-        allowedReaders = emptySet()
+    fun currentToken(): String? = synchronized(sessionLock) { authSession?.token }
+
+    fun currentTokenEpoch(): Long = synchronized(sessionLock) { authSession?.tokenEpoch ?: 0L }
+
+    fun localIdentity(): ChatPeerIdentity? = synchronized(sessionLock) { authSession?.local }
+
+    fun hasSession(): Boolean = synchronized(sessionLock) { authSession != null }
+
+    fun isKnownPeer(message: ChatWireMessage): Boolean = synchronized(sessionLock) {
+        authSession?.identities?.values?.any { identity ->
+            identity.playerId == message.playerId && identity.playerName == message.playerName
+        } == true
     }
 
-    /**
-     * 校验消息里自称的 [playerId] 是否确实来自该玩家的虚拟 IP。
-     *
-     * 同一大厅内任何成员都能直连他人的聊天端口，若完全信任请求体里的 `playerId`，
-     * 任意成员都可以伪造成房主或其他玩家发言（含 announce / recall / avatar 等控制消息）。
-     *
-     * 判定规则与桌面端一致：名册为空、或名册中没有该 playerId 时放行（升级过程与
-     * 新玩家刚加入都属正常）；名册中存在但登记 IP 与来源 IP 不一致时判定为冒名。
-     */
-    internal fun senderIdentityMatches(playerId: String, remoteIp: String?): Boolean {
-        val roster = peerRoster
-        if (roster.isEmpty() || playerId.isBlank()) return true
-        val expected = roster[playerId] ?: return true
-        if (remoteIp.isNullOrBlank()) return true
-        return expected == normalizeIp(remoteIp)
+    /** 把本机发送的消息加入存储（供他人拉取）。 */
+    fun addLocal(message: ChatWireMessage): Boolean {
+        val session = synchronized(sessionLock) { authSession } ?: return false
+        if (message.playerId != session.local.playerId || message.playerName != session.local.playerName) return false
+        if (!isValidMessage(message, hostId = session.hostId, checkHost = true)) return false
+        return storeMessage(message)
     }
 
-    /** 归一化来源地址：去掉 IPv6 映射前缀与端口，便于与名册里的 IPv4 文本比较。 */
-    private fun normalizeIp(raw: String): String {
-        var ip = raw.trim()
-        if (ip.startsWith("::ffff:")) ip = ip.removePrefix("::ffff:")
-        return ip
+    /** Stop/reset is a security boundary: revoke credentials and discard history. */
+    fun clearSession() {
+        synchronized(sessionLock) { authSession = null }
+        synchronized(rateLimitLock) { requestTimes.clear() }
+        synchronized(historyLock) {
+            messages.clear()
+            historyBytes = 0
+        }
     }
 
-    private fun trim() {
-        while (messages.size > 1000) messages.removeAt(0)
-    }
-
-    private fun messagesSince(since: Long?): List<ChatWireMessage> =
+    private fun messagesSince(since: Long?): List<ChatWireMessage> = synchronized(historyLock) {
         if (since == null) messages.toList() else messages.filter { it.timestamp > since }
+    }
 
     override fun serve(session: IHTTPSession): Response {
         val origin = LanCors.originOf(session)
-        // 预检请求：仅对白名单来源回写跨域头
         if (session.method == Method.OPTIONS) {
             return withCors(newFixedLengthResponse(Response.Status.OK, "text/plain", ""), origin)
         }
         return try {
             when {
-                session.uri == "/api/chat/messages" && session.method == Method.GET -> {
-                    // 非大厅成员不得拉取聊天历史
-                    if (!isAllowedReader(session.remoteIpAddress)) {
-                        Log.w(TAG, "拒绝非大厅成员拉取聊天历史：来源 ${session.remoteIpAddress}")
-                        withCors(
-                            newFixedLengthResponse(Response.Status.FORBIDDEN, "text/plain", "forbidden"),
-                            origin,
-                        )
-                    } else {
-                        val since = session.parameters["since"]?.firstOrNull()?.toLongOrNull()
-                        json(messagesSince(since), origin)
-                    }
-                }
+                session.uri == "/api/chat/messages" && session.method == Method.GET -> handleMessages(session, origin)
                 session.uri == "/api/chat/send" && session.method == Method.POST -> handleSend(session, origin)
                 else -> withCors(newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "not found"), origin)
             }
+        } catch (rejected: RequestRejected) {
+            withCors(newFixedLengthResponse(rejected.status, "text/plain", rejected.message ?: "request rejected"), origin)
         } catch (e: Exception) {
             Log.w(TAG, "处理聊天请求失败: ${e.message}")
             withCors(newFixedLengthResponse(Response.Status.INTERNAL_ERROR, "text/plain", "error"), origin)
         }
     }
 
-    /**
-     * 为响应附加跨域头。
-     *
-     * 只对白名单内的来源回写 `Access-Control-Allow-Origin`（详见 [LanCors]），
-     * 避免虚拟网内任意网页在浏览器里读取本机聊天记录。
-     */
-    private fun withCors(response: Response, origin: String?): Response =
-        LanCors.apply(response, origin)
+    private fun handleMessages(session: IHTTPSession, origin: String?): Response {
+        val auth = authenticate(session)
+        if (!allowRequest(auth.identity, auth.sourceIp)) reject(Response.Status.TOO_MANY_REQUESTS)
+        val rawSince = session.parameters["since"]?.firstOrNull()
+        val since = when {
+            rawSince == null -> null
+            rawSince.isBlank() -> reject(Response.Status.BAD_REQUEST)
+            else -> rawSince.toLongOrNull()?.takeIf { it >= 0L } ?: reject(Response.Status.BAD_REQUEST)
+        }
+        return json(messagesSince(since), origin)
+    }
 
     private fun handleSend(session: IHTTPSession, origin: String?): Response {
-        // 【中文乱码修复】不依赖 nanohttpd 的 parseBody（其默认按非 UTF-8 解码请求体，
-        // 会把桌面端发来的中文变成乱码），直接按 Content-Length 读原始字节并以 UTF-8 解码。
-        val len = session.headers["content-length"]?.toIntOrNull() ?: 0
-        val body = if (len > 0) {
-            val buf = ByteArray(len)
-            var off = 0
-            while (off < len) {
-                val r = session.inputStream.read(buf, off, len - off)
-                if (r < 0) break
-                off += r
-            }
-            String(buf, 0, off, Charsets.UTF_8)
-        } else {
-            // 兜底：极少数情况下没有 Content-Length，退回 parseBody
-            val files = HashMap<String, String>()
-            session.parseBody(files)
-            files["postData"] ?: session.queryParameterString ?: ""
-        }
-        val req = MctierJson.decodeFromString(ChatSendRequest.serializer(), body)
-        // 身份绑定：拒绝冒用他人 playerId 的消息（含控制类消息）
-        if (!senderIdentityMatches(req.playerId, session.remoteIpAddress)) {
-            Log.w(TAG, "拒绝冒名消息：自称 ${req.playerId} 但来源为 ${session.remoteIpAddress}")
-            return withCors(
-                newFixedLengthResponse(Response.Status.FORBIDDEN, "text/plain", "identity mismatch"),
-                origin,
-            )
-        }
+        val auth = authenticate(session)
+        if (!allowRequest(auth.identity, auth.sourceIp)) reject(Response.Status.TOO_MANY_REQUESTS)
+        val body = readJsonBody(session)
+        val req = runCatching {
+            MctierJson.decodeFromString(ChatSendRequest.serializer(), body)
+        }.getOrElse { reject(Response.Status.BAD_REQUEST) }
+        val type = req.messageType.trim().lowercase(Locale.US)
+        val id = req.id?.trim()?.takeIf { it.isNotEmpty() }
         val message = ChatWireMessage(
-            id = req.id ?: "msg-${req.playerId}-${System.currentTimeMillis()}",
-            playerId = req.playerId,
-            playerName = req.playerName,
+            id = id ?: "msg-${auth.identity.playerId}-${UUID.randomUUID()}",
+            playerId = auth.identity.playerId,
+            playerName = auth.identity.playerName,
             content = req.content,
-            messageType = req.messageType,
-            timestamp = System.currentTimeMillis() / 1000,
+            messageType = type,
+            timestamp = System.currentTimeMillis() / 1000L,
             imageData = req.imageData,
         )
-        messages.add(message)
-        trim()
+        if (!isValidMessage(message, auth.hostId, checkHost = true)) {
+            reject(Response.Status.BAD_REQUEST)
+        }
+        if (!storeMessage(message)) reject(Response.Status.PAYLOAD_TOO_LARGE)
         onMessageReceived?.invoke(message)
         return json(message, origin)
     }
+
+    private fun authenticate(session: IHTTPSession): AuthenticatedRequest {
+        val snapshot = synchronized(sessionLock) { authSession }
+            ?: reject(Response.Status.UNAUTHORIZED)
+        val supplied = singleHeader(session, ChatTokenHeader) ?: reject(Response.Status.UNAUTHORIZED)
+        if (!constantTimeEquals(supplied, snapshot.token)) reject(Response.Status.UNAUTHORIZED)
+        val source = parseUsableIp(session.remoteIpAddress) ?: reject(Response.Status.FORBIDDEN)
+        val identity = snapshot.identities[source] ?: reject(Response.Status.FORBIDDEN)
+        return AuthenticatedRequest(snapshot.hostId, source, identity)
+    }
+
+    private fun readJsonBody(session: IHTTPSession): String {
+        if (session.headers.keys.any { it.equals("transfer-encoding", ignoreCase = true) }) {
+            reject(Response.Status.BAD_REQUEST)
+        }
+        val contentType = singleHeader(session, "content-type")
+            ?.substringBefore(';')
+            ?.trim()
+            ?.takeIf { it.equals("application/json", ignoreCase = true) }
+            ?: reject(Response.Status.UNSUPPORTED_MEDIA_TYPE)
+        @Suppress("UNUSED_VARIABLE")
+        val ignoredContentType = contentType
+        val lengthText = singleHeader(session, "content-length") ?: reject(Response.Status.LENGTH_REQUIRED)
+        val length = lengthText.toLongOrNull()?.takeIf { it >= 0L }
+            ?: reject(Response.Status.BAD_REQUEST)
+        if (length > ChatMaxHttpBodyBytes.toLong()) reject(Response.Status.PAYLOAD_TOO_LARGE)
+        val bytes = ByteArray(length.toInt())
+        var offset = 0
+        while (offset < bytes.size) {
+            val read = session.inputStream.read(bytes, offset, bytes.size - offset)
+            if (read <= 0) reject(Response.Status.BAD_REQUEST)
+            offset += read
+        }
+        if (bytes.isEmpty()) reject(Response.Status.BAD_REQUEST)
+        return bytes.toString(Charsets.UTF_8)
+    }
+
+    private fun allowRequest(identity: ChatPeerIdentity, sourceIp: InetAddress): Boolean {
+        val key = RateLimitKey(identity.playerId, sourceIp)
+        val now = System.nanoTime()
+        synchronized(rateLimitLock) {
+            val entries = requestTimes.getOrPut(key) { ArrayDeque() }
+            while (entries.peekFirst()?.let { now - it > RATE_WINDOW_NANOS } == true) entries.removeFirst()
+            if (entries.size >= RATE_MAX_REQUESTS) return false
+            entries.addLast(now)
+            if (requestTimes.size > RATE_KEY_LIMIT) {
+                requestTimes.entries.removeIf { it.value.isEmpty() }
+            }
+            return true
+        }
+    }
+
+    private fun storeMessage(message: ChatWireMessage): Boolean {
+        val encodedSize = runCatching {
+            MctierJson.encodeToString(ChatWireMessage.serializer(), message).toByteArray(Charsets.UTF_8).size
+        }.getOrNull() ?: return false
+        if (encodedSize > ChatMaxHistoryBytes) return false
+        synchronized(historyLock) {
+            if (messages.any { it.id == message.id }) return false
+            while (messages.size >= ChatMaxHistoryMessages || historyBytes + encodedSize > ChatMaxHistoryBytes) {
+                if (messages.isEmpty()) break
+                val removed = messages.removeFirst()
+                historyBytes = (historyBytes - encodedSizeOf(removed)).coerceAtLeast(0)
+            }
+            historyBytes += encodedSize
+            messages.addLast(message)
+        }
+        return true
+    }
+
+    private fun encodedSizeOf(message: ChatWireMessage): Int = runCatching {
+        MctierJson.encodeToString(ChatWireMessage.serializer(), message).toByteArray(Charsets.UTF_8).size
+    }.getOrDefault(0)
+
+    private fun isValidMessage(message: ChatWireMessage, hostId: String?, checkHost: Boolean): Boolean {
+        if (!isMessageIdForPlayer(message.id, message.playerId)) return false
+        if (message.content.toByteArray(Charsets.UTF_8).size > MAX_CONTENT_BYTES) return false
+        if (message.playerId.isBlank() || message.playerId.toByteArray(Charsets.UTF_8).size > MAX_ID_BYTES) return false
+        if (message.playerName.isBlank() || message.playerName.toByteArray(Charsets.UTF_8).size > MAX_PLAYER_NAME_BYTES || message.playerName.any { it.isISOControl() }) return false
+        if (checkHost && message.messageType == "announce" && hostId != message.playerId) return false
+        return when (message.messageType.lowercase(Locale.US)) {
+            "text" -> message.content.isNotEmpty() && message.contentBytes() <= MAX_TEXT_BYTES && message.imageData == null
+            "image" -> message.contentBytes() <= MAX_IMAGE_CONTENT_BYTES && validImage(message.imageData)
+            "announce" -> message.contentBytes() <= MAX_ANNOUNCE_BYTES && message.imageData == null
+            "voicegroup" -> message.contentBytes() <= MAX_VOICE_GROUP_BYTES &&
+                message.imageData == null && message.content.toIntOrNull()?.let { it in 0..4 } == true
+            "clipboard" -> message.contentBytes() <= MAX_CLIPBOARD_BYTES && message.imageData == null
+            "todo" -> message.contentBytes() <= MAX_TODO_BYTES && message.imageData == null
+            "whiteboard" -> message.contentBytes() <= MAX_WHITEBOARD_BYTES && message.imageData == null
+            "recall" -> message.content.isNotEmpty() && message.contentBytes() <= MAX_RECALL_BYTES &&
+                message.imageData == null && validRecall(message)
+            "avatar" -> message.contentBytes() <= MAX_AVATAR_BYTES && message.imageData == null &&
+                (message.content.isEmpty() || message.content.startsWith("data:image/"))
+            else -> false
+        }
+    }
+
+    private fun validRecall(message: ChatWireMessage): Boolean {
+        val now = System.currentTimeMillis() / 1000L
+        val target = synchronized(historyLock) { messages.lastOrNull { it.id == message.content } } ?: return false
+        return target.playerId == message.playerId && now >= target.timestamp && now - target.timestamp <= RECALL_WINDOW_SECS
+    }
+
+    private fun validImage(image: List<Int>?): Boolean = image != null && image.isNotEmpty() &&
+        image.size <= MAX_IMAGE_BYTES && image.all { it in 0..255 }
+
+    private fun ChatWireMessage.contentBytes(): Int = content.toByteArray(Charsets.UTF_8).size
+
+    private fun singleHeader(session: IHTTPSession, name: String): String? {
+        val matches = session.headers.entries.filter { it.key.equals(name, ignoreCase = true) }
+        return if (matches.size == 1) matches.single().value else null
+    }
+
+    private fun withCors(response: Response, origin: String?): Response = LanCors.apply(response, origin)
 
     private fun json(value: List<ChatWireMessage>, origin: String?): Response =
         withCors(newFixedLengthResponse(
@@ -194,12 +321,113 @@ class ChatHttpServer(
         ), origin)
 
     private fun json(value: ChatWireMessage, origin: String?): Response =
-        withCors(newFixedLengthResponse(Response.Status.OK, "application/json; charset=utf-8", MctierJson.encodeToString(ChatWireMessage.serializer(), value)), origin)
+        withCors(newFixedLengthResponse(
+            Response.Status.OK,
+            "application/json; charset=utf-8",
+            MctierJson.encodeToString(ChatWireMessage.serializer(), value),
+        ), origin)
+
+    private data class AuthSession(
+        val token: String,
+        val tokenEpoch: Long,
+        val local: ChatPeerIdentity,
+        val hostId: String?,
+        val identities: Map<InetAddress, ChatPeerIdentity>,
+    )
+
+    private data class AuthenticatedRequest(
+        val hostId: String?,
+        val sourceIp: InetAddress,
+        val identity: ChatPeerIdentity,
+    )
+
+    private data class RateLimitKey(val playerId: String, val ip: InetAddress)
+
+    private class RequestRejected(val status: Response.Status) : RuntimeException()
 
     companion object {
         private const val TAG = "ChatHttpServer"
+        private const val MAX_ID_BYTES = 128
+        private const val MAX_PLAYER_NAME_BYTES = 256
+        private const val MAX_CONTENT_BYTES = 512 * 1024
+        private const val MAX_TEXT_BYTES = 16 * 1024
+        private const val MAX_IMAGE_BYTES = 512 * 1024
+        private const val MAX_IMAGE_CONTENT_BYTES = 256
+        private const val MAX_ANNOUNCE_BYTES = 16 * 1024
+        private const val MAX_VOICE_GROUP_BYTES = 32
+        private const val MAX_CLIPBOARD_BYTES = 16 * 1024
+        private const val MAX_TODO_BYTES = 64 * 1024
+        private const val MAX_WHITEBOARD_BYTES = 64 * 1024
+        private const val MAX_RECALL_BYTES = 128
+        private const val MAX_AVATAR_BYTES = 192 * 1024
+        private const val RECALL_WINDOW_SECS = 2 * 60
+        private const val RATE_MAX_REQUESTS = 12
+        private const val RATE_KEY_LIMIT = 256
+        private const val RATE_WINDOW_NANOS = 3_000_000_000L
+        private const val MAX_PEERS = ChatMaxHistoryMessages
 
-        /** 兜底监听地址：仅在拿不到虚拟 IP 时使用。 */
-        const val DEFAULT_BIND_IP = "0.0.0.0"
+        /** Numeric, specific virtual IP only; wildcard and loopback binds are rejected. */
+        private fun requireBindIp(raw: String): String =
+            parseUsableIp(raw)?.hostAddress ?: throw IllegalArgumentException("Chat server requires a specific virtual IP")
+
+        internal fun parseUsableIp(raw: String): InetAddress? {
+            val value = raw.trim()
+            if (value.isEmpty() || value.contains('%')) return null
+            val numeric = if (value.contains(':')) {
+                value.matches(Regex("[0-9A-Fa-f:]+"))
+            } else {
+                value.matches(Regex("[0-9.]+"))
+            }
+            if (!numeric) return null
+            return runCatching { InetAddress.getByName(value) }.getOrNull()?.takeIf {
+                it is Inet4Address &&
+                    it.address.sliceArray(0..2).contentEquals(byteArrayOf(10, 126, 126)) &&
+                    (it.address[3].toInt() and 0xff) in 1..254
+            }
+        }
+
+        private fun normalizeIdentity(identity: ChatPeerIdentity): ChatPeerIdentity? {
+            val ip = parseUsableIp(identity.virtualIp) ?: return null
+            val normalizedIp = ip.hostAddress ?: return null
+            if (identity.playerId.isBlank() || identity.playerId.toByteArray(Charsets.UTF_8).size > MAX_ID_BYTES) return null
+            if (identity.playerName.isBlank() || identity.playerName.toByteArray(Charsets.UTF_8).size > MAX_PLAYER_NAME_BYTES || identity.playerName.any { it.isISOControl() }) return null
+            if (identity.playerId.any { it.isISOControl() }) return null
+            return identity.copy(virtualIp = normalizedIp)
+        }
+
+        private fun buildIdentityMap(
+            local: ChatPeerIdentity,
+            peers: List<ChatPeerIdentity>,
+        ): Map<InetAddress, ChatPeerIdentity>? {
+            val map = LinkedHashMap<InetAddress, ChatPeerIdentity>()
+            val ids = HashSet<String>()
+            val all = sequenceOf(local).plus(peers.asSequence().take(MAX_PEERS))
+            for (raw in all) {
+                val identity = normalizeIdentity(raw) ?: return null
+                val ip = parseUsableIp(identity.virtualIp) ?: return null
+                if (!ids.add(identity.playerId) || map.put(ip, identity) != null) return null
+            }
+            return map
+        }
+
+        private fun isValidChatToken(token: String): Boolean =
+            token.length == ChatTokenHexLength && token.all { it.isDigit() || it.lowercaseChar() in 'a'..'f' }
+
+        private fun isMessageIdForPlayer(id: String, playerId: String): Boolean {
+            if (id.isBlank() || id.toByteArray(Charsets.UTF_8).size > MAX_ID_BYTES || id.any { it.isISOControl() }) return false
+            return listOf("msg-$playerId-", "recall-$playerId-").any { prefix ->
+                id.startsWith(prefix) && id.length > prefix.length
+            }
+        }
+
+        private fun isValidHostId(
+            hostId: String?,
+            identities: Map<InetAddress, ChatPeerIdentity>,
+        ): Boolean = hostId == null || identities.values.any { it.playerId == hostId }
+
+        private fun constantTimeEquals(left: String, right: String): Boolean =
+            MessageDigest.isEqual(left.toByteArray(Charsets.UTF_8), right.toByteArray(Charsets.UTF_8))
+
+        private fun reject(status: Response.Status): Nothing = throw RequestRejected(status)
     }
 }

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/ChatP2PClient.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/ChatP2PClient.kt
@@ -7,114 +7,167 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import top.pmh13.mctier.data.ChatPeerIdentity
 import top.pmh13.mctier.data.ChatSendRequest
-import top.pmh13.mctier.data.ChatServerPort
 import top.pmh13.mctier.data.ChatWireMessage
 import top.pmh13.mctier.data.MctierWireJson
 import java.util.Collections
+import java.util.LinkedHashSet
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 /**
- * P2P 聊天客户端。
+ * P2P chat client.
  *
- * [bindIp] 为 EasyTier 分配的虚拟网卡地址，透传给内部的 [ChatHttpServer]，
- * 使聊天服务只监听虚拟网卡而不是 `0.0.0.0`（见 issue #17）。
+ * The HTTP listener is deliberately inert until the signaling session has
+ * supplied a valid chat token and epoch. Peer destinations and message
+ * identities are populated from the same authenticated signaling snapshot.
  */
 class ChatP2PClient(
     private val playerId: String,
     private val scope: CoroutineScope,
-    bindIp: String = ChatHttpServer.DEFAULT_BIND_IP,
+    private val bindIp: String,
     private val onMessage: (ChatWireMessage) -> Unit,
 ) {
     private val client = OkHttpClient.Builder()
         .connectTimeout(3, TimeUnit.SECONDS)
         .callTimeout(15, TimeUnit.SECONDS)
+        .followRedirects(false)
+        .followSslRedirects(false)
         .build()
-    private val server = ChatHttpServer(playerId, bindIp).also { it.onMessageReceived = { m -> accept(m) } }
-    private val seen = Collections.synchronizedSet(HashSet<String>())
+    private val server = ChatHttpServer(playerId, bindIp).also { it.onMessageReceived = { message -> accept(message) } }
+    private val seen = Collections.synchronizedSet(LinkedHashSet<String>())
 
-    @Volatile private var peerIps: List<String> = emptyList()
+    @Volatile private var peerIdentities: List<ChatPeerIdentity> = emptyList()
+    @Volatile private var localPlayerName: String = ""
+    @Volatile private var started = false
 
-    fun start() {
-        runCatching { server.start(5000, false) }
-            .onFailure { Log.w(TAG, "Chat server start failed: ${it.message}") }
+    /** Install the first session or a newer registration snapshot. */
+    fun configureSession(token: String, tokenEpoch: Long, playerName: String, hostId: String?): Boolean {
+        localPlayerName = playerName
+        val local = ChatPeerIdentity(playerId, playerName, bindIp)
+        return server.configureSession(token, tokenEpoch, local, peerIdentities, hostId)
+    }
+
+    /** Apply a signaling-issued token rotation. Lower epochs are ignored. */
+    fun rotateToken(token: String, tokenEpoch: Long): Boolean = server.rotateToken(token, tokenEpoch)
+
+    fun updateHostId(hostId: String?): Boolean = server.updateHostId(hostId)
+
+    fun isReady(): Boolean = server.hasSession()
+
+    fun isAuthoritativePeer(expectedPlayerId: String, rawIp: String): Boolean {
+        if (!server.hasSession()) return false
+        val ip = ChatHttpServer.parseUsableIp(rawIp)?.hostAddress ?: return false
+        return peerIdentities.any { it.playerId == expectedPlayerId && it.virtualIp == ip }
+    }
+
+    /** Start only after [configureSession] succeeds. */
+    fun start(): Boolean {
+        if (!server.hasSession()) {
+            Log.w(TAG, "Chat server start refused before authenticated session")
+            return false
+        }
+        if (started) return true
+        return runCatching {
+            server.start(5000, false)
+            started = true
+            true
+        }.onFailure { Log.w(TAG, "Chat server start failed: ${it.message}") }.getOrDefault(false)
     }
 
     fun stop() {
+        started = false
         runCatching { server.stop() }
-        server.clear()
+        server.clearSession()
         seen.clear()
-        peerIps = emptyList()
+        peerIdentities = emptyList()
+        localPlayerName = ""
     }
 
-    fun setPeers(ips: List<String>) {
-        peerIps = ips.filter { it.isNotBlank() }
+    /** Update the authoritative peer IP-to-player map from signaling. */
+    fun setPeers(peers: List<ChatPeerIdentity>): Boolean {
+        val normalized = peers
+            .asSequence()
+            .filter { it.playerId.isNotBlank() && it.playerId != playerId }
+            .mapNotNull { peer ->
+                ChatHttpServer.parseUsableIp(peer.virtualIp)?.hostAddress?.let { ip -> peer.copy(virtualIp = ip) }
+            }
+            .toList()
+        if (
+            normalized.size > MAX_PEERS ||
+            normalized.map { it.playerId }.distinct().size != normalized.size ||
+            normalized.map { it.virtualIp }.distinct().size != normalized.size
+        ) {
+            Log.w(TAG, "Rejected duplicate or oversized chat peer snapshot")
+            return false
+        }
+        if (server.hasSession() && !server.updatePeers(normalized)) {
+            Log.w(TAG, "Rejected invalid chat peer identity snapshot")
+            return false
+        }
+        peerIdentities = normalized
+        return true
     }
 
-    /**
-     * 下发大厅身份名册（playerId -> 虚拟IP，含自己）。
-     *
-     * 内部聊天服务器据此校验收到的消息是否来自其自称的玩家，
-     * 避免同大厅成员冒用他人身份发言。
-     */
-    fun setPeerRoster(roster: Map<String, String>) {
-        server.setPeerRoster(roster)
-    }
-
-    /**
-     * 下发允许读取本机聊天记录的成员 IP。
-     *
-     * 读取类接口不携带 playerId，只能按来源 IP 判断，因此与名册分开下发；
-     * 仅在所有成员虚拟IP均已就绪时传入非空集合。
-     */
-    fun setAllowedReaders(ips: Collection<String>) {
-        server.setAllowedReaders(ips)
-    }
-
-    fun sendText(playerName: String, content: String): ChatWireMessage =
+    fun sendText(playerName: String, content: String): ChatWireMessage? =
         sendInternal(playerName, content, "text", null)
 
-    fun sendImage(playerName: String, imageBytes: List<Int>): ChatWireMessage =
+    fun sendImage(playerName: String, imageBytes: List<Int>): ChatWireMessage? =
         sendInternal(playerName, "[Image]", "image", imageBytes)
 
-    fun sendAnnounce(playerName: String, text: String): ChatWireMessage =
+    fun sendAnnounce(playerName: String, text: String): ChatWireMessage? =
         sendInternal(playerName, text, "announce", null)
 
-    fun sendVoiceGroup(playerName: String, group: Int): ChatWireMessage =
+    fun sendVoiceGroup(playerName: String, group: Int): ChatWireMessage? =
         sendInternal(playerName, group.toString(), "voicegroup", null)
 
     /** 多人协同待办：content 为待办列表 JSON（与桌面端一致，后写覆盖全队同步） */
-    fun sendTodo(playerName: String, todosJson: String): ChatWireMessage =
+    fun sendTodo(playerName: String, todosJson: String): ChatWireMessage? =
         sendInternal(playerName, todosJson, "todo", null)
 
-    fun sendRecall(playerName: String, messageId: String): ChatWireMessage =
+    fun sendRecall(playerName: String, messageId: String): ChatWireMessage? =
         sendInternal(playerName, messageId, "recall", null)
 
-    fun sendAvatar(avatarData: String?): ChatWireMessage =
-        sendInternal("", avatarData.orEmpty(), "avatar", null)
+    fun sendAvatar(avatarData: String?): ChatWireMessage? =
+        sendInternal(localPlayerName, avatarData.orEmpty(), "avatar", null)
 
-    private fun sendInternal(playerName: String, content: String, type: String, imageData: List<Int>?): ChatWireMessage {
-        val id = "msg-$playerId-${System.currentTimeMillis()}"
-        val msg = ChatWireMessage(id, playerId, playerName, content, type, System.currentTimeMillis() / 1000, imageData)
-        seen.add(id)
-        server.addLocal(msg)
-        val req = ChatSendRequest(id, playerId, playerName, content, type, imageData)
+    private fun sendInternal(playerName: String, content: String, type: String, imageData: List<Int>?): ChatWireMessage? {
+        if (!server.hasSession()) {
+            Log.w(TAG, "Chat send suppressed before authenticated session")
+            return null
+        }
+        val effectiveName = localPlayerName.ifBlank { playerName }
+        val id = "msg-$playerId-${System.currentTimeMillis()}-${UUID.randomUUID()}"
+        val msg = ChatWireMessage(id, playerId, effectiveName, content, type, System.currentTimeMillis() / 1000L, imageData)
+        if (!server.addLocal(msg)) {
+            Log.w(TAG, "Rejected invalid or duplicate local chat message")
+            return null
+        }
+        remember(id)
+        val req = ChatSendRequest(id, playerId, effectiveName, content, type, imageData)
         val body = MctierWireJson.encodeToString(ChatSendRequest.serializer(), req)
-        peerIps.forEach { ip -> scope.launch { postWithRetry(ip, body) } }
+        peerIdentities.map { it.virtualIp }.distinct().forEach { ip ->
+            scope.launch { postWithRetry(ip, body) }
+        }
         return msg
     }
 
     private fun accept(msg: ChatWireMessage) {
-        if (!seen.add(msg.id)) return
+        if (!server.isKnownPeer(msg)) return
         if (msg.playerId == playerId) return
+        if (!remember(msg.id)) return
         onMessage(msg)
     }
 
     private fun postWithRetry(ip: String, body: String) {
         repeat(2) { attempt ->
+            val token = server.currentToken()
+            if (token == null) return
             val ok = runCatching {
                 val req = Request.Builder()
-                    .url("http://$ip:$ChatServerPort/api/chat/send")
+                    .url("http://${formatHost(ip)}:14540/api/chat/send")
+                    .header(ChatTokenHeader, token)
                     .post(body.toRequestBody("application/json".toMediaType()))
                     .build()
                 client.newCall(req).execute().use { it.isSuccessful }
@@ -124,7 +177,21 @@ class ChatP2PClient(
         }
     }
 
+    private fun remember(id: String): Boolean = synchronized(seen) {
+        if (!seen.add(id)) return false
+        while (seen.size > MAX_SEEN_IDS) {
+            val first = seen.firstOrNull() ?: break
+            seen.remove(first)
+        }
+        true
+    }
+
+    private fun formatHost(ip: String): String = if (ip.contains(':')) "[$ip]" else ip
+
     private companion object {
         private const val TAG = "ChatP2PClient"
+        private const val MAX_SEEN_IDS = 1000
+        private const val MAX_PEERS = 64
+        private const val ChatTokenHeader = "x-mctier-chat-token"
     }
 }

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/FileShareHttpServer.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/FileShareHttpServer.kt
@@ -9,58 +9,68 @@ import kotlinx.serialization.encodeToString
 import top.pmh13.mctier.data.FileSharePort
 import top.pmh13.mctier.data.MctierJson
 import top.pmh13.mctier.data.SharedFolder
+import java.net.Inet4Address
+import java.net.InetAddress
 import java.net.URLDecoder
+import java.util.ArrayDeque
+import java.util.concurrent.ConcurrentHashMap
+
+private const val MaxVerifyBodyBytes = 16 * 1024
+private const val LobbyTokenHeader = "x-mctier-lobby-token"
+private const val LobbyTokenHexLength = 64
+
+private fun requireOverlayBindIp(bindIp: String): String {
+    val candidate = bindIp.trim()
+    require(candidate.isNotEmpty()) { "EasyTier virtual IP is required" }
+    val numeric = candidate.all { it in '0'..'9' || it == '.' } && candidate.count { it == '.' } == 3
+    require(numeric) { "EasyTier virtual IP must be a numeric address" }
+    val address = runCatching { InetAddress.getByName(candidate) }
+        .getOrNull()
+        ?: error("EasyTier virtual IP is invalid")
+    require(
+        address is Inet4Address &&
+            address.address.sliceArray(0..2).contentEquals(byteArrayOf(10, 126, 126)) &&
+            (address.address[3].toInt() and 0xff) in 1..254
+    ) {
+        "EasyTier virtual IP must be a concrete overlay address"
+    }
+    return address.hostAddress ?: candidate
+}
 
 /**
  * 文件共享 HTTP 服务。
  *
  * [bindIp] 为 EasyTier 分配的虚拟网卡地址。只绑定该地址（而非 `0.0.0.0`），
  * 可避免服务同时暴露在 Wi-Fi / 蜂窝等物理网络接口上被同网段任意设备访问。
- * 若调用方暂时拿不到虚拟 IP，会退回 `0.0.0.0` 以保证功能可用（见 issue #17）。
  */
 class FileShareHttpServer(
     private val context: Context,
     private val ownerId: String,
-    bindIp: String = DEFAULT_BIND_IP,
-) : NanoHTTPD(bindIp.ifBlank { DEFAULT_BIND_IP }, FileSharePort) {
-    private val folders = linkedMapOf<String, SharedFolder>()
+    bindIp: String,
+) : NanoHTTPD(requireOverlayBindIp(bindIp), FileSharePort) {
+    private val folders = ConcurrentHashMap<String, SharedFolder>()
+    private val passwordFailureLock = Any()
+    private val passwordFailures = HashMap<String, ArrayDeque<Long>>()
+    private val lobbyTokenLock = Any()
+    private var lobbyToken: String? = null
+    private var lobbyTokenEpoch: Long = 0L
 
-    /**
-     * 允许访问共享的大厅成员虚拟 IP 集合。
-     *
-     * EasyTier 的网络名与密钥在大厅存续期间不变，被房主移出大厅的玩家仍可能留在
-     * 虚拟网内。若不校验来源，其仍能继续浏览与下载本机共享内容。
-     */
-    @Volatile
-    private var allowedPeers: Set<String> = emptySet()
-
-    /** 更新可访问成员集合（含自己，便于本机自查） */
-    fun setAllowedPeers(ips: Collection<String>) {
-        allowedPeers = ips.filter { it.isNotBlank() }.toSet()
+    fun configureLobbyToken(token: String, epoch: Long): Boolean {
+        if (token.length != LobbyTokenHexLength || token.any { !it.isDigit() && it.lowercaseChar() !in 'a'..'f' } || epoch <= 0L) {
+            return false
+        }
+        synchronized(lobbyTokenLock) {
+            if (epoch < lobbyTokenEpoch) return false
+            if (epoch == lobbyTokenEpoch && lobbyToken != null && lobbyToken != token) return false
+            lobbyToken = token
+            lobbyTokenEpoch = epoch
+        }
+        return true
     }
 
-    /** 清空可访问成员集合（退出大厅时调用） */
-    fun clearAllowedPeers() {
-        allowedPeers = emptySet()
-    }
-
-    /**
-     * 判断调用方是否仍是本大厅成员。
-     *
-     * 与桌面端一致：名单为空时放行（尚未下发或对端为旧版本），
-     * 名单非空则要求来源 IP 在册。
-     */
-    internal fun isLobbyMember(remoteIp: String?): Boolean {
-        val allowed = allowedPeers
-        if (allowed.isEmpty()) return true
-        if (remoteIp.isNullOrBlank()) return true
-        return allowed.contains(normalizeIp(remoteIp))
-    }
-
-    /** 归一化来源地址：去掉 IPv6 映射前缀，便于与名单里的 IPv4 文本比较。 */
-    private fun normalizeIp(raw: String): String {
-        val ip = raw.trim()
-        return if (ip.startsWith("::ffff:")) ip.removePrefix("::ffff:") else ip
+    fun clearLobbyToken() = synchronized(lobbyTokenLock) {
+        lobbyToken = null
+        lobbyTokenEpoch = 0L
     }
 
     fun addFolder(folder: SharedFolder) {
@@ -78,15 +88,17 @@ class FileShareHttpServer(
         if (session.method == Method.OPTIONS) {
             return withCors(newFixedLengthResponse(Response.Status.OK, "text/plain", ""), origin)
         }
-        val path = session.uri.orEmpty()
-        // 成员校验：非本大厅成员一律拒绝浏览与下载
-        if (!isLobbyMember(session.remoteIpAddress)) {
-            return withCors(forbidden(), origin)
+        if (!authenticateLobby(session)) {
+            return withCors(unauthorized(), origin)
         }
+        val path = session.uri.orEmpty()
         val response = when {
-            path == "/api/shares" -> json(ShareListResponse(folders.values.map { it.toDto() }))
-            path.matches(Regex("/api/shares/[^/]+/files")) -> listFiles(path, session)
-            path.contains("/download/") -> download(path, session)
+            path == "/api/shares" -> json(
+                ShareListResponse(folders.values.filterNot { it.isExpired() }.map { it.toDto() })
+            )
+            path.matches(Regex("^/api/shares/[^/]+/files$")) && session.method == Method.GET -> listFiles(path, session)
+            path.matches(Regex("^/api/shares/[^/]+/verify$")) && session.method == Method.POST -> verify(path, session)
+            path.startsWith("/api/shares/") && path.contains("/download/") && session.method == Method.GET -> download(path, session)
             else -> newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "not found")
         }
         return withCors(response, origin)
@@ -101,20 +113,33 @@ class FileShareHttpServer(
     private fun withCors(response: Response, origin: String?): Response =
         LanCors.apply(response, origin)
 
+    private fun authenticateLobby(session: IHTTPSession): Boolean {
+        val expected = synchronized(lobbyTokenLock) { lobbyToken } ?: return false
+        val supplied = session.headers.entries
+            .filter { it.key.equals(LobbyTokenHeader, ignoreCase = true) }
+            .singleOrNull()
+            ?.value
+            ?: return false
+        return constantTimeEquals(supplied, expected)
+    }
+
     private fun listFiles(path: String, session: IHTTPSession): Response {
         val shareId = path.split("/").getOrNull(3) ?: return missing()
         val share = folders[shareId] ?: return missing()
+        if (share.isExpired()) return expired()
         if (!checkPassword(share, session)) return unauthorized()
         val requestedPath = session.parameters["path"]?.firstOrNull().orEmpty()
         val root = DocumentFile.fromTreeUri(context, Uri.parse(share.uri)) ?: return missing()
         val folder = findDocument(root, requestedPath) ?: return missing()
-        val files = folder.listFiles().map {
+        val files = folder.listFiles().mapNotNull { document ->
+            val name = document.name?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            if (!document.isDirectory && !document.isFile) return@mapNotNull null
             SharedFileInfo(
-                name = it.name.orEmpty(),
-                path = listOf(requestedPath, it.name.orEmpty()).filter { part -> part.isNotBlank() }.joinToString("/"),
-                size = it.length(),
-                isDir = it.isDirectory,
-                modified = it.lastModified(),
+                name = name,
+                path = listOf(requestedPath, name).filter { part -> part.isNotBlank() }.joinToString("/"),
+                size = document.length(),
+                isDir = document.isDirectory,
+                modified = document.lastModified(),
             )
         }.sortedWith(compareBy<SharedFileInfo> { !it.isDir }.thenBy { it.name.lowercase() })
         return json(FileList(files, requestedPath))
@@ -124,51 +149,156 @@ class FileShareHttpServer(
         val shareId = path.split("/").getOrNull(3) ?: return missing()
         val rawFilePath = path.substringAfter("/api/shares/$shareId/download/", "")
         val share = folders[shareId] ?: return missing()
+        if (share.isExpired()) return expired()
         if (!checkPassword(share, session)) return unauthorized()
         val root = DocumentFile.fromTreeUri(context, Uri.parse(share.uri)) ?: return missing()
-        val target = findDocument(root, URLDecoder.decode(rawFilePath, "UTF-8")) ?: return missing()
+        val decodedPath = runCatching { URLDecoder.decode(rawFilePath, "UTF-8") }.getOrNull()
+            ?: return badRequest()
+        val target = findDocument(root, decodedPath) ?: return missing()
         if (target.isDirectory) return newFixedLengthResponse(Response.Status.BAD_REQUEST, "text/plain", "directory")
         val fileLen = target.length()
         val rangeHeader = session.headers["range"]
         // 断点续传：解析 Range: bytes=start- 头，返回 206 PARTIAL_CONTENT
-        if (!rangeHeader.isNullOrBlank() && rangeHeader.startsWith("bytes=") && fileLen > 0) {
-            val spec = rangeHeader.removePrefix("bytes=").substringBefore(",")
-            val start = spec.substringBefore("-").toLongOrNull() ?: 0L
-            val end = spec.substringAfter("-", "").toLongOrNull() ?: (fileLen - 1)
-            if (start in 0 until fileLen) {
-                val realEnd = end.coerceIn(start, fileLen - 1)
-                val len = realEnd - start + 1
-                val input = context.contentResolver.openInputStream(target.uri) ?: return missing()
-                var skipped = 0L
-                while (skipped < start) {
-                    val s = input.skip(start - skipped)
-                    if (s <= 0) break
-                    skipped += s
+        if (!rangeHeader.isNullOrBlank()) {
+            if (fileLen <= 0) return rangeNotSatisfiable(fileLen)
+            val match = Regex("^bytes=(?:(\\d+)-(\\d*)|-(\\d+))$", RegexOption.IGNORE_CASE)
+                .matchEntire(rangeHeader.trim())
+                ?: return rangeNotSatisfiable(fileLen)
+            val suffixText = match.groupValues[3]
+            val (start, realEnd) = if (suffixText.isNotEmpty()) {
+                val suffixLength = suffixText.toLongOrNull()
+                    ?.takeIf { it > 0 }
+                    ?: return rangeNotSatisfiable(fileLen)
+                fileLen - suffixLength.coerceAtMost(fileLen) to fileLen - 1
+            } else {
+                val rangeStart = match.groupValues[1].toLongOrNull()
+                    ?: return rangeNotSatisfiable(fileLen)
+                val endText = match.groupValues[2]
+                val rangeEnd = if (endText.isEmpty()) {
+                    fileLen - 1
+                } else {
+                    endText.toLongOrNull()?.coerceAtMost(fileLen - 1)
+                        ?: return rangeNotSatisfiable(fileLen)
                 }
-                return newFixedLengthResponse(Response.Status.PARTIAL_CONTENT, "application/octet-stream", input, len).apply {
-                    addHeader("Content-Disposition", "attachment; filename=\"${target.name.orEmpty()}\"")
-                    addHeader("Accept-Ranges", "bytes")
-                    addHeader("Content-Range", "bytes $start-$realEnd/$fileLen")
+                if (rangeStart !in 0 until fileLen || rangeEnd < rangeStart) {
+                    return rangeNotSatisfiable(fileLen)
                 }
+                rangeStart to rangeEnd
+            }
+            val len = realEnd - start + 1
+            val input = context.contentResolver.openInputStream(target.uri) ?: return missing()
+            var skipped = 0L
+            while (skipped < start) {
+                val amount = input.skip(start - skipped)
+                if (amount <= 0) {
+                    if (input.read() < 0) {
+                        runCatching { input.close() }
+                        return rangeNotSatisfiable(fileLen)
+                    }
+                    skipped += 1
+                } else {
+                    skipped += amount
+                }
+            }
+            return newFixedLengthResponse(Response.Status.PARTIAL_CONTENT, "application/octet-stream", input, len).apply {
+                addHeader("Content-Disposition", contentDisposition(target.name))
+                addHeader("Accept-Ranges", "bytes")
+                addHeader("Content-Range", "bytes $start-$realEnd/$fileLen")
             }
         }
         val input = context.contentResolver.openInputStream(target.uri) ?: return missing()
         return if (fileLen > 0) {
             newFixedLengthResponse(Response.Status.OK, "application/octet-stream", input, fileLen).apply {
-                addHeader("Content-Disposition", "attachment; filename=\"${target.name.orEmpty()}\"")
+                addHeader("Content-Disposition", contentDisposition(target.name))
                 addHeader("Accept-Ranges", "bytes")
             }
         } else {
+            // Some SAF providers report 0 when the length is unknown. A
+            // chunked response preserves the content and is also valid for a
+            // genuinely empty file.
             newChunkedResponse(Response.Status.OK, "application/octet-stream", input).apply {
-                addHeader("Content-Disposition", "attachment; filename=\"${target.name.orEmpty()}\"")
+                addHeader("Content-Disposition", contentDisposition(target.name))
+                addHeader("Accept-Ranges", "bytes")
             }
         }
     }
 
+    private fun verify(path: String, session: IHTTPSession): Response {
+        val shareId = path.split("/").getOrNull(3) ?: return missing()
+        val share = folders[shareId] ?: return missing()
+        if (share.isExpired()) return expired()
+        val body = readRequestBody(session) ?: return badRequest()
+        val request = runCatching {
+            MctierJson.decodeFromString(VerifyPasswordRequest.serializer(), body)
+        }.getOrNull() ?: return badRequest()
+        val expected = share.password?.takeIf { it.isNotBlank() }
+        val success = expected == null || checkPassword(share, session, request.password)
+        return json(VerifyPasswordResponse(success, if (success) "验证成功" else "密码错误"))
+    }
+
+    private fun readRequestBody(session: IHTTPSession): String? {
+        if (session.headers.keys.any { it.equals("transfer-encoding", ignoreCase = true) }) return null
+        val mediaType = session.headers.entries
+            .firstOrNull { it.key.equals("content-type", ignoreCase = true) }
+            ?.value
+            ?.substringBefore(';')
+            ?.trim()
+        if (!mediaType.equals("application/json", ignoreCase = true)) return null
+        val length = session.headers["content-length"]?.toLongOrNull() ?: return null
+        if (length <= 0 || length > MaxVerifyBodyBytes) return null
+        val bytes = ByteArray(length.toInt())
+        var offset = 0
+        while (offset < bytes.size) {
+            val read = session.inputStream.read(bytes, offset, bytes.size - offset)
+            if (read <= 0) return null
+            offset += read
+        }
+        return String(bytes, Charsets.UTF_8)
+    }
+
     private fun checkPassword(share: SharedFolder, session: IHTTPSession): Boolean {
-        val expected = share.password
-        if (expected.isNullOrEmpty()) return true
-        return constantTimeEquals(session.headers["x-share-password"].orEmpty(), expected)
+        val expected = share.password?.takeIf { it.isNotBlank() } ?: return true
+        return checkPassword(share, session, session.headers["x-share-password"].orEmpty(), expected)
+    }
+
+    private fun checkPassword(share: SharedFolder, session: IHTTPSession, supplied: String): Boolean {
+        val expected = share.password?.takeIf { it.isNotBlank() } ?: return true
+        return checkPassword(share, session, supplied, expected)
+    }
+
+    private fun checkPassword(
+        share: SharedFolder,
+        session: IHTTPSession,
+        supplied: String,
+        expected: String,
+    ): Boolean {
+        val key = "${session.remoteIpAddress}|${share.id}"
+        val now = System.currentTimeMillis()
+        synchronized(passwordFailureLock) {
+            val iterator = passwordFailures.iterator()
+            while (iterator.hasNext()) {
+                val entry = iterator.next()
+                while (entry.value.peekFirst()?.let { now - it > PasswordFailureWindowMs } == true) {
+                    entry.value.removeFirst()
+                }
+                if (entry.value.isEmpty()) iterator.remove()
+            }
+            if (!passwordFailures.containsKey(key) && passwordFailures.size >= MaxPasswordFailureKeys) {
+                return false
+            }
+            val failures = passwordFailures.getOrPut(key) { ArrayDeque() }
+            if (failures.size >= MaxPasswordFailures) return false
+        }
+
+        val valid = constantTimeEquals(supplied, expected)
+        synchronized(passwordFailureLock) {
+            if (valid) {
+                passwordFailures.remove(key)
+            } else {
+                passwordFailures.getOrPut(key) { ArrayDeque() }.addLast(now)
+            }
+        }
+        return valid
     }
 
     /**
@@ -189,18 +319,37 @@ class FileShareHttpServer(
 
     private fun findDocument(root: DocumentFile, relPath: String): DocumentFile? {
         if (relPath.isBlank()) return root
-        if (relPath.contains("..")) return null
-        return relPath.split("/").filter { it.isNotBlank() }.fold(root as DocumentFile?) { current, name ->
+        val parts = relPath.split('/')
+        if (parts.any { it.isBlank() || it == "." || it == ".." || it.contains('\\') || it.contains('\u0000') }) {
+            return null
+        }
+        return parts.fold(root as DocumentFile?) { current, name ->
             current?.listFiles()?.firstOrNull { it.name == name }
         }
     }
+
+    private fun contentDisposition(name: String?): String {
+        val safeName = name.orEmpty().map { ch ->
+            if (ch == '"' || ch == '\\' || ch.isISOControl()) '_' else ch
+        }.joinToString("").ifBlank { "download" }
+        return "attachment; filename=\"$safeName\""
+    }
+
+    private fun SharedFolder.isExpired(nowMillis: Long = System.currentTimeMillis()): Boolean =
+        expireAt?.let { it <= nowMillis } == true
 
     private inline fun <reified T> json(value: T): Response =
         newFixedLengthResponse(Response.Status.OK, "application/json", MctierJson.encodeToString(value))
 
     private fun missing(): Response = newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "not found")
-    private fun forbidden(): Response = newFixedLengthResponse(Response.Status.FORBIDDEN, "text/plain", "forbidden")
+    private fun badRequest(): Response = newFixedLengthResponse(Response.Status.BAD_REQUEST, "text/plain", "invalid request")
+    private fun expired(): Response = newFixedLengthResponse(Response.Status.GONE, "text/plain", "share expired")
     private fun unauthorized(): Response = newFixedLengthResponse(Response.Status.UNAUTHORIZED, "text/plain", "unauthorized")
+    private fun rangeNotSatisfiable(fileLen: Long): Response =
+        newFixedLengthResponse(Response.Status.RANGE_NOT_SATISFIABLE, "text/plain", "range not satisfiable").apply {
+            addHeader("Content-Range", "bytes */$fileLen")
+            addHeader("Accept-Ranges", "bytes")
+        }
 
     @Serializable
     private data class ShareListResponse(val shares: List<ShareDto>)
@@ -220,12 +369,18 @@ class FileShareHttpServer(
     private fun SharedFolder.toDto(): ShareDto = ShareDto(
         id = id,
         name = name,
-        hasPassword = !password.isNullOrBlank(),
+        hasPassword = !password.isNullOrBlank() && password.isNotBlank(),
         expireTime = expireAt?.let { it / 1000 },
         compressBeforeSend = compressBeforeSend,
         ownerId = ownerId,
         createdAt = createdAt / 1000,
     )
+
+    @Serializable
+    private data class VerifyPasswordRequest(val password: String)
+
+    @Serializable
+    private data class VerifyPasswordResponse(val success: Boolean, val message: String)
 
     @Serializable
     private data class FileList(val files: List<SharedFileInfo>, val current_path: String)
@@ -239,8 +394,9 @@ class FileShareHttpServer(
         val modified: Long,
     )
 
-    companion object {
-        /** 兜底监听地址：仅在拿不到虚拟 IP 时使用。 */
-        const val DEFAULT_BIND_IP = "0.0.0.0"
+    private companion object {
+        const val MaxPasswordFailures = 10
+        const val MaxPasswordFailureKeys = 4096
+        const val PasswordFailureWindowMs = 30_000L
     }
 }

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/LanCors.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/LanCors.kt
@@ -48,7 +48,7 @@ internal object LanCors {
             response.addHeader("Access-Control-Allow-Origin", origin)
             response.addHeader("Vary", "Origin")
             response.addHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            response.addHeader("Access-Control-Allow-Headers", "Content-Type, Range, X-Share-Password")
+            response.addHeader("Access-Control-Allow-Headers", "Content-Type, Range, X-Share-Password, X-MCTier-Chat-Token")
             response.addHeader("Access-Control-Expose-Headers", EXPOSED_HEADERS)
             response.addHeader("Access-Control-Max-Age", "86400")
         }

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/LobbyInviteCodec.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/LobbyInviteCodec.kt
@@ -2,7 +2,9 @@ package top.pmh13.mctier.network
 
 import java.net.URLDecoder
 import java.net.URLEncoder
+import java.net.URI
 import java.nio.charset.StandardCharsets
+import java.util.Locale
 
 data class LobbyInviteData(
     val name: String,
@@ -12,6 +14,54 @@ data class LobbyInviteData(
 )
 
 object LobbyInviteCodec {
+    private val EasyTierSchemes = setOf("tcp", "udp", "ws", "wss", "txt")
+    private val SignalingSchemes = setOf("ws", "wss")
+
+    /** Keep values safe before they reach the EasyTier TOML/config or WebSocket URL boundary. */
+    fun isValidLobbyName(value: String): Boolean {
+        if (value.any(::isUnsafeControl)) return false
+        val text = value.trim()
+        if (text.length !in 4..32) return false
+        val hasAlnum = text.any {
+            it in 'a'..'z' || it in 'A'..'Z' || it in '0'..'9' || it in '\u4e00'..'\u9fa5'
+        }
+        if (!hasAlnum) return false
+        return text.all {
+            it in 'a'..'z' || it in 'A'..'Z' || it in '0'..'9' ||
+                it == '_' || it == '-' || it == ' ' || it in '\u4e00'..'\u9fa5'
+        }
+    }
+
+    fun isValidLobbyPassword(value: String): Boolean {
+        if (value.any(::isUnsafeControl)) return false
+        val text = value.trim()
+        if (text.isEmpty()) return true
+        if (text.length !in 8..32) return false
+        if (text.any(::isUnsafeControl)) return false
+        val hasLetter = text.any { it in 'a'..'z' || it in 'A'..'Z' }
+        val hasDigit = text.any { it in '0'..'9' }
+        return hasLetter && hasDigit
+    }
+
+    fun isValidEasyTierNode(value: String): Boolean = isValidEndpoint(value, EasyTierSchemes)
+
+    fun isValidSignalingServer(value: String): Boolean = isValidEndpoint(value, SignalingSchemes)
+
+    private fun isValidEndpoint(value: String, schemes: Set<String>): Boolean {
+        val text = value.trim()
+        if (text.isBlank() || text.length > 2048 || text.any { it.isWhitespace() || isUnsafeControl(it) }) return false
+        val uri = runCatching { URI(text) }.getOrNull() ?: return false
+        val scheme = uri.scheme?.lowercase(Locale.US) ?: return false
+        return scheme in schemes &&
+            !uri.host.isNullOrBlank() &&
+            uri.userInfo == null &&
+            uri.fragment == null &&
+            uri.port in -1..65535
+    }
+
+    private fun isUnsafeControl(value: Char): Boolean =
+        value.code < 0x20 || value.code in 0x7f..0x9f || value == '\u2028' || value == '\u2029'
+
     fun formatText(invite: LobbyInviteData, english: Boolean): String {
         val link = buildLink(invite)
         return if (english) {

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/NetworkController.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/NetworkController.kt
@@ -3,6 +3,7 @@ package top.pmh13.mctier.network
 import android.content.Context
 import android.content.Intent
 import android.net.VpnService
+import android.os.Build
 import android.util.Log
 import com.easytier.jni.EasyTierJNI
 import com.easytier.jni.EasyTierVpnService
@@ -211,7 +212,11 @@ class NetworkController(private val context: Context) {
             putStringArrayListExtra(EasyTierVpnService.EXTRA_ROUTES, arrayListOf(route))
             putExtra(EasyTierVpnService.EXTRA_MAGIC_DNS, magicDns)
         }
-        context.startService(intent)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent)
+        } else {
+            context.startService(intent)
+        }
     }
 
     // 【互通关键修复】固定使用 EasyTier 默认 DHCP 网段 10.126.126.0/24。

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/RemoteFileClient.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/RemoteFileClient.kt
@@ -14,9 +14,20 @@ import top.pmh13.mctier.data.RemoteFileListResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.coroutines.CancellationException
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.net.Inet4Address
+import java.net.InetAddress
 import java.net.URLEncoder
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import java.util.UUID
 import java.util.concurrent.TimeUnit
+
+private const val MaxRemoteFileBytes = 2L * 1024 * 1024 * 1024
+private const val MaxRemoteMetadataBytes = 4L * 1024 * 1024
+private const val LobbyTokenHeader = "x-mctier-lobby-token"
 
 /**
  * 远端文件共享客户端：浏览并下载其他玩家（含电脑端）共享的文件。
@@ -26,39 +37,95 @@ class RemoteFileClient(private val context: Context) {
     private val client = OkHttpClient.Builder()
         .connectTimeout(2, TimeUnit.SECONDS)
         .callTimeout(60, TimeUnit.SECONDS)
+        .followRedirects(false)
+        .followSslRedirects(false)
         .build()
 
+    private fun overlayHost(raw: String): String {
+        val value = raw.trim()
+        require(value.matches(Regex("[0-9.]+"))) { "目标不是有效的 EasyTier 虚拟 IPv4" }
+        val address = runCatching { InetAddress.getByName(value) }.getOrNull()
+            ?: error("目标不是有效的 EasyTier 虚拟 IPv4")
+        require(
+            address is Inet4Address &&
+                address.address.sliceArray(0..2).contentEquals(byteArrayOf(10, 126, 126)) &&
+                !address.isAnyLocalAddress &&
+                !address.isLoopbackAddress &&
+                !address.isLinkLocalAddress &&
+                !address.isMulticastAddress &&
+                address.hostAddress != "255.255.255.255"
+        ) { "目标 IP 不在允许的虚拟网络范围内" }
+        return address.hostAddress ?: error("目标 IP 无效")
+    }
+
+    private fun pathSegment(value: String): String =
+        URLEncoder.encode(value, "UTF-8").replace("+", "%20")
+
+    private fun Request.Builder.authorizeLobby(token: String): Request.Builder {
+        require(token.length == 64 && token.all { it.isDigit() || it.lowercaseChar() in 'a'..'f' }) {
+            "大厅文件认证凭据无效"
+        }
+        return addHeader(LobbyTokenHeader, token)
+    }
+
+    private fun readBodyLimited(body: okhttp3.ResponseBody?): String {
+        val responseBody = body ?: return ""
+        val advertisedLength = responseBody.contentLength()
+        if (advertisedLength > MaxRemoteMetadataBytes) {
+            error("远程响应超过元数据大小限制")
+        }
+        responseBody.byteStream().use { input ->
+            val output = ByteArrayOutputStream()
+            val buffer = ByteArray(16 * 1024)
+            var total = 0L
+            while (true) {
+                val count = input.read(buffer)
+                if (count < 0) break
+                val nextTotal = total + count.toLong()
+                if (nextTotal < total || nextTotal > MaxRemoteMetadataBytes) {
+                    error("远程响应超过元数据大小限制")
+                }
+                output.write(buffer, 0, count)
+                total = nextTotal
+            }
+            return String(output.toByteArray(), Charsets.UTF_8)
+        }
+    }
+
     /** 浏览某个共享下的文件列表 */
-    fun listShares(ownerIp: String): List<FileShareWire> {
-        val url = "http://$ownerIp:$FileSharePort/api/shares"
-        val req = Request.Builder().url(url).build()
+    fun listShares(ownerIp: String, lobbyToken: String): List<FileShareWire> {
+        val host = overlayHost(ownerIp)
+        val url = "http://$host:$FileSharePort/api/shares"
+        val req = Request.Builder().url(url).authorizeLobby(lobbyToken).build()
         val quickClient = client.newBuilder().callTimeout(2, TimeUnit.SECONDS).build()
         quickClient.newCall(req).execute().use { resp ->
             if (!resp.isSuccessful) error("HTTP ${resp.code}")
-            val text = resp.body?.string().orEmpty()
+            val text = readBodyLimited(resp.body)
             val shares = MctierJson.decodeFromString(RemoteShareListResponse.serializer(), text).shares
             return shares.map {
                 FileShareWire(
                     shareId = it.id,
                     shareName = it.name,
                     playerName = "",
-                    hasPassword = it.hasPassword || !it.legacyPassword.isNullOrBlank(),
+                    hasPassword = it.hasPassword,
                 )
             }
         }
     }
 
-    fun listFiles(ownerIp: String, shareId: String, path: String, password: String?): List<RemoteFileInfo> {
+    fun listFiles(ownerIp: String, shareId: String, path: String, password: String?, lobbyToken: String): List<RemoteFileInfo> {
+        val host = overlayHost(ownerIp)
         val url = buildString {
-            append("http://$ownerIp:$FileSharePort/api/shares/$shareId/files")
+            append("http://$host:$FileSharePort/api/shares/${pathSegment(shareId)}/files")
             if (path.isNotBlank()) append("?path=").append(URLEncoder.encode(path, "UTF-8"))
         }
-        val reqBuilder = Request.Builder().url(url)
+        val reqBuilder = Request.Builder().url(url).authorizeLobby(lobbyToken)
         if (!password.isNullOrBlank()) reqBuilder.addHeader("x-share-password", password)
         client.newCall(reqBuilder.build()).execute().use { resp ->
             if (resp.code == 401) error("密码错误，请重试")
+            if (resp.code == 410) error("共享已过期")
             if (!resp.isSuccessful) error("HTTP ${resp.code}")
-            val text = resp.body?.string().orEmpty()
+            val text = readBodyLimited(resp.body)
             return MctierJson.decodeFromString(RemoteFileListResponse.serializer(), text).files
         }
     }
@@ -70,93 +137,161 @@ class RemoteFileClient(private val context: Context) {
         filePath: String,
         fileName: String,
         password: String?,
+        lobbyToken: String,
         downloadTreeUri: String = "",
+        expectedSize: Long? = null,
         onProgress: ((downloaded: Long, total: Long) -> Unit)? = null,
         isCanceled: () -> Boolean = { false },
         onCall: ((okhttp3.Call) -> Unit)? = null,
     ): String {
         if (isCanceled()) throw CancellationException("下载已取消")
+        require(expectedSize == null || expectedSize in 0L..MaxRemoteFileBytes) {
+            "文件超过远程下载大小限制"
+        }
+        val host = overlayHost(ownerIp)
         val encodedPath = filePath.split("/").joinToString("/") { URLEncoder.encode(it, "UTF-8").replace("+", "%20") }
-        val url = "http://$ownerIp:$FileSharePort/api/shares/$shareId/download/$encodedPath"
-        val safeFileName = fileName.substringAfterLast('/').substringAfterLast('\\').trim()
-        if (safeFileName.isBlank() || safeFileName == "." || safeFileName == "..") error("文件名无效")
+        val url = "http://$host:$FileSharePort/api/shares/${pathSegment(shareId)}/download/$encodedPath"
+        val safeFileName = validateRemoteFileName(fileName)
         val customTree = downloadTreeUri.trim().takeIf { it.isNotEmpty() }?.let { uriText ->
             val tree = DocumentFile.fromTreeUri(context, Uri.parse(uriText))
                 ?: error("自定义下载目录不可用，请重新选择文件夹")
             if (!tree.canWrite()) error("自定义下载目录没有写入权限，请重新选择文件夹")
             tree
         }
-        val dir = if (customTree == null) File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), "MCTier") else null
+        val externalDir = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+            ?: error("默认下载目录不可用")
+        val dir = if (customTree == null) File(externalDir, "MCTier") else null
         if (dir != null && !dir.exists() && !dir.mkdirs()) error("无法创建默认下载目录")
-        val outFile = dir?.let { File(it, safeFileName) }
-        val partFile = dir?.let { File(it, "$safeFileName.part") }
-        val customPart = customTree?.findFile("$safeFileName.part")
-            ?: customTree?.createFile("application/octet-stream", "$safeFileName.part")
+        if (dir != null && Files.isSymbolicLink(dir.toPath())) {
+            error("下载目录不能是符号链接")
+        }
+        val canonicalDir = dir?.canonicalFile
+        if (canonicalDir != null) {
+            require(canonicalDir.isDirectory) { "下载目录不可用" }
+        }
+        val outFile = canonicalDir?.let { File(it, safeFileName) }
+        val tempName = ".$safeFileName.${UUID.randomUUID()}.part"
+        val partFile = canonicalDir?.let { File(it, tempName) }
+        if (outFile?.exists() == true || customTree?.findFile(safeFileName) != null) {
+            error("目标文件已存在")
+        }
+        val customPart = customTree?.createFile("application/octet-stream", tempName)
             ?: customTree?.let { error("无法创建临时下载文件") }
-        // 断点续传：若存在 .part 文件，从已下载字节处继续
-        val existing = customPart?.length() ?: partFile?.takeIf { it.exists() }?.length() ?: 0L
+        if (customPart != null && customPart.name != tempName) {
+            customPart.delete()
+            error("临时下载文件名不匹配")
+        }
 
-        val reqBuilder = Request.Builder().url(url)
-        if (!password.isNullOrBlank()) reqBuilder.addHeader("x-share-password", password)
-        if (existing > 0) reqBuilder.addHeader("Range", "bytes=$existing-")
+        val reqBuilder = Request.Builder().url(url).authorizeLobby(lobbyToken)
+        if (!password.isNullOrBlank() && password.isNotBlank()) reqBuilder.addHeader("x-share-password", password)
 
         // 大文件下载使用更长（无限）超时
         val dlClient = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).readTimeout(0, TimeUnit.SECONDS).build()
         val call = dlClient.newCall(reqBuilder.build())
         onCall?.invoke(call)
-        call.execute().use { resp ->
-            if (isCanceled()) throw CancellationException("下载已取消")
-            if (resp.code == 401) error("密码错误，请重试")
-            if (!resp.isSuccessful) error("HTTP ${resp.code}")
-            val isResume = resp.code == 206
-            val body = resp.body ?: error("空响应")
-            val contentLen = body.contentLength().takeIf { it > 0 } ?: -1L
-            val total = if (isResume && contentLen > 0) existing + contentLen else contentLen
-            val startAt = if (isResume) existing else 0L
-            // 206 续传则追加，否则从头写
-            val append = isResume && existing > 0
-            body.byteStream().use { input ->
-                val output = if (customPart != null) {
-                    context.contentResolver.openOutputStream(customPart.uri, if (append) "wa" else "w")
-                } else {
-                    java.io.FileOutputStream(partFile!!, append)
-                } ?: error("无法写入下载文件")
-                output.use { outputStream ->
-                    val buf = ByteArray(64 * 1024)
-                    var downloaded = startAt
-                    while (true) {
-                        if (isCanceled()) throw CancellationException("下载已取消")
-                        val n = input.read(buf)
-                        if (n < 0) break
-                        if (isCanceled()) throw CancellationException("Download canceled")
-                        outputStream.write(buf, 0, n)
-                        downloaded += n
-                        onProgress?.invoke(downloaded, total)
+        var committed = false
+        try {
+            var downloaded = 0L
+            var contentLen = -1L
+            call.execute().use { resp ->
+                if (isCanceled()) throw CancellationException("下载已取消")
+                if (resp.code == 401) error("密码错误，请重试")
+                if (resp.code == 410) error("共享已过期")
+                if (resp.code == 206) error("服务器返回了意外的部分响应")
+                if (!resp.isSuccessful) error("HTTP ${resp.code}")
+                val body = resp.body ?: error("空响应")
+                contentLen = body.contentLength()
+                if (contentLen > MaxRemoteFileBytes) {
+                    error("响应超过远程下载大小限制")
+                }
+                if (expectedSize != null && contentLen >= 0 && expectedSize != contentLen) {
+                    error("响应长度与预期不匹配")
+                }
+                body.byteStream().use { input ->
+                    val output = if (customPart != null) {
+                        context.contentResolver.openOutputStream(customPart.uri, "w")
+                    } else {
+                        Files.newOutputStream(
+                            partFile!!.toPath(),
+                            StandardOpenOption.CREATE_NEW,
+                            StandardOpenOption.WRITE,
+                        )
+                    } ?: error("无法写入下载文件")
+                    output.use { outputStream ->
+                        val buf = ByteArray(64 * 1024)
+                        while (true) {
+                            if (isCanceled()) throw CancellationException("下载已取消")
+                            val n = input.read(buf)
+                            if (n < 0) break
+                            if (isCanceled()) throw CancellationException("下载已取消")
+                            val nextDownloaded = downloaded + n.toLong()
+                            if (nextDownloaded < downloaded || nextDownloaded > MaxRemoteFileBytes) {
+                                error("响应超过远程下载大小限制")
+                            }
+                            val expectedLength = expectedSize ?: contentLen.takeIf { it >= 0 }
+                            if (expectedLength != null && nextDownloaded > expectedLength) {
+                                error("响应内容超过预期长度")
+                            }
+                            outputStream.write(buf, 0, n)
+                            downloaded = nextDownloaded
+                            onProgress?.invoke(downloaded, expectedSize ?: contentLen)
+                        }
                     }
                 }
+                val expectedLength = expectedSize ?: contentLen.takeIf { it >= 0 }
+                if (expectedLength != null && downloaded != expectedLength) error("下载长度不匹配")
             }
-        }
-        // 下载完成：去掉 .part 后缀
-        if (customTree != null && customPart != null) {
-            customTree.findFile(safeFileName)?.delete()
-            if (!customPart.renameTo(safeFileName)) {
+
+            if (customTree != null && customPart != null) {
+                if (customTree.findFile(safeFileName) != null) error("目标文件已存在")
                 val finalFile = customTree.createFile("application/octet-stream", safeFileName)
                     ?: error("无法创建最终下载文件")
-                val input = context.contentResolver.openInputStream(customPart.uri)
-                    ?: error("无法读取临时下载文件")
-                val output = context.contentResolver.openOutputStream(finalFile.uri)
-                    ?: error("无法写入最终下载文件")
-                input.use { source -> output.use { target -> source.copyTo(target) } }
+                if (finalFile.name != safeFileName) {
+                    finalFile.delete()
+                    error("目标文件名不匹配")
+                }
+                val sameName = customTree.findFile(safeFileName)
+                if (sameName == null || sameName.uri != finalFile.uri) {
+                    finalFile.delete()
+                    error("目标文件已存在")
+                }
+                try {
+                    val input = context.contentResolver.openInputStream(customPart.uri)
+                        ?: error("无法读取临时下载文件")
+                    val output = context.contentResolver.openOutputStream(finalFile.uri, "w")
+                        ?: error("无法写入最终下载文件")
+                    input.use { source -> output.use { target -> source.copyTo(target) } }
+                    val expectedLength = expectedSize ?: contentLen.takeIf { it >= 0 }
+                    if (expectedLength != null && finalFile.length() != expectedLength) {
+                        error("最终文件长度不匹配")
+                    }
+                } catch (error: Throwable) {
+                    finalFile.delete()
+                    throw error
+                }
                 customPart.delete()
+                committed = true
+                return finalFile.uri.toString()
             }
-            return customTree.findFile(safeFileName)?.uri?.toString()
-                ?: error("下载文件保存后无法访问")
+
+            require(partFile != null && outFile != null) { "下载路径不可用" }
+            val expectedLength = expectedSize ?: contentLen.takeIf { it >= 0 }
+            if (expectedLength != null && partFile.length() != expectedLength) {
+                error("临时文件长度不匹配")
+            }
+            try {
+                Files.move(partFile.toPath(), outFile.toPath())
+            } catch (_: FileAlreadyExistsException) {
+                error("目标文件已存在")
+            }
+            committed = true
+            return outFile.absolutePath
+        } finally {
+            if (!committed) {
+                runCatching { partFile?.let { Files.deleteIfExists(it.toPath()) } }
+                runCatching { customPart?.delete() }
+            }
         }
-        if (outFile!!.exists()) outFile.delete()
-        if (!partFile!!.renameTo(outFile)) {
-            partFile.copyTo(outFile, overwrite = true); partFile.delete()
-        }
-        return outFile!!.absolutePath
     }
 
     @Serializable
@@ -166,9 +301,15 @@ class RemoteFileClient(private val context: Context) {
     private data class RemoteShareDto(
         val id: String,
         val name: String,
-        @SerialName("has_password") val hasPassword: Boolean = false,
-        // 仅用于兼容尚未升级的旧节点；不会继续暴露给 UI 或其他接口。
-        @SerialName("password") val legacyPassword: String? = null,
+        @SerialName("has_password") val hasPassword: Boolean,
         @SerialName("owner_id") val ownerId: String? = null,
     )
+}
+
+internal fun validateRemoteFileName(fileName: String): String {
+    require(fileName.isNotBlank() && fileName != "." && fileName != "..") { "文件名无效" }
+    require(fileName.none { it == '/' || it == '\\' || it == '\u0000' || it.isISOControl() }) {
+        "远端文件名必须是单个文件名"
+    }
+    return fileName
 }

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/SignalingClient.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/SignalingClient.kt
@@ -28,8 +28,9 @@ class SignalingClient {
         .build()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     @Volatile private var webSocket: WebSocket? = null
-    private var reconnectAttempts = 0
+    @Volatile private var reconnectAttempts = 0
     private var connectArgs: ConnectArgs? = null
+    @Volatile private var connectionGeneration = 0L
     @Volatile private var reconnectJob: Job? = null
     @Volatile private var stableJob: Job? = null
     @Volatile private var heartbeatJob: Job? = null
@@ -41,9 +42,17 @@ class SignalingClient {
     val connected: StateFlow<Boolean> = _connected
 
     fun connect(args: ConnectArgs) {
-        connectArgs = args
-        reconnectAttempts = 0
-        open(args)
+        val generation = synchronized(this) {
+            connectionGeneration += 1
+            connectArgs = args
+            reconnectAttempts = 0
+            connectionGeneration
+        }
+        reconnectJob?.cancel(); reconnectJob = null
+        stableJob?.cancel(); stableJob = null
+        heartbeatJob?.cancel(); heartbeatJob = null
+        _connected.value = false
+        open(args, generation)
     }
 
     fun send(message: SignalingEnvelope): Boolean {
@@ -53,11 +62,26 @@ class SignalingClient {
 
     fun refreshRegistration(): Boolean {
         val args = connectArgs ?: return false
-        return sendRegistration(args)
+        if (webSocket == null) return false
+        val generation = connectionGeneration
+        reconnectJob?.cancel()
+        webSocket?.let { runCatching { it.cancel() } }
+        webSocket = null
+        _connected.value = false
+        reconnectJob = scope.launch {
+            delay(200)
+            if (isActive && generation == connectionGeneration && connectArgs == args) {
+                open(args, generation)
+            }
+        }
+        return true
     }
 
     fun close() {
-        connectArgs = null
+        synchronized(this) {
+            connectionGeneration += 1
+            connectArgs = null
+        }
         _connected.value = false
         reconnectJob?.cancel(); reconnectJob = null
         stableJob?.cancel(); stableJob = null
@@ -66,14 +90,14 @@ class SignalingClient {
         webSocket = null
     }
 
-    private fun open(args: ConnectArgs) {
+    private fun open(args: ConnectArgs, generation: Long) {
         // 先彻底关闭旧连接，避免与服务器形成“重复连接”被来回踢导致信令抖动(flapping)
         webSocket?.let { runCatching { it.cancel() } }
         webSocket = null
         val request = Request.Builder().url(args.url).build()
         val ws = client.newWebSocket(request, object : WebSocketListener() {
             override fun onOpen(ws: WebSocket, response: Response) {
-                if (ws !== webSocket) return
+                if (ws !== webSocket || generation != connectionGeneration) return
                 _connected.value = true
                 sendRegistration(args)
                 startHeartbeat()
@@ -83,31 +107,31 @@ class SignalingClient {
             }
 
             override fun onMessage(ws: WebSocket, text: String) {
-                if (ws !== webSocket) return
+                if (ws !== webSocket || generation != connectionGeneration) return
                 runCatching {
                     MctierJson.decodeFromString(SignalingEnvelope.serializer(), text)
                 }.onSuccess { _events.tryEmit(it) }
             }
 
             override fun onClosed(ws: WebSocket, code: Int, reason: String) {
-                if (ws !== webSocket) return // 旧连接的回调，忽略，避免触发重连风暴
+                if (ws !== webSocket || generation != connectionGeneration) return // 旧连接的回调，忽略，避免触发重连风暴
                 webSocket = null
                 _connected.value = false
                 android.util.Log.w("SignalingClient", "WS onClosed code=$code reason=$reason")
-                scheduleReconnect()
+                scheduleReconnect(args, generation)
             }
 
             override fun onClosing(ws: WebSocket, code: Int, reason: String) {
-                if (ws !== webSocket) return
+                if (ws !== webSocket || generation != connectionGeneration) return
                 android.util.Log.w("SignalingClient", "WS onClosing code=$code reason=$reason")
             }
 
             override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
-                if (ws !== webSocket) return // 旧连接被主动取消触发的失败，忽略
+                if (ws !== webSocket || generation != connectionGeneration) return // 旧连接被主动取消触发的失败，忽略
                 webSocket = null
                 _connected.value = false
                 android.util.Log.e("SignalingClient", "WS onFailure: ${t.message} resp=${response?.code}")
-                scheduleReconnect()
+                scheduleReconnect(args, generation)
             }
         })
         webSocket = ws
@@ -127,8 +151,8 @@ class SignalingClient {
         ),
     )
 
-    private fun scheduleReconnect() {
-        val args = connectArgs ?: return
+    private fun scheduleReconnect(args: ConnectArgs, generation: Long) {
+        if (generation != connectionGeneration || connectArgs != args) return
         reconnectAttempts += 1
         // 快速重连：配合桌面端 3 秒"离线确认窗口"，保证断线后能在 3 秒内重新注册回来，
         // 让桌面端判定为"短时恢复"而不显示离开/加入抖动。连接风暴已由"仅当前连接重连+先关旧连接"挡住。
@@ -137,7 +161,7 @@ class SignalingClient {
         reconnectJob?.cancel()
         reconnectJob = scope.launch {
             delay(delayMs)
-            if (isActive && connectArgs != null) open(args)
+            if (isActive && generation == connectionGeneration && connectArgs == args) open(args, generation)
         }
     }
 

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/UpdateChecker.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/network/UpdateChecker.kt
@@ -9,9 +9,12 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.ResponseBody
 import top.pmh13.mctier.data.AppClientVersion
 import top.pmh13.mctier.data.AvailableUpdate
 import top.pmh13.mctier.ui.L
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 
 /**
@@ -20,40 +23,104 @@ import java.util.concurrent.TimeUnit
 class UpdateChecker(private val context: Context) {
     private val client = OkHttpClient.Builder()
         .connectTimeout(8, TimeUnit.SECONDS)
-        .callTimeout(120, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .callTimeout(20, TimeUnit.SECONDS)
+        // A version response must come from the pinned Gitee endpoint. Do not
+        // allow a compromised redirect to supply update metadata.
+        .followRedirects(false)
+        .followSslRedirects(false)
         .build()
     private val json = Json { ignoreUnknownKeys = true }
-    private val tagsUrl = "https://gitee.com/api/v5/repos/peng-minghang/mctier/tags"
+    private val tagsUrl = "https://gitee.com/api/v5/repos/peng-minghang/mctier/tags?per_page=100&page=1"
     private val downloadWebsite = "https://mctier.pmhs.top"
+
+    private companion object {
+        const val MaxVersionResponseBytes = 256 * 1024L
+        const val MaxTags = 100
+        const val MaxReleaseNotesBytes = 8 * 1024
+        val ReleaseVersionPattern = Regex("^v?(0|[1-9]\\d{0,8})\\.(0|[1-9]\\d{0,8})\\.(0|[1-9]\\d{0,8})$")
+        val CommitShaPattern = Regex("^[0-9a-fA-F]{40}$")
+    }
 
     /** 检测是否有新版本。回调在子线程触发，UI 层需切回主线程。 */
     fun check(onResult: (AvailableUpdate?) -> Unit) {
         Thread {
             runCatching {
-                client.newCall(Request.Builder().url(tagsUrl).build()).execute().use { resp ->
+                client.newCall(
+                    Request.Builder()
+                        .url(tagsUrl)
+                        .header("Accept", "application/json")
+                        .header("User-Agent", "MCTier-Android-update-check")
+                        .build(),
+                ).execute().use { resp ->
                     if (!resp.isSuccessful) { onResult(null); return@use }
-                    val text = resp.body?.string().orEmpty()
-                    val arr = json.parseToJsonElement(text).jsonArray
-                    val latestTag = arr.maxWithOrNull { left, right ->
-                        val leftVersion = left.jsonObject["name"]?.jsonPrimitive?.content.orEmpty().removePrefix("v")
-                        val rightVersion = right.jsonObject["name"]?.jsonPrimitive?.content.orEmpty().removePrefix("v")
-                        compareVersions(leftVersion, rightVersion)
-                    }
-                    val latest = latestTag?.jsonObject?.get("name")?.jsonPrimitive?.content.orEmpty().removePrefix("v")
-                    if (latest.isBlank() || compareVersions(latest, AppClientVersion) <= 0) {
+                    val contentType = resp.header("Content-Type")?.lowercase()
+                    if (contentType != null && !contentType.startsWith("application/json")) {
                         onResult(null)
                         return@use
                     }
-                    val releaseNotes = latestTag?.jsonObject?.get("message")?.jsonPrimitive?.content
-                        .orEmpty()
+                    val body = resp.body ?: run { onResult(null); return@use }
+                    val text = readLimitedBody(body)
+                    val arr = json.parseToJsonElement(text).jsonArray
+                    if (arr.size > MaxTags) {
+                        onResult(null)
+                        return@use
+                    }
+                    val tags = arr.mapNotNull { element ->
+                        val obj = element.jsonObject
+                        val rawName = obj["name"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                        val version = normalizeReleaseVersion(rawName) ?: return@mapNotNull null
+                        val sha = obj["commit"]?.jsonObject?.get("sha")?.jsonPrimitive?.content
+                            ?: return@mapNotNull null
+                        if (!CommitShaPattern.matches(sha)) return@mapNotNull null
+                        val message = obj["message"]?.jsonPrimitive?.content.orEmpty()
+                        if (message.toByteArray(StandardCharsets.UTF_8).size > MaxReleaseNotesBytes) {
+                            return@mapNotNull null
+                        }
+                        UpdateTag(version, message)
+                    }
+                    val latestTag = tags.maxWithOrNull { left, right -> compareVersions(left.version, right.version) }
+                    val latest = latestTag?.version
+                    val current = normalizeReleaseVersion(AppClientVersion)
+                    if (latest == null || current == null || compareVersions(latest, current) <= 0) {
+                        onResult(null)
+                        return@use
+                    }
+                    val releaseNotes = latestTag.notes
                         .lineSequence()
                         .map { it.trim().removePrefix("- ").trim() }
+                        .take(64)
                         .filter { it.isNotBlank() }
+                        .map { it.take(512) }
                         .toList()
                     onResult(AvailableUpdate(latest, releaseNotes))
                 }
             }.onFailure { onResult(null) }
         }.start()
+    }
+
+    private data class UpdateTag(val version: String, val notes: String)
+
+    private fun readLimitedBody(body: ResponseBody): String {
+        val declaredLength = body.contentLength()
+        if (declaredLength > MaxVersionResponseBytes) {
+            throw IllegalArgumentException("版本响应过大")
+        }
+        val output = ByteArrayOutputStream(
+            minOf(declaredLength.coerceAtLeast(0L), MaxVersionResponseBytes).toInt(),
+        )
+        val buffer = ByteArray(8192)
+        var total = 0L
+        body.byteStream().use { input ->
+            while (true) {
+                val count = input.read(buffer)
+                if (count < 0) break
+                total += count
+                if (total > MaxVersionResponseBytes) throw IllegalArgumentException("版本响应过大")
+                output.write(buffer, 0, count)
+            }
+        }
+        return output.toString(StandardCharsets.UTF_8.name())
     }
 
     /** 版本仍从 Gitee 检测，安装包统一由官网引导用户手动下载。 */
@@ -66,13 +133,18 @@ class UpdateChecker(private val context: Context) {
     }
 
     private fun compareVersions(v1: String, v2: String): Int {
-        val a = v1.removePrefix("v").split(".").map { it.toIntOrNull() ?: 0 }
-        val b = v2.removePrefix("v").split(".").map { it.toIntOrNull() ?: 0 }
+        val a = v1.removePrefix("v").split(".").map { it.toIntOrNull() ?: return 0 }
+        val b = v2.removePrefix("v").split(".").map { it.toIntOrNull() ?: return 0 }
         for (i in 0 until maxOf(a.size, b.size)) {
             val x = a.getOrElse(i) { 0 }
             val y = b.getOrElse(i) { 0 }
             if (x != y) return x.compareTo(y)
         }
         return 0
+    }
+
+    private fun normalizeReleaseVersion(value: String): String? {
+        val match = ReleaseVersionPattern.matchEntire(value) ?: return null
+        return "${match.groupValues[1]}.${match.groupValues[2]}.${match.groupValues[3]}"
     }
 }

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/service/VoiceForegroundService.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/service/VoiceForegroundService.kt
@@ -1,5 +1,6 @@
 package top.pmh13.mctier.service
 
+import android.Manifest
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -8,8 +9,10 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import top.pmh13.mctier.MainActivity
 import top.pmh13.mctier.ui.L
 
@@ -27,6 +30,13 @@ class VoiceForegroundService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+            checkSelfPermission(Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.w(TAG, "Rejecting voice foreground service without microphone permission")
+            stopSelfResult(startId)
+            return START_NOT_STICKY
+        }
         ensureChannel()
         val tapIntent = runCatching {
             PendingIntent.getActivity(
@@ -42,13 +52,17 @@ class VoiceForegroundService : Service() {
             .setOngoing(true)
             .also { if (tapIntent != null) it.setContentIntent(tapIntent) }
             .build()
-        runCatching {
+        val started = runCatching {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)
             } else {
                 startForeground(NOTIFICATION_ID, notification)
             }
-        }
+        }.onFailure {
+            Log.e(TAG, "Failed to start voice foreground service", it)
+            stopSelfResult(startId)
+        }.isSuccess
+        if (!started) return START_NOT_STICKY
         // 进程存活期间维持后台语音；进程被系统杀掉后无需自动重建（届时大厅连接也已断开）
         return START_NOT_STICKY
     }
@@ -72,6 +86,7 @@ class VoiceForegroundService : Service() {
     }
 
     companion object {
+        private const val TAG = "MCTierVoiceService"
         private const val CHANNEL_ID = "mctier_voice_mic"
         private const val NOTIFICATION_ID = 4542
 

--- a/MCTier-Android/app/src/main/java/top/pmh13/mctier/ui/MctierApp.kt
+++ b/MCTier-Android/app/src/main/java/top/pmh13/mctier/ui/MctierApp.kt
@@ -287,7 +287,11 @@ fun MctierApp(repository: MctierRepository, onConsentGranted: () -> Unit = {}) {
     val state by repository.state.collectAsState()
     val consentCtx = androidx.compose.ui.platform.LocalContext.current
     var agreed by remember { mutableStateOf(ConsentStore.isAgreed(consentCtx)) }
-    LaunchedEffect(Unit) { repository.maybeAutoJoin() }
+    // An external invite launches the activity and leaves a pending join form. Do not
+    // connect to the separately saved auto-join lobby in the same startup pass.
+    LaunchedEffect(Unit) {
+        if (state.pendingJoin == null) repository.maybeAutoJoin()
+    }
     // 主题：根据设置实时应用（深/浅色 + 自定义主色），切换即重组整个界面
     LaunchedEffect(state.settings.themeMode, state.settings.themePrimary) {
         applyAppTheme(state.settings.themeMode, state.settings.themePrimary)
@@ -929,7 +933,7 @@ private fun HomeScreen(state: MctierUiState, repository: MctierRepository) {
                     Spacer(Modifier.height(16.dp))
                     MctierField(lobbyName, { lobbyName = it; joinNodeOverride = null; joinSignalingOverride = null }, L("大厅名称（4-32位）", "Lobby Name (4-32 chars)"), enabled = !connecting)
                     Spacer(Modifier.height(12.dp))
-                    MctierField(password, { password = it }, L("大厅密码（8-32位，含字母和数字）", "Password (8-32, letters & digits)"), enabled = !connecting, isPassword = true)
+                    MctierField(password, { password = it }, L("留空为无密码大厅，或输入8-32位密码", "Leave blank for no password, or enter 8-32 characters"), enabled = !connecting, isPassword = true)
                     Spacer(Modifier.height(12.dp))
                     MctierField(state.settings.playerName, {
                         val name = it.replace(Regex("\\s+"), "")
@@ -1016,7 +1020,7 @@ private fun PublicPlazaDialog(state: MctierUiState, repository: MctierRepository
                         items(state.publicLobbies, key = { it.lobbyName + it.hostName }) { lobby ->
                             Row(
                                 Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp)).background(PanelHigh)
-                                    .clickable { onFill(lobby.lobbyName, lobby.password, lobby.serverNode); onDismiss() }.padding(12.dp),
+                                    .clickable { onFill(lobby.lobbyName, "", lobby.serverNode); onDismiss() }.padding(12.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
                                 Column(Modifier.weight(1f)) {
@@ -2145,8 +2149,12 @@ private fun LobbySettingsCard(state: MctierUiState, repository: MctierRepository
         }
         Spacer(Modifier.height(14.dp))
         PrimaryButton(L("保存大厅设置", "Save Lobby Settings")) {
-            val lobbyPwd = state.lobby?.password
-            repository.setLobbyOptions(maxText.toIntOrNull()?.takeIf { it > 0 }, isPublic, description, lobbyPwd)
+            if (isPublic && !state.lobby?.password.isNullOrEmpty()) {
+                isPublic = false
+                android.widget.Toast.makeText(ctx, L("公开大厅必须不设密码", "Public lobbies must not have a password"), android.widget.Toast.LENGTH_SHORT).show()
+                return@PrimaryButton
+            }
+            repository.setLobbyOptions(maxText.toIntOrNull()?.takeIf { it > 0 }, isPublic, description)
             android.widget.Toast.makeText(ctx, L("大厅设置已保存", "Lobby settings saved"), android.widget.Toast.LENGTH_SHORT).show()
         }
     }

--- a/MCTier-Android/app/src/main/res/xml/file_paths.xml
+++ b/MCTier-Android/app/src/main/res/xml/file_paths.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-    <external-files-path name="downloads" path="." />
-    <external-files-path name="update" path="." />
-</paths>

--- a/MCTier-Android/gradle/wrapper/gradle-wrapper.properties
+++ b/MCTier-Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/MCTier-Android/scripts/build-easytier-jni.ps1
+++ b/MCTier-Android/scripts/build-easytier-jni.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
     默认使用仓库同级目录下已有的 EasyTier 源码；也可通过 -Repo / -Rev 让脚本自动
-    clone 并 checkout 到指定 commit，使构建可复现（见 issue #17 第 11 条）。
+    clone 并 checkout 到指定完整 commit，使构建可复现（见 issue #17 第 11 条）。
 
     构建时会：
       1. 打开 release 的 strip，避免 .so 残留调试符号；
@@ -13,50 +13,157 @@
       3. 构建完成后输出每个 .so 的 SHA-256，便于登记与复核。
 
 .PARAMETER Repo
-    EasyTier 仓库地址。指定后脚本会 clone 到 -EasyTierRoot（若该目录不存在）。
+    EasyTier 仓库地址。默认只允许官方仓库；自定义 HTTPS 仓库必须同时传入
+    -AllowUntrustedSource，并会 clone 到 -EasyTierRoot（若该目录不存在）。
 
 .PARAMETER Rev
-    要 checkout 的 commit / tag。强烈建议在发布构建时显式指定，以锁定源码版本。
+    要 checkout 的 40 位完整 commit SHA。默认要求完整 SHA；自定义 tag/分支必须
+    同时传入 -AllowUntrustedSource。
+
+.PARAMETER AllowUntrustedSource
+    显式允许从非官方仓库或可变 ref 获取源码。该选项会在输出中发出高风险警告，
+    仅用于开发者自定义构建，不应出现在发布流程中。
 
 .EXAMPLE
     .\build-easytier-jni.ps1
-    .\build-easytier-jni.ps1 -Repo https://github.com/EasyTier/EasyTier.git -Rev v2.6.0
+    .\build-easytier-jni.ps1 -Repo https://github.com/EasyTier/EasyTier.git -Rev 79b562cdc9f1dc3f52195a47a02cf83542c225ab
 #>
 param(
     [string]$EasyTierRoot = (Join-Path (Resolve-Path "$PSScriptRoot\..\..\..").Path "EasyTier-main"),
     [string[]]$Abis = @("arm64-v8a"),
     [string]$Repo,
-    [string]$Rev
+    [string]$Rev,
+    [switch]$AllowUntrustedSource
 )
 
 $ErrorActionPreference = "Stop"
+
+$OfficialEasyTierHost = "github.com"
+$OfficialEasyTierPath = "/EasyTier/EasyTier.git"
+
+function Test-OfficialEasyTierRepo([string]$Value) {
+    try {
+        $uri = [System.Uri]::new($Value)
+    } catch {
+        return $false
+    }
+    return $uri.IsAbsoluteUri -and
+        $uri.Scheme -eq "https" -and
+        $uri.Host -ieq $OfficialEasyTierHost -and
+        $uri.AbsolutePath.TrimEnd("/") -ieq $OfficialEasyTierPath.TrimEnd("/") -and
+        [string]::IsNullOrEmpty($uri.UserInfo) -and
+        [string]::IsNullOrEmpty($uri.Query) -and
+        [string]::IsNullOrEmpty($uri.Fragment)
+}
+
+function Test-HttpsRepo([string]$Value) {
+    try {
+        $uri = [System.Uri]::new($Value)
+    } catch {
+        return $false
+    }
+    return $uri.IsAbsoluteUri -and
+        $uri.Scheme -eq "https" -and
+        [string]::IsNullOrEmpty($uri.UserInfo) -and
+        [string]::IsNullOrEmpty($uri.Query) -and
+        [string]::IsNullOrEmpty($uri.Fragment) -and
+        $uri.AbsolutePath -notmatch "[\x00-\x1F\x7F]"
+}
+
+function Test-ImmutableRevision([string]$Value) {
+    return $Value -match "^[0-9a-fA-F]{40}$"
+}
+
+function Test-SafeGitRef([string]$Value) {
+    # Git refs may contain slashes, dots, underscores, and hyphens, but never
+    # begin with '-' or contain shell/control characters or option syntax.
+    return $Value -match "^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$" -and
+        $Value -notmatch "\.\.|//|/\.|\./|@$|@\{|[\\~^:?*\[\]]"
+}
+
+function Assert-CleanGitWorkTree([string]$Root) {
+    $status = @(& git -C $Root status --porcelain=v1 --untracked-files=all 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        throw "无法检查 EasyTier 工作树状态。"
+    }
+    if ($status.Count -gt 0) {
+        throw "EasyTier 工作树不干净，拒绝使用固定 commit 构建；请清理已跟踪或未跟踪的改动。"
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($EasyTierRoot) -or $EasyTierRoot.IndexOf([char]0) -ge 0) {
+    throw "-EasyTierRoot 不是有效路径。"
+}
+if ($Rev -and -not $Repo) {
+    throw "-Rev 只能与 -Repo 一起使用。"
+}
+if ($Repo -and -not (Test-HttpsRepo $Repo)) {
+    throw "-Repo 必须是无凭据、无查询参数的 HTTPS Git 仓库地址。"
+}
+if ($Repo -and -not (Test-OfficialEasyTierRepo $Repo) -and -not $AllowUntrustedSource) {
+    throw "只允许从官方 EasyTier 仓库获取源码；自定义仓库必须显式传入 -AllowUntrustedSource。"
+}
+if ($Repo -and -not $Rev -and -not $AllowUntrustedSource) {
+    throw "指定 -Repo 时必须同时指定 40 位完整 commit SHA；可变分支/tag 仅可通过 -AllowUntrustedSource 显式启用。"
+}
+if ($Rev -and -not (Test-SafeGitRef $Rev)) {
+    throw "-Rev 不是安全的 Git ref，拒绝可能的路径或命令行参数注入。"
+}
+if ($Repo -and $Rev -and -not (Test-ImmutableRevision $Rev) -and -not $AllowUntrustedSource) {
+    throw "-Rev 默认必须是 40 位十六进制 commit SHA；可变 tag/分支仅可通过 -AllowUntrustedSource 显式启用。"
+}
+if ($AllowUntrustedSource -and ($Repo -or $Rev)) {
+    Write-Warning "已启用 -AllowUntrustedSource：源码仓库或 ref 可能不是可复现的官方固定版本。"
+}
 
 # 若指定了 -Repo，则确保源码存在并锁定到 -Rev，使构建可复现。
 if ($Repo) {
     if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
         throw "git was not found. Install git first, or omit -Repo."
     }
-    if (-not (Test-Path $EasyTierRoot)) {
+    if (-not (Test-Path -LiteralPath $EasyTierRoot)) {
         Write-Host "Cloning $Repo -> $EasyTierRoot"
-        git clone $Repo $EasyTierRoot
+        & git clone -- $Repo $EasyTierRoot
         if ($LASTEXITCODE -ne 0) { throw "Failed to clone $Repo" }
+    } else {
+        $existingRoot = (Resolve-Path -LiteralPath $EasyTierRoot).Path
+        $isWorkTree = (& git -C $existingRoot rev-parse --is-inside-work-tree 2>$null)
+        if ($LASTEXITCODE -ne 0 -or $isWorkTree.Trim() -ne "true") {
+            throw "EasyTierRoot 已存在但不是 Git 工作区: $existingRoot"
+        }
+        $remote = (& git -C $existingRoot config --get remote.origin.url 2>$null | Select-Object -First 1)
+        if ($LASTEXITCODE -ne 0 -or -not $remote -or -not (Test-HttpsRepo $remote.Trim())) {
+            throw "EasyTierRoot 的 origin 不是允许的 HTTPS Git 仓库，拒绝构建。"
+        }
+        if ($Repo -and $remote.Trim().TrimEnd('/') -ine $Repo.Trim().TrimEnd('/')) {
+            throw "EasyTierRoot 的 origin 与 -Repo 不一致，拒绝构建。"
+        }
+        if (-not $AllowUntrustedSource -and -not (Test-OfficialEasyTierRepo $remote.Trim())) {
+            throw "EasyTierRoot 的 origin 不是官方 EasyTier 仓库，拒绝构建。"
+        }
     }
+    $EasyTierRoot = (Resolve-Path -LiteralPath $EasyTierRoot).Path
     if ($Rev) {
-        Push-Location $EasyTierRoot
-        try {
-            git fetch --all --tags
-            git checkout $Rev
-            if ($LASTEXITCODE -ne 0) { throw "Failed to checkout $Rev" }
-        } finally {
-            Pop-Location
+        & git -C $EasyTierRoot fetch --no-tags origin $Rev
+        if ($LASTEXITCODE -ne 0) { throw "Failed to fetch requested revision $Rev" }
+        & git -C $EasyTierRoot checkout --detach $Rev
+        if ($LASTEXITCODE -ne 0) { throw "Failed to checkout requested revision $Rev" }
+        $checkedOut = (& git -C $EasyTierRoot rev-parse HEAD 2>$null).Trim()
+        if ($LASTEXITCODE -ne 0 -or ((Test-ImmutableRevision $Rev) -and ($checkedOut -ine $Rev))) {
+            throw "检出的 EasyTier commit 与请求的 commit SHA 不一致。"
+        }
+        if (Test-ImmutableRevision $Rev) {
+            # A pinned commit is not sufficient when a reused checkout still
+            # contains local source changes that Cargo would compile.
+            Assert-CleanGitWorkTree $EasyTierRoot
         }
     }
 }
 
-if (-not (Test-Path $EasyTierRoot)) {
+if (-not (Test-Path -LiteralPath $EasyTierRoot)) {
     throw "EasyTier source was not found at $EasyTierRoot. Pass -EasyTierRoot, or -Repo to clone it."
 }
-$EasyTierRoot = (Resolve-Path $EasyTierRoot).Path
+$EasyTierRoot = (Resolve-Path -LiteralPath $EasyTierRoot).Path
 
 # 记录本次构建实际使用的 EasyTier commit，便于在发布说明中登记。
 $easyTierCommit = "(unknown)"
@@ -186,13 +293,13 @@ foreach ($abi in $Abis) {
 
     Write-Host "Building EasyTier FFI for $abi..."
     Push-Location (Join-Path $EasyTierRoot "easytier-contrib\easytier-ffi")
-    cargo build --target $rustTarget --release
+    cargo build --target $rustTarget --release --locked
     if ($LASTEXITCODE -ne 0) { throw "Failed to build easytier-ffi for $abi" }
     Pop-Location
 
     Write-Host "Building EasyTier Android JNI for $abi..."
     Push-Location (Join-Path $EasyTierRoot "easytier-contrib\easytier-android-jni")
-    cargo build --target $rustTarget --release
+    cargo build --target $rustTarget --release --locked
     if ($LASTEXITCODE -ne 0) { throw "Failed to build easytier-android-jni for $abi" }
     Pop-Location
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-deep-link": "^2.4.9",
-        "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-shell": "^2.3.5",
         "@types/qrcode": "^1.5.6",
@@ -1940,15 +1939,6 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
-      }
-    },
-    "node_modules/@tauri-apps/plugin-opener": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmmirror.com/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
-      "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-process": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
-    "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@types/qrcode": "^1.5.6",

--- a/scripts/fetch-binaries.ps1
+++ b/scripts/fetch-binaries.ps1
@@ -33,9 +33,54 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-$RepoRoot = Split-Path -Parent $PSScriptRoot
+$RepoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
 $TargetDir = Join-Path $RepoRoot 'src-tauri\resources\binaries'
-$WorkDir = Join-Path ([System.IO.Path]::GetTempPath()) ('mctier-fetch-' + [Guid]::NewGuid().ToString('N').Substring(0, 8))
+$WorkDir = Join-Path ([System.IO.Path]::GetTempPath()) ('mctier-fetch-' + [Guid]::NewGuid().ToString('N'))
+$MaximumArchiveBytes = 128MB
+$MaximumExtractedBytes = 128MB
+$MaximumEntryBytes = 64MB
+$MaximumEntryCount = 1000
+$MaximumRedirects = 3
+$repoFullPath = [System.IO.Path]::GetFullPath($RepoRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+$repoPrefix = $repoFullPath + [System.IO.Path]::DirectorySeparatorChar
+
+function Test-PathWithinRepo([string]$Path) {
+    $fullPath = [System.IO.Path]::GetFullPath($Path).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+    return $fullPath.StartsWith($repoPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Assert-SafeTargetDirectory {
+    $parent = Split-Path -Parent $TargetDir
+    if (-not (Test-Path -LiteralPath $parent -PathType Container)) {
+        throw '目标目录的父目录不存在。'
+    }
+    $resolvedParent = (Resolve-Path -LiteralPath $parent).Path
+    if (-not (Test-PathWithinRepo $resolvedParent)) {
+        throw '目标目录必须位于仓库目录内。'
+    }
+
+    $target = Get-Item -LiteralPath $TargetDir -Force -ErrorAction SilentlyContinue
+    if (-not $target) { return }
+    if (-not $target.PSIsContainer) {
+        throw '目标路径不是目录。'
+    }
+    if (($target.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw '拒绝使用重解析点作为目标目录。'
+    }
+    $resolvedTarget = (Resolve-Path -LiteralPath $TargetDir).Path
+    if (-not (Test-PathWithinRepo $resolvedTarget)) {
+        throw '目标目录解析后位于仓库外。'
+    }
+}
+
+function Assert-SafeTargetFile([string]$Name) {
+    $path = Join-Path $TargetDir $Name
+    $item = Get-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+    if (-not $item) { return }
+    if ($item.PSIsContainer -or (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        throw "拒绝覆盖非普通目标文件: $Name"
+    }
+}
 
 # EasyTier 官方 Windows 发布包（tag v2.5.0 / commit 88a45d115670631dfe6a05ba192387d615ddb95b）
 $EasyTierVersion = 'v2.5.0'
@@ -68,8 +113,187 @@ function Get-Sha256([string]$Path) {
 
 function Test-ExistingFile([string]$Name) {
     $path = Join-Path $TargetDir $Name
-    if (-not (Test-Path -LiteralPath $path)) { return $false }
+    $item = Get-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+    if (-not $item -or $item.PSIsContainer -or (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        return $false
+    }
     return (Get-Sha256 $path) -eq $Expected[$Name]
+}
+
+function Test-AllowedDownloadUri([System.Uri]$Uri) {
+    if (-not $Uri.IsAbsoluteUri -or $Uri.Scheme -ne 'https' -or $Uri.UserInfo) {
+        throw "拒绝不安全的下载重定向: $Uri"
+    }
+    $uriHost = $Uri.Host.ToLowerInvariant()
+    $allowed = $uriHost -eq 'github.com' -or
+        $uriHost.EndsWith('.github.com', [System.StringComparison]::OrdinalIgnoreCase) -or
+        $uriHost -eq 'githubusercontent.com' -or
+        $uriHost.EndsWith('.githubusercontent.com', [System.StringComparison]::OrdinalIgnoreCase)
+    if (-not $allowed) {
+        throw "拒绝非 GitHub 官方下载主机: $uriHost"
+    }
+}
+
+function Save-HttpDownload([System.Uri]$Uri, [string]$Destination, [long]$MaximumBytes) {
+    Test-AllowedDownloadUri $Uri
+    $handler = [System.Net.Http.HttpClientHandler]::new()
+    $handler.AllowAutoRedirect = $false
+    $handler.AutomaticDecompression = [System.Net.DecompressionMethods]::None
+    $client = [System.Net.Http.HttpClient]::new($handler)
+    $client.Timeout = [System.TimeSpan]::FromSeconds(90)
+    $client.DefaultRequestHeaders.UserAgent.ParseAdd('MCTier-fetch-binaries')
+    $currentUri = $Uri
+    try {
+        for ($redirect = 0; $redirect -le $MaximumRedirects; $redirect++) {
+            Test-AllowedDownloadUri $currentUri
+            $request = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Get, $currentUri)
+            try {
+                $response = $client.SendAsync($request, [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).GetAwaiter().GetResult()
+            } finally {
+                $request.Dispose()
+            }
+
+            try {
+                $statusCode = [int]$response.StatusCode
+                if ($statusCode -ge 300 -and $statusCode -lt 400) {
+                    if ($redirect -ge $MaximumRedirects -or -not $response.Headers.Location) {
+                        throw '下载重定向次数超过上限或缺少 Location。'
+                    }
+                    $nextUri = $response.Headers.Location
+                    if (-not $nextUri.IsAbsoluteUri) { $nextUri = [System.Uri]::new($currentUri, $nextUri) }
+                    Test-AllowedDownloadUri $nextUri
+                    $currentUri = $nextUri
+                    continue
+                }
+                if (-not $response.IsSuccessStatusCode) {
+                    throw "下载失败，HTTP 状态码 $statusCode。"
+                }
+
+                $contentLength = $response.Content.Headers.ContentLength
+                if ($null -ne $contentLength -and [long]$contentLength -gt $MaximumBytes) {
+                    throw "下载内容超过大小上限 ($MaximumBytes 字节)。"
+                }
+
+                $input = $response.Content.ReadAsStreamAsync().GetAwaiter().GetResult()
+                $output = [System.IO.File]::Open($Destination, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+                try {
+                    $buffer = New-Object byte[] 65536
+                    [long]$total = 0
+                    while (($read = $input.Read($buffer, 0, $buffer.Length)) -gt 0) {
+                        $total += $read
+                        if ($total -gt $MaximumBytes) {
+                            throw "下载内容超过大小上限 ($MaximumBytes 字节)。"
+                        }
+                        $output.Write($buffer, 0, $read)
+                    }
+                    $output.Flush()
+                } finally {
+                    $output.Dispose()
+                    $input.Dispose()
+                }
+                return
+            } finally {
+                $response.Dispose()
+            }
+        }
+        throw '下载重定向次数超过上限。'
+    } finally {
+        $client.Dispose()
+        $handler.Dispose()
+    }
+}
+
+function Test-ZipArchive([string]$Path) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    [long]$totalBytes = 0
+    [int]$entryCount = 0
+    try {
+        foreach ($entry in $archive.Entries) {
+            $entryCount++
+            if ($entryCount -gt $MaximumEntryCount) {
+                throw "ZIP 条目数量超过上限 ($MaximumEntryCount)。"
+            }
+            $entryName = $entry.FullName.Replace('\', '/')
+            if ([string]::IsNullOrWhiteSpace($entryName) -or $entryName.IndexOf([char]0) -ge 0) {
+                throw 'ZIP 包含无效条目名称。'
+            }
+            if ($entryName.StartsWith('/') -or $entryName -match '^[A-Za-z]:/' -or $entryName -match '(^|/)\.\.(/|$)') {
+                throw "ZIP 包含不安全的路径: $($entry.FullName)"
+            }
+            if ($entry.Length -gt $MaximumEntryBytes) {
+                throw "ZIP 条目超过大小上限: $($entry.FullName)"
+            }
+            if ($entry.Length -gt ($MaximumExtractedBytes - $totalBytes)) {
+                throw "ZIP 解压总大小超过上限 ($MaximumExtractedBytes 字节)。"
+            }
+            $totalBytes += $entry.Length
+        }
+    } finally {
+        $archive.Dispose()
+    }
+}
+
+function Copy-VerifiedZipEntries([string]$ZipPath, [string]$DestinationDir) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+    $failed = @()
+    $copied = 0
+    [long]$totalExtractedBytes = 0
+    try {
+        foreach ($name in $Expected.Keys) {
+            $matches = @($archive.Entries | Where-Object {
+                -not $_.FullName.EndsWith('/') -and
+                [System.IO.Path]::GetFileName($_.FullName.Replace('/', [System.IO.Path]::DirectorySeparatorChar)) -ceq $name
+            })
+            if ($matches.Count -eq 0) {
+                if ($Required -contains $name) { $failed += "${name}: 未在发布包中找到" }
+                continue
+            }
+            if ($matches.Count -ne 1) {
+                $failed += "${name}: 发布包中存在多个同名条目"
+                continue
+            }
+
+            $entry = $matches[0]
+            $destination = Join-Path $DestinationDir $name
+            $input = $entry.Open()
+            $output = [System.IO.File]::Open($destination, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+            try {
+                $buffer = New-Object byte[] 65536
+                [long]$total = 0
+                while (($read = $input.Read($buffer, 0, $buffer.Length)) -gt 0) {
+                    $total += $read
+                    $totalExtractedBytes += $read
+                    if ($total -gt $MaximumEntryBytes) { throw "ZIP 条目超过大小上限: $name" }
+                    if ($totalExtractedBytes -gt $MaximumExtractedBytes) {
+                        throw "ZIP 实际解压总大小超过上限 ($MaximumExtractedBytes 字节)。"
+                    }
+                    $output.Write($buffer, 0, $read)
+                }
+                $output.Flush()
+            } finally {
+                $output.Dispose()
+                $input.Dispose()
+            }
+
+            $actual = Get-Sha256 $destination
+            if ($actual -ne $Expected[$name]) {
+                Remove-Item -LiteralPath $destination -Force -ErrorAction SilentlyContinue
+                $failed += "${name}: SHA-256 不匹配`n    期望 $($Expected[$name])`n    实际 $actual"
+                continue
+            }
+            Write-Host ("  [OK] {0,-24} {1}" -f $name, $actual) -ForegroundColor Green
+            $copied++
+        }
+    } finally {
+        $archive.Dispose()
+    }
+    if ($failed.Count -gt 0) {
+        $failed | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+        throw '依赖校验未通过，已中止。请勿使用未校验的二进制进行构建。'
+    }
+    return $copied
 }
 
 Write-Host 'MCTier 构建依赖获取脚本' -ForegroundColor Cyan
@@ -79,7 +303,9 @@ Write-Host 'Npcap 许可提示: Packet.dll 属 Npcap (Insecure.Com LLC)，非开
 Write-Host '未经 Nmap Project 书面许可不得随其他软件再分发。详见 THIRD_PARTY_NOTICES.md 第 8 节。' -ForegroundColor Yellow
 Write-Host ''
 
+Assert-SafeTargetDirectory
 New-Item -ItemType Directory -Force -Path $TargetDir | Out-Null
+Assert-SafeTargetDirectory
 
 if (-not $Force) {
     $missing = @($Required | Where-Object { -not (Test-ExistingFile $_) })
@@ -92,54 +318,33 @@ if (-not $Force) {
     Write-Host ''
 }
 
-New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+New-Item -ItemType Directory -Path $WorkDir | Out-Null
 try {
     $zipPath = Join-Path $WorkDir 'easytier.zip'
+    $stagingDir = Join-Path $WorkDir 'verified'
+    $workItem = Get-Item -LiteralPath $WorkDir -Force
+    if (($workItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw '拒绝使用重解析点作为临时工作目录。'
+    }
+    New-Item -ItemType Directory -Path $stagingDir | Out-Null
     Write-Host "正在下载 EasyTier $EasyTierVersion ..."
     Write-Host "  $EasyTierUrl"
-    $progressPreferenceBackup = $ProgressPreference
-    $ProgressPreference = 'SilentlyContinue'
-    try {
-        Invoke-WebRequest -Uri $EasyTierUrl -OutFile $zipPath -UseBasicParsing -Headers @{ 'User-Agent' = 'MCTier-fetch-binaries' }
-    } finally {
-        $ProgressPreference = $progressPreferenceBackup
-    }
+    Save-HttpDownload ([System.Uri]::new($EasyTierUrl)) $zipPath $MaximumArchiveBytes
     Write-Host ("  下载完成: {0:N0} 字节" -f (Get-Item -LiteralPath $zipPath).Length)
 
-    $extractDir = Join-Path $WorkDir 'extracted'
-    New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
-    Expand-Archive -LiteralPath $zipPath -DestinationPath $extractDir -Force
-
-    $failed = @()
-    $copied = 0
-    foreach ($name in $Expected.Keys) {
-        $found = Get-ChildItem -LiteralPath $extractDir -Recurse -File -Filter $name -ErrorAction SilentlyContinue |
-            Select-Object -First 1
-        if (-not $found) {
-            if ($Required -contains $name) { $failed += "${name}: 未在发布包中找到" }
-            continue
-        }
-
-        $actual = Get-Sha256 $found.FullName
-        if ($actual -ne $Expected[$name]) {
-            $failed += "${name}: SHA-256 不匹配`n    期望 $($Expected[$name])`n    实际 $actual"
-            continue
-        }
-
-        Copy-Item -LiteralPath $found.FullName -Destination (Join-Path $TargetDir $name) -Force
-        Write-Host ("  [OK] {0,-24} {1}" -f $name, $actual) -ForegroundColor Green
-        $copied++
-    }
-
-    if ($failed.Count -gt 0) {
-        Write-Host ''
-        Write-Host '以下文件校验失败：' -ForegroundColor Red
-        $failed | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
-        throw '依赖校验未通过，已中止。请勿使用未校验的二进制进行构建。'
-    }
+    Test-ZipArchive $zipPath
+    $copied = Copy-VerifiedZipEntries $zipPath $stagingDir
 
     Write-Host ''
     Write-Host "完成，共放置 $copied 个文件。" -ForegroundColor Green
+
+    # Only publish after every required entry has passed verification, so a
+    # failed download can never leave a mixed set of dependencies in place.
+    Get-ChildItem -LiteralPath $stagingDir -File | ForEach-Object {
+        Assert-SafeTargetFile $_.Name
+        Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $TargetDir $_.Name) -Force
+    }
+    Assert-SafeTargetDirectory
 
     $stillMissing = @($Required | Where-Object { -not (Test-ExistingFile $_) })
     if ($stillMissing.Count -gt 0) {
@@ -147,7 +352,8 @@ try {
     }
     Write-Host 'include_bytes! 所需的 5 个二进制均已就位，现在可以执行 npm run tauri build。' -ForegroundColor Green
 } finally {
-    if (Test-Path -LiteralPath $WorkDir) {
+    $workItem = Get-Item -LiteralPath $WorkDir -Force -ErrorAction SilentlyContinue
+    if ($workItem -and $workItem.PSIsContainer -and (($workItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0)) {
         Remove-Item -LiteralPath $WorkDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -380,10 +380,10 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -396,7 +396,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower 0.5.3",
  "tower-layer",
@@ -413,13 +413,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1304,7 +1304,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg 0.55.0",
+ "winreg",
 ]
 
 [[package]]
@@ -1579,6 +1579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -2002,16 +2003,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http 0.2.12",
+ "http",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -2114,17 +2115,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2135,23 +2125,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -2162,8 +2141,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2187,30 +2166,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -2219,8 +2174,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2232,16 +2188,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.32",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2254,17 +2228,19 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2831,12 +2807,13 @@ dependencies = [
  "dirs 5.0.1",
  "env_logger",
  "futures-util",
+ "libc",
  "log",
  "parking_lot",
  "proptest",
  "rand 0.8.5",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "rfd",
  "serde",
  "serde_json",
@@ -2846,7 +2823,6 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-global-shortcut",
- "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tempfile",
@@ -3665,9 +3641,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
@@ -3887,9 +3863,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4116,44 +4092,46 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "winreg 0.50.0",
 ]
 
 [[package]]
@@ -4166,10 +4144,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "js-sys",
  "log",
@@ -4177,7 +4155,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower 0.5.3",
@@ -4212,6 +4190,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4253,12 +4245,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "base64 0.21.7",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4728,16 +4744,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -4980,12 +4986,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -5006,20 +5006,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5111,7 +5111,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http 1.4.0",
+ "http",
  "jni",
  "libc",
  "log",
@@ -5277,28 +5277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-opener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
-dependencies = [
- "dunce",
- "glob",
- "objc2-app-kit",
- "objc2-foundation",
- "open",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "url",
- "windows 0.61.3",
- "zbus",
-]
-
-[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5343,7 +5321,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http 1.4.0",
+ "http",
  "jni",
  "objc2",
  "objc2-ui-kit",
@@ -5366,7 +5344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
- "http 1.4.0",
+ "http",
  "jni",
  "log",
  "objc2",
@@ -5399,7 +5377,7 @@ dependencies = [
  "dunce",
  "glob",
  "html5ever 0.29.1",
- "http 1.4.0",
+ "http",
  "infer",
  "json-patch",
  "kuchikiki",
@@ -5586,7 +5564,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5609,6 +5587,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -5769,7 +5757,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5785,8 +5773,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -5810,8 +5798,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower 0.5.3",
@@ -5911,7 +5899,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -6013,6 +6001,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -6356,9 +6350,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -7130,16 +7124,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -7276,7 +7260,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "gtk",
- "http 1.4.0",
+ "http",
  "javascriptcore-rs",
  "jni",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,6 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }
-tauri-plugin-opener = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-clipboard-manager = "2"
@@ -39,7 +38,7 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 rand = "0.8"
-reqwest = { version = "0.11", features = ["blocking", "stream", "json"] }
+reqwest = { version = "0.12", features = ["blocking", "stream", "json"] }
 rfd = "0.15"
 urlencoding = "2.1"
 base64 = "0.22"
@@ -56,6 +55,9 @@ async-stream = "0.3"
 zip = "2"
 sonora = "0.2.0"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 wasapi = "0.23"
 windows = { version = "0.58", features = [
@@ -65,6 +67,7 @@ windows = { version = "0.58", features = [
     "Win32_UI_Shell",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_Security",
+    "Win32_Security_Credentials",
     "Win32_System_Threading",
     "Win32_System_Performance",
 ] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -2,7 +2,8 @@ fn main() {
     #[cfg(windows)]
     {
         let mut windows = tauri_build::WindowsAttributes::new();
-        windows = windows.app_manifest(r#"
+        windows = windows.app_manifest(
+            r#"
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
@@ -24,7 +25,8 @@ fn main() {
     </dependentAssembly>
   </dependency>
 </assembly>
-"#);
+"#,
+        );
         let attrs = tauri_build::Attributes::new().windows_attributes(windows);
         tauri_build::try_build(attrs).expect("failed to run build script");
 
@@ -39,7 +41,7 @@ fn main() {
              processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'"
         );
     }
-    
+
     #[cfg(not(windows))]
     {
         tauri_build::build()

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,8 +9,6 @@
     "core:event:allow-unlisten",
     "core:event:allow-emit",
     "core:event:allow-emit-to",
-    "opener:allow-default-urls",
-    "opener:allow-open-url",
     "shell:allow-open",
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-write-text",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,14 +3,14 @@ pub mod modules;
 
 use log::{error, info};
 use modules::app_core::AppCore;
-use modules::tauri_commands::AppState;
-use modules::system_audio::{start_system_audio_loopback, stop_system_audio_loopback};
 use modules::sonora_audio::{process_voice_frame, process_voice_frames, reset_voice_processor};
+use modules::system_audio::{start_system_audio_loopback, stop_system_audio_loopback};
+use modules::tauri_commands::AppState;
 use std::sync::Arc;
-use tokio::sync::Mutex;
-use tauri::Manager;
 use tauri::Emitter;
+use tauri::Manager;
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
+use tokio::sync::Mutex;
 static TRAY_NOTIFICATION_TEXT: std::sync::OnceLock<std::sync::RwLock<(String, String)>> =
     std::sync::OnceLock::new();
 static TRAY_SUMMON_HOTKEY: std::sync::OnceLock<std::sync::RwLock<String>> =
@@ -29,20 +29,21 @@ fn apply_gpu_settings_on_startup() {
     } else {
         return;
     };
-    
+
     if !config_path.exists() {
         println!("配置文件不存在，使用默认GPU设置（启用）");
         return;
     }
-    
+
     // 读取配置文件
     if let Ok(content) = std::fs::read_to_string(&config_path) {
         if let Ok(config) = serde_json::from_str::<serde_json::Value>(&content) {
             // 检查 GPU 渲染设置（配置文件使用 snake_case）
-            let enable_gpu = config.get("enable_gpu_rendering")
+            let enable_gpu = config
+                .get("enable_gpu_rendering")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(true);
-            
+
             if !enable_gpu {
                 // 设置环境变量完全禁用 GPU（包括GPU进程）
                 std::env::set_var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", 
@@ -50,8 +51,10 @@ fn apply_gpu_settings_on_startup() {
                 println!("✅ GPU 渲染已完全禁用（包括GPU进程）");
             } else {
                 // 启用 GPU 时，明确设置启用硬件加速的参数
-                std::env::set_var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", 
-                    "--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist");
+                std::env::set_var(
+                    "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
+                    "--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist",
+                );
                 println!("✅ GPU 渲染已启用（通过环境变量）");
             }
         }
@@ -83,58 +86,43 @@ fn reset_microphone_permission_cache_on_startup() {
     }
 }
 
-
 use modules::tauri_commands::{
-    create_lobby, join_lobby, leave_lobby,
-    toggle_mic, set_mic_enabled, open_microphone_privacy_settings, reset_microphone_permission, mute_player, mute_all,
-    get_config, update_config, save_opacity,
-    get_audio_devices, get_app_state, get_current_lobby, get_players,
-    get_mic_status, get_global_mute_status, is_player_muted,
-    get_network_status, get_virtual_ip, get_peer_connection_types,
-    set_always_on_top, toggle_mini_mode, set_window_opacity,
-    send_signaling_message, broadcast_status_update, send_heartbeat,
-    force_stop_easytier,
-    cancel_lobby_connecting,
-    check_virtual_adapter, check_firewall_rules, ping_virtual_ip, check_udp_port,
-    is_admin, add_firewall_rules, restart_as_admin,
-    save_window_position, exit_app,
-    add_player_domain, remove_player_domain,
-    get_folder_name, get_folder_info, list_directory_files,
-    read_file_bytes, write_file_bytes, select_folder, select_file, select_save_location,
-    select_file_share_download_folder, get_file_share_download_dir, set_file_share_download_dir,
-    get_file_share_download_path,
-    save_file, save_chat_image, read_file, delete_file, extract_zip,
-    open_file_location, open_folder,
-    start_file_server, stop_file_server, check_file_server_status,
-    add_shared_folder, remove_shared_folder, get_local_shares,
-    cleanup_expired_shares, get_remote_shares, get_remote_files,
-    verify_share_password, get_download_url, diagnose_file_share_connection,
-    download_remote_file, cancel_remote_download, export_logs, test_node_latency,
-    download_remote_batch, detect_security_software,
-    send_p2p_chat_message, get_p2p_chat_messages, clear_p2p_chat_messages,
-    set_chat_peer_roster, clear_chat_peer_roster,
-    set_share_allowed_peers, clear_share_allowed_peers,
-    open_screen_viewer_window,
-    open_danmaku_window, close_danmaku_window,
-    set_danmaku_ignore_cursor, danmaku_cursor_pos, save_danmaku_image,
-    open_game_hud_window, close_game_hud_window,
-    set_gamehud_ignore_cursor, gamehud_cursor_pos,
-    open_log_folder, open_log_file, get_log_file_path, read_log_file, set_avatar_data, clear_avatar_cache,
-    save_settings, get_settings, set_auto_start, check_auto_start,
-    reset_config_to_default, save_voice_volume,
-    export_config, import_config,
-    restart_app_with_gpu_settings,
-    save_exit_node_advanced_config, get_exit_node_advanced_config,
+    add_firewall_rules, add_player_domain, add_shared_folder, broadcast_status_update,
+    cancel_lobby_connecting, cancel_remote_download, check_auto_start, check_file_server_status,
+    check_firewall_rules, check_udp_port, check_virtual_adapter, cleanup_expired_shares,
+    clear_avatar_cache, clear_p2p_chat_messages, close_danmaku_window, close_game_hud_window,
+    configure_p2p_chat, create_lobby, danmaku_cursor_pos, delete_file, detect_security_software,
+    diagnose_file_share_connection, download_remote_batch, download_remote_file, exit_app,
+    export_config, export_logs, extract_zip, force_stop_easytier, gamehud_cursor_pos,
+    get_app_state, get_audio_devices, get_config, get_current_lobby, get_download_url,
+    get_exit_node_advanced_config, get_file_share_download_dir, get_file_share_download_path,
+    get_folder_info, get_folder_name, get_global_mute_status, get_local_shares, get_log_file_path,
+    get_mic_status, get_network_status, get_p2p_chat_messages, get_peer_connection_types,
+    get_players, get_remote_files, get_remote_shares, get_settings, get_virtual_ip, import_config,
+    is_admin, is_player_muted, join_lobby, leave_lobby, list_directory_files, mute_all,
+    mute_player, open_danmaku_window, open_file_location, open_folder, open_game_hud_window,
+    open_log_file, open_log_folder, open_microphone_privacy_settings, open_screen_viewer_window,
+    ping_virtual_ip, read_file, read_file_bytes, read_log_file, remove_player_domain,
+    remove_shared_folder, reset_config_to_default, reset_microphone_permission,
+    restart_app_with_gpu_settings, restart_as_admin, save_chat_image, save_danmaku_image,
+    save_exit_node_advanced_config, save_file, save_opacity, save_settings, save_voice_volume,
+    save_window_position, select_file, select_file_share_download_folder, select_folder,
+    select_save_location, send_heartbeat, send_p2p_chat_message, send_signaling_message,
+    set_always_on_top, set_auto_start, set_avatar_data, set_danmaku_ignore_cursor,
+    set_file_share_download_dir, set_gamehud_ignore_cursor, set_mic_enabled, set_window_opacity,
+    start_file_server, stop_file_server, stop_p2p_chat, test_node_latency, toggle_mic,
+    toggle_mini_mode, update_config, update_p2p_chat_peers, verify_share_password,
+    write_file_bytes,
 };
 
 use modules::easytier_advanced_commands::{
-    save_global_easytier_advanced_config, get_global_easytier_advanced_config,
-    save_lobby_easytier_advanced_config, get_lobby_easytier_advanced_config,
-    clear_lobby_easytier_advanced_config,
+    clear_lobby_easytier_advanced_config, get_global_easytier_advanced_config,
+    get_lobby_easytier_advanced_config, save_global_easytier_advanced_config,
+    save_lobby_easytier_advanced_config,
 };
 
 use modules::minecraft_discovery::{
-    scan_minecraft_servers, query_minecraft_server, measure_peers_latency,
+    measure_peers_latency, query_minecraft_server, scan_minecraft_servers,
 };
 
 use modules::mc_lan_bridge::{start_mc_lan_broadcast, stop_mc_lan_broadcast};
@@ -159,7 +147,9 @@ fn open_devtools(_app: tauri::AppHandle) {
         }
     }
     #[cfg(not(debug_assertions))]
-    { log::warn!("开发者工具仅在 debug 模式下可用"); }
+    {
+        log::warn!("开发者工具仅在 debug 模式下可用");
+    }
 }
 
 /// 【#1】确保窗口在可视范围内：若窗口已完全移出所有显示器，则自动居中。
@@ -301,7 +291,10 @@ fn show_tray_background_notification(app: &tauri::AppHandle, generation: u64) {
         return;
     };
     if window.is_visible().unwrap_or(true) {
-        info!("窗口已恢复，跳过托盘后台运行通知任务：generation={}", generation);
+        info!(
+            "窗口已恢复，跳过托盘后台运行通知任务：generation={}",
+            generation
+        );
         return;
     }
     let _notification_lock = match TRAY_NOTIFICATION_LOCK.lock() {
@@ -309,7 +302,10 @@ fn show_tray_background_notification(app: &tauri::AppHandle, generation: u64) {
         Err(error) => error.into_inner(),
     };
     if TRAY_NOTIFICATION_GENERATION.load(std::sync::atomic::Ordering::Acquire) != generation {
-        info!("跳过已被新托盘状态取代的通知任务：generation={}", generation);
+        info!(
+            "跳过已被新托盘状态取代的通知任务：generation={}",
+            generation
+        );
         return;
     }
 
@@ -317,7 +313,8 @@ fn show_tray_background_notification(app: &tauri::AppHandle, generation: u64) {
         .get_or_init(|| {
             std::sync::RwLock::new((
                 "MCTier 正在后台运行".to_string(),
-                "MCTier 已最小化到系统托盘。点击右下角托盘图标或按 {shortcut} 可恢复窗口。".to_string(),
+                "MCTier 已最小化到系统托盘。点击右下角托盘图标或按 {shortcut} 可恢复窗口。"
+                    .to_string(),
             ))
         })
         .read()
@@ -325,7 +322,8 @@ fn show_tray_background_notification(app: &tauri::AppHandle, generation: u64) {
         .unwrap_or_else(|_| {
             (
                 "MCTier 正在后台运行".to_string(),
-                "MCTier 已最小化到系统托盘。点击右下角托盘图标或按 {shortcut} 可恢复窗口。".to_string(),
+                "MCTier 已最小化到系统托盘。点击右下角托盘图标或按 {shortcut} 可恢复窗口。"
+                    .to_string(),
             )
         });
     let summon_hotkey = TRAY_SUMMON_HOTKEY
@@ -407,9 +405,9 @@ fn show_tray_background_notification(app: &tauri::AppHandle, generation: u64) {
         let mut previous = HWND::default();
         let mut tray_window = None;
         loop {
-            let Ok(candidate) = (unsafe {
-                FindWindowExW(HWND::default(), previous, w!("tray_icon_app"), None)
-            }) else {
+            let Ok(candidate) =
+                (unsafe { FindWindowExW(HWND::default(), previous, w!("tray_icon_app"), None) })
+            else {
                 break;
             };
             if candidate.0.is_null() {
@@ -449,7 +447,11 @@ fn show_tray_background_notification(app: &tauri::AppHandle, generation: u64) {
             clear_data.uID = tray_id;
             clear_data.uFlags = NIF_INFO;
             let cleared = unsafe { Shell_NotifyIconW(NIM_MODIFY, &clear_data).as_bool() };
-            let clear_error = if cleared { 0 } else { unsafe { GetLastError().0 } };
+            let clear_error = if cleared {
+                0
+            } else {
+                unsafe { GetLastError().0 }
+            };
             if cleared {
                 std::thread::sleep(std::time::Duration::from_millis(80));
             }
@@ -470,7 +472,11 @@ fn show_tray_background_notification(app: &tauri::AppHandle, generation: u64) {
             write_wide(&mut data.szInfoTitle, &title);
             write_wide(&mut data.szInfo, &notification_body);
             let shown = unsafe { Shell_NotifyIconW(NIM_MODIFY, &data).as_bool() };
-            let show_error = if shown { 0 } else { unsafe { GetLastError().0 } };
+            let show_error = if shown {
+                0
+            } else {
+                unsafe { GetLastError().0 }
+            };
             log::info!(
                 "Windows tray balloon on MCTier tray icon: hwnd={:?}, pid={}, id={}, cb_size={}, cleared={} error={}, shown={} error={}",
                 tray_window.0,
@@ -511,7 +517,11 @@ fn show_tray_background_notification(app: &tauri::AppHandle, generation: u64) {
                 add_data.hIcon = fallback_icon;
                 let _ = unsafe { Shell_NotifyIconW(NIM_DELETE, &add_data) };
                 let added = unsafe { Shell_NotifyIconW(NIM_ADD, &add_data).as_bool() };
-                let add_error = if added { 0 } else { unsafe { GetLastError().0 } };
+                let add_error = if added {
+                    0
+                } else {
+                    unsafe { GetLastError().0 }
+                };
                 if added {
                     std::thread::sleep(std::time::Duration::from_millis(80));
                     let mut fallback_data = NOTIFYICONDATAW::default();
@@ -523,9 +533,8 @@ fn show_tray_background_notification(app: &tauri::AppHandle, generation: u64) {
                     fallback_data.Anonymous.uTimeout = 7000;
                     write_wide(&mut fallback_data.szInfoTitle, &title);
                     write_wide(&mut fallback_data.szInfo, &notification_body);
-                    let fallback_shown = unsafe {
-                        Shell_NotifyIconW(NIM_MODIFY, &fallback_data).as_bool()
-                    };
+                    let fallback_shown =
+                        unsafe { Shell_NotifyIconW(NIM_MODIFY, &fallback_data).as_bool() };
                     let fallback_error = if fallback_shown {
                         0
                     } else {
@@ -569,7 +578,6 @@ fn show_tray_background_notification(app: &tauri::AppHandle, generation: u64) {
             log::warn!("MCTier tray window was not found for balloon notification");
         }
     }
-
 }
 
 /// Hide the main window without closing its WebView and tell the user where it went.
@@ -582,7 +590,10 @@ fn hide_main_window_to_tray(app: &tauri::AppHandle, source: &str) {
 
     let was_visible = window.is_visible().unwrap_or(false);
     if !was_visible && source != "关闭按钮" {
-        info!("{}：MCTier 已经处于系统托盘，不重复发送后台运行通知", source);
+        info!(
+            "{}：MCTier 已经处于系统托盘，不重复发送后台运行通知",
+            source
+        );
         return;
     }
 
@@ -590,10 +601,7 @@ fn hide_main_window_to_tray(app: &tauri::AppHandle, source: &str) {
     // stale taskbar/Win+D state from the previous transition.
     let _ = window.unminimize();
     let was_always_on_top = window.is_always_on_top().unwrap_or(false);
-    RESTORE_ALWAYS_ON_TOP_AFTER_TRAY.store(
-        was_always_on_top,
-        std::sync::atomic::Ordering::Release,
-    );
+    RESTORE_ALWAYS_ON_TOP_AFTER_TRAY.store(was_always_on_top, std::sync::atomic::Ordering::Release);
     if was_always_on_top {
         let _ = window.set_always_on_top(false);
     }
@@ -604,11 +612,12 @@ fn hide_main_window_to_tray(app: &tauri::AppHandle, source: &str) {
     #[cfg(target_os = "windows")]
     release_windows_foreground_after_hide(&window);
 
-    info!("{}：MCTier 已最小化到系统托盘，准备发送后台运行通知", source);
-    let generation = TRAY_NOTIFICATION_GENERATION.fetch_add(
-        1,
-        std::sync::atomic::Ordering::AcqRel,
-    ) + 1;
+    info!(
+        "{}：MCTier 已最小化到系统托盘，准备发送后台运行通知",
+        source
+    );
+    let generation =
+        TRAY_NOTIFICATION_GENERATION.fetch_add(1, std::sync::atomic::Ordering::AcqRel) + 1;
     let notification_app = app.clone();
     std::thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_millis(300));
@@ -642,9 +651,11 @@ fn minimize_main_window_to_tray(app: tauri::AppHandle) {
 }
 
 #[cfg(target_os = "windows")]
-static SUMMON_FALLBACK_TX: std::sync::OnceLock<std::sync::mpsc::SyncSender<()>> = std::sync::OnceLock::new();
+static SUMMON_FALLBACK_TX: std::sync::OnceLock<std::sync::mpsc::SyncSender<()>> =
+    std::sync::OnceLock::new();
 #[cfg(target_os = "windows")]
-static SUMMON_FALLBACK_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static SUMMON_FALLBACK_ENABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 #[cfg(target_os = "windows")]
 fn start_summon_fallback_listener(app: &tauri::AppHandle) {
@@ -664,7 +675,9 @@ fn start_summon_fallback_listener(app: &tauri::AppHandle) {
         }
     });
     std::thread::spawn(move || {
-        use windows::Win32::UI::Input::KeyboardAndMouse::{GetAsyncKeyState, VK_CONTROL, VK_M, VK_MENU};
+        use windows::Win32::UI::Input::KeyboardAndMouse::{
+            GetAsyncKeyState, VK_CONTROL, VK_M, VK_MENU,
+        };
 
         let mut triggered = false;
         loop {
@@ -704,7 +717,9 @@ unsafe extern "system" fn window_subclass_proc(
 ) -> windows::Win32::Foundation::LRESULT {
     use windows::Win32::Foundation::LRESULT;
     use windows::Win32::UI::Shell::DefSubclassProc;
-    use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SC_MINIMIZE, SW_HIDE, WM_SYSCOMMAND};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        ShowWindow, SC_MINIMIZE, SW_HIDE, WM_SYSCOMMAND,
+    };
 
     if msg == WM_SYSCOMMAND && (wparam.0 & 0xFFF0) == SC_MINIMIZE as usize {
         let _ = ShowWindow(hwnd, SW_HIDE);
@@ -792,7 +807,9 @@ fn normalize_hotkey(raw: &str) -> String {
         .map(|part| {
             let lower = part.to_lowercase();
             match lower.as_str() {
-                "ctrl" | "control" | "commandorcontrol" | "cmdorctrl" => "CommandOrControl".to_string(),
+                "ctrl" | "control" | "commandorcontrol" | "cmdorctrl" => {
+                    "CommandOrControl".to_string()
+                }
                 "alt" | "option" => "Alt".to_string(),
                 "shift" => "Shift".to_string(),
                 "meta" | "cmd" | "command" | "super" | "win" => "Super".to_string(),
@@ -841,8 +858,8 @@ fn register_global_hotkeys(
     );
 
     // ===== 唤出主窗口 =====
-    let use_default_summon_fallback = cfg!(target_os = "windows")
-        && summon_hotkey.eq_ignore_ascii_case("CommandOrControl+Alt+M");
+    let use_default_summon_fallback =
+        cfg!(target_os = "windows") && summon_hotkey.eq_ignore_ascii_case("CommandOrControl+Alt+M");
     #[cfg(target_os = "windows")]
     if use_default_summon_fallback {
         start_summon_fallback_listener(app);
@@ -851,99 +868,173 @@ fn register_global_hotkeys(
     }
     if !summon_hotkey.is_empty() && !use_default_summon_fallback {
         let hs = app.clone();
-        if let Err(e) = app.global_shortcut().on_shortcut(summon_hotkey.as_str(), move |_, _, ev| {
-            if ev.state == tauri_plugin_global_shortcut::ShortcutState::Released { return; }
-            toggle_main_window(&hs);
-        }) {
+        if let Err(e) =
+            app.global_shortcut()
+                .on_shortcut(summon_hotkey.as_str(), move |_, _, ev| {
+                    if ev.state == tauri_plugin_global_shortcut::ShortcutState::Released {
+                        return;
+                    }
+                    toggle_main_window(&hs);
+                })
+        {
             error!("唤出窗口快捷键 {} 注册失败: {}", summon_hotkey, e);
         }
     }
 
-    let ltm = Arc::new(Mutex::new(std::time::Instant::now() - std::time::Duration::from_millis(500)));
-    let ltt = Arc::new(Mutex::new(std::time::Instant::now() - std::time::Duration::from_millis(500)));
+    let ltm = Arc::new(Mutex::new(
+        std::time::Instant::now() - std::time::Duration::from_millis(500),
+    ));
+    let ltt = Arc::new(Mutex::new(
+        std::time::Instant::now() - std::time::Duration::from_millis(500),
+    ));
     let ltf = Arc::new(Mutex::new((false, false))); // (is_pressed, original_mic_state)
 
     // ===== 麦克风开关 =====
     if !mic_hotkey.is_empty() {
-        let cm = Arc::clone(&core); let hm = app.clone(); let lm = Arc::clone(&ltm);
-        if let Err(e) = app.global_shortcut().on_shortcut(mic_hotkey.as_str(), move |_, _, ev| {
-            if ev.state == tauri_plugin_global_shortcut::ShortcutState::Released { return; }
-            let mut lt = match lm.try_lock() { Ok(g) => g, Err(_) => return };
-            let now = std::time::Instant::now();
-            if now.duration_since(*lt) < std::time::Duration::from_millis(200) { return; }
-            *lt = now; drop(lt);
-            let c = Arc::clone(&cm); let h = hm.clone();
-            tauri::async_runtime::spawn(async move {
-                match c.lock().await.toggle_mic().await {
-                    Ok(s) => { let _ = h.emit("mic-toggled", s); }
-                    Err(e) => { error!("切换麦克风失败: {}", e); }
+        let cm = Arc::clone(&core);
+        let hm = app.clone();
+        let lm = Arc::clone(&ltm);
+        if let Err(e) = app
+            .global_shortcut()
+            .on_shortcut(mic_hotkey.as_str(), move |_, _, ev| {
+                if ev.state == tauri_plugin_global_shortcut::ShortcutState::Released {
+                    return;
                 }
-            });
-        }) {
+                let mut lt = match lm.try_lock() {
+                    Ok(g) => g,
+                    Err(_) => return,
+                };
+                let now = std::time::Instant::now();
+                if now.duration_since(*lt) < std::time::Duration::from_millis(200) {
+                    return;
+                }
+                *lt = now;
+                drop(lt);
+                let c = Arc::clone(&cm);
+                let h = hm.clone();
+                tauri::async_runtime::spawn(async move {
+                    match c.lock().await.toggle_mic().await {
+                        Ok(s) => {
+                            let _ = h.emit("mic-toggled", s);
+                        }
+                        Err(e) => {
+                            error!("切换麦克风失败: {}", e);
+                        }
+                    }
+                });
+            })
+        {
             error!("麦克风快捷键 {} 注册失败: {}", mic_hotkey, e);
         }
     }
 
     // ===== 全局听筒 =====
     if !global_mute_hotkey.is_empty() {
-        let ct = Arc::clone(&core); let ht = app.clone(); let lt2 = Arc::clone(&ltt);
-        if let Err(e) = app.global_shortcut().on_shortcut(global_mute_hotkey.as_str(), move |_, _, ev| {
-            if ev.state == tauri_plugin_global_shortcut::ShortcutState::Released { return; }
-            let mut lt = match lt2.try_lock() { Ok(g) => g, Err(_) => return };
-            let now = std::time::Instant::now();
-            if now.duration_since(*lt) < std::time::Duration::from_millis(200) { return; }
-            *lt = now; drop(lt);
-            let c = Arc::clone(&ct); let h = ht.clone();
-            tauri::async_runtime::spawn(async move {
-                let vs = c.lock().await.get_voice_service();
-                let v = vs.lock().await;
-                let ns = !v.is_global_muted();
-                match v.mute_all(ns).await {
-                    Ok(_) => { let _ = h.emit("global-mute-toggled", ns); }
-                    Err(e) => { error!("切换静音失败: {}", e); }
-                }
-            });
-        }) {
+        let ct = Arc::clone(&core);
+        let ht = app.clone();
+        let lt2 = Arc::clone(&ltt);
+        if let Err(e) =
+            app.global_shortcut()
+                .on_shortcut(global_mute_hotkey.as_str(), move |_, _, ev| {
+                    if ev.state == tauri_plugin_global_shortcut::ShortcutState::Released {
+                        return;
+                    }
+                    let mut lt = match lt2.try_lock() {
+                        Ok(g) => g,
+                        Err(_) => return,
+                    };
+                    let now = std::time::Instant::now();
+                    if now.duration_since(*lt) < std::time::Duration::from_millis(200) {
+                        return;
+                    }
+                    *lt = now;
+                    drop(lt);
+                    let c = Arc::clone(&ct);
+                    let h = ht.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let vs = c.lock().await.get_voice_service();
+                        let v = vs.lock().await;
+                        let ns = !v.is_global_muted();
+                        match v.mute_all(ns).await {
+                            Ok(_) => {
+                                let _ = h.emit("global-mute-toggled", ns);
+                            }
+                            Err(e) => {
+                                error!("切换静音失败: {}", e);
+                            }
+                        }
+                    });
+                })
+        {
             error!("全局听筒快捷键 {} 注册失败: {}", global_mute_hotkey, e);
         }
     }
 
     // ===== 临时开麦（按住说话）=====
     if !push_to_talk_hotkey.is_empty() {
-        let cf = Arc::clone(&core); let hf = app.clone(); let ltf2 = Arc::clone(&ltf);
-        if let Err(e) = app.global_shortcut().on_shortcut(push_to_talk_hotkey.as_str(), move |_, _, ev| {
-            let c = Arc::clone(&cf); let h = hf.clone(); let lf = Arc::clone(&ltf2);
-            tauri::async_runtime::spawn(async move {
-                let mut state = match lf.try_lock() { Ok(g) => g, Err(_) => return };
+        let cf = Arc::clone(&core);
+        let hf = app.clone();
+        let ltf2 = Arc::clone(&ltf);
+        if let Err(e) =
+            app.global_shortcut()
+                .on_shortcut(push_to_talk_hotkey.as_str(), move |_, _, ev| {
+                    let c = Arc::clone(&cf);
+                    let h = hf.clone();
+                    let lf = Arc::clone(&ltf2);
+                    tauri::async_runtime::spawn(async move {
+                        let mut state = match lf.try_lock() {
+                            Ok(g) => g,
+                            Err(_) => return,
+                        };
 
-                if ev.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
-                    if state.0 { return; } // 已按下，防重复触发
-                    state.0 = true;
-                    let current_mic_state = c.lock().await.get_voice_service().lock().await.is_mic_enabled();
-                    state.1 = current_mic_state;
-                    drop(state);
-                    if !current_mic_state {
-                        info!("临时开麦：开启麦克风");
-                        match c.lock().await.toggle_mic().await {
-                            Ok(s) => { let _ = h.emit("mic-toggled", s); }
-                            Err(e) => { error!("临时开麦开启失败: {}", e); }
+                        if ev.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
+                            if state.0 {
+                                return;
+                            } // 已按下，防重复触发
+                            state.0 = true;
+                            let current_mic_state = c
+                                .lock()
+                                .await
+                                .get_voice_service()
+                                .lock()
+                                .await
+                                .is_mic_enabled();
+                            state.1 = current_mic_state;
+                            drop(state);
+                            if !current_mic_state {
+                                info!("临时开麦：开启麦克风");
+                                match c.lock().await.toggle_mic().await {
+                                    Ok(s) => {
+                                        let _ = h.emit("mic-toggled", s);
+                                    }
+                                    Err(e) => {
+                                        error!("临时开麦开启失败: {}", e);
+                                    }
+                                }
+                            }
+                        } else if ev.state == tauri_plugin_global_shortcut::ShortcutState::Released
+                        {
+                            if !state.0 {
+                                return;
+                            }
+                            let original_state = state.1;
+                            state.0 = false;
+                            drop(state);
+                            if !original_state {
+                                info!("临时开麦：恢复麦克风状态");
+                                match c.lock().await.toggle_mic().await {
+                                    Ok(s) => {
+                                        let _ = h.emit("mic-toggled", s);
+                                    }
+                                    Err(e) => {
+                                        error!("临时开麦恢复失败: {}", e);
+                                    }
+                                }
+                            }
                         }
-                    }
-                } else if ev.state == tauri_plugin_global_shortcut::ShortcutState::Released {
-                    if !state.0 { return; }
-                    let original_state = state.1;
-                    state.0 = false;
-                    drop(state);
-                    if !original_state {
-                        info!("临时开麦：恢复麦克风状态");
-                        match c.lock().await.toggle_mic().await {
-                            Ok(s) => { let _ = h.emit("mic-toggled", s); }
-                            Err(e) => { error!("临时开麦恢复失败: {}", e); }
-                        }
-                    }
-                }
-            });
-        }) {
+                    });
+                })
+        {
             error!("临时开麦快捷键 {} 注册失败: {}", push_to_talk_hotkey, e);
         }
     }
@@ -978,7 +1069,7 @@ pub fn run() {
     reset_microphone_permission_cache_on_startup();
     // 在应用启动时检查并应用 GPU 设置
     apply_gpu_settings_on_startup();
-    
+
     use std::fs::OpenOptions;
     let log_path = if let Some(data_dir) = dirs::data_local_dir() {
         let mctier_dir = data_dir.join("MCTier");
@@ -987,7 +1078,11 @@ pub fn run() {
     } else {
         std::path::PathBuf::from("mctier.log")
     };
-    let log_file = OpenOptions::new().create(true).append(true).open(&log_path).expect("无法创建日志文件");
+    let log_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("无法创建日志文件");
     env_logger::Builder::from_default_env()
         .filter_level(log::LevelFilter::Info)
         .format_timestamp_millis()
@@ -1001,14 +1096,21 @@ pub fn run() {
         match AppCore::new().await {
             Ok(core) => {
                 info!("应用核心初始化成功");
-                if let Err(e) = core.start().await { error!("应用启动失败: {}", e); }
+                if let Err(e) = core.start().await {
+                    error!("应用启动失败: {}", e);
+                }
                 core
             }
-            Err(e) => { error!("应用核心初始化失败: {}", e); panic!("无法初始化应用核心: {}", e); }
+            Err(e) => {
+                error!("应用核心初始化失败: {}", e);
+                panic!("无法初始化应用核心: {}", e);
+            }
         }
     });
 
-    let app_state = AppState { core: Arc::new(Mutex::new(app_core)) };
+    let app_state = AppState {
+        core: Arc::new(Mutex::new(app_core)),
+    };
 
     let result = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
@@ -1020,7 +1122,6 @@ pub fn run() {
             restore_main_window(app);
         }))
         .plugin(tauri_plugin_deep_link::init())
-        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_clipboard_manager::init())
@@ -1055,9 +1156,8 @@ pub fn run() {
             verify_share_password, get_download_url, diagnose_file_share_connection,
             download_remote_file, cancel_remote_download, export_logs, test_node_latency,
             download_remote_batch, detect_security_software,
+            configure_p2p_chat, update_p2p_chat_peers, stop_p2p_chat,
             send_p2p_chat_message, get_p2p_chat_messages, clear_p2p_chat_messages,
-            set_chat_peer_roster, clear_chat_peer_roster,
-            set_share_allowed_peers, clear_share_allowed_peers,
             open_screen_viewer_window,
             open_danmaku_window, close_danmaku_window,
             set_danmaku_ignore_cursor, danmaku_cursor_pos, save_danmaku_image,
@@ -1135,12 +1235,12 @@ pub fn run() {
                     }
                 });
             }
-            
+
             println!("🔍 [Setup] 尝试获取 AppState...");
             if let Some(state) = app.try_state::<AppState>() {
                 println!("✅ [Setup] 成功获取 AppState");
                 let core_hk = Arc::clone(&state.core);
-                
+
                 // 从用户配置读取自定义快捷键（缺省回落到默认键位），并完成注册。
                 // 用户在设置中修改后，前端会调用 apply_hotkeys 命令重新注册，无需重启。
                 let bindings = tauri::async_runtime::block_on(async {
@@ -1178,7 +1278,7 @@ pub fn run() {
                         }
                     }
                 }
-                
+
                 // 应用窗口配置
                 if let Some(state) = app.try_state::<AppState>() {
                     let core = Arc::clone(&state.core);
@@ -1187,7 +1287,7 @@ pub fn run() {
                         let config_manager = core.lock().await.get_config_manager();
                         let cfg_mgr = config_manager.lock().await;
                         let config = cfg_mgr.get_config();
-                        
+
                         // 应用窗口置顶设置
                         let always_on_top = config.always_on_top.unwrap_or(true);
                         if let Err(e) = win.set_always_on_top(always_on_top) {
@@ -1195,7 +1295,7 @@ pub fn run() {
                         } else {
                             info!("窗口置顶设置成功: {}", always_on_top);
                         }
-                        
+
                         // 应用窗口位置设置
                         let remember_position = config.remember_window_position.unwrap_or(false);
                         if remember_position {
@@ -1287,6 +1387,9 @@ pub fn run() {
             }
         })
         .run(tauri::generate_context!());
-    if let Err(e) = result { error!("运行错误: {}", e); panic!("error: {}", e); }
+    if let Err(e) = result {
+        error!("运行错误: {}", e);
+        panic!("error: {}", e);
+    }
     info!("MCTier 应用程序已关闭");
 }

--- a/src-tauri/src/modules/app_core.rs
+++ b/src-tauri/src/modules/app_core.rs
@@ -1,19 +1,19 @@
 // AppCore 模块 - 应用程序核心
 // 负责应用程序生命周期管理、模块初始化、全局状态维护
 
+use log::{info, warn};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use log::{info, warn};
 
-use super::config_manager::ConfigManager;
-use super::lobby_manager::LobbyManager;
-use super::network_service::{NetworkService, NetworkConfig};
-use super::voice_service::VoiceService;
-use super::p2p_signaling::P2PSignalingService;
-use super::websocket_signaling::WebSocketSignalingServer;
-use super::file_transfer::FileTransferService;
 use super::chat_service::ChatService;
+use super::config_manager::ConfigManager;
 use super::error::AppError;
+use super::file_transfer::FileTransferService;
+use super::lobby_manager::LobbyManager;
+use super::network_service::{NetworkConfig, NetworkService};
+use super::p2p_signaling::P2PSignalingService;
+use super::voice_service::VoiceService;
+use super::websocket_signaling::WebSocketSignalingServer;
 
 /// 应用程序状态枚举
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,7 +29,7 @@ pub enum AppState {
 }
 
 /// 应用程序核心结构体
-/// 
+///
 /// 负责协调所有子模块的交互，管理应用程序的生命周期
 pub struct AppCore {
     /// 大厅管理器
@@ -54,19 +54,19 @@ pub struct AppCore {
 
 impl AppCore {
     /// 初始化应用核心
-    /// 
+    ///
     /// 创建所有子模块实例并初始化配置
-    /// 
+    ///
     /// # 返回
-    /// 
+    ///
     /// * `Ok(AppCore)` - 成功初始化的应用核心实例
     /// * `Err(AppError)` - 初始化失败的错误信息
-    /// 
+    ///
     /// # 示例
-    /// 
+    ///
     /// ```no_run
     /// use mctier::modules::app_core::AppCore;
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let app_core = AppCore::new().await.unwrap();
@@ -137,11 +137,11 @@ impl AppCore {
     }
 
     /// 启动应用
-    /// 
+    ///
     /// 执行应用启动时的必要操作
-    /// 
+    ///
     /// # 返回
-    /// 
+    ///
     /// * `Ok(())` - 启动成功
     /// * `Err(AppError)` - 启动失败的错误信息
     pub async fn start(&self) -> Result<(), AppError> {
@@ -169,15 +169,15 @@ impl AppCore {
     }
 
     /// 关闭应用
-    /// 
+    ///
     /// 执行应用关闭时的清理操作，包括：
     /// - 断开所有网络连接
     /// - 停止所有音频流
     /// - 终止子进程
     /// - 清理资源
-    /// 
+    ///
     /// # 返回
-    /// 
+    ///
     /// * `Ok(())` - 关闭成功
     /// * `Err(AppError)` - 关闭失败的错误信息
     pub async fn shutdown(&self) -> Result<(), AppError> {
@@ -203,7 +203,13 @@ impl AppCore {
 
         // 退出大厅（如果在大厅中）
         let network_service_ref = self.network_service.lock().await;
-        match self.lobby_manager.lock().await.leave_lobby(&*network_service_ref).await {
+        match self
+            .lobby_manager
+            .lock()
+            .await
+            .leave_lobby(&*network_service_ref)
+            .await
+        {
             Ok(_) => info!("已退出大厅"),
             Err(e) => {
                 // 如果不在大厅中，这是正常的
@@ -213,7 +219,7 @@ impl AppCore {
             }
         }
         drop(network_service_ref);
-        
+
         // 额外的hosts清理：确保清理所有可能的MCTier hosts记录
         // 这是一个保险措施，防止因为异常退出导致hosts文件残留
         info!("执行彻底的hosts文件清理...");
@@ -239,17 +245,24 @@ impl AppCore {
     }
 
     /// 设置 Tauri 应用句柄
-    /// 
+    ///
     /// 必须在使用网络服务之前调用此方法
-    /// 
+    ///
     /// # 参数
-    /// 
+    ///
     /// * `app_handle` - Tauri 应用句柄
     pub async fn set_app_handle(&self, app_handle: tauri::AppHandle) {
         info!("设置 Tauri 应用句柄");
-        self.network_service.lock().await.set_app_handle(app_handle.clone());
-        self.p2p_signaling.lock().await.set_app_handle(app_handle.clone()).await;
-        
+        self.network_service
+            .lock()
+            .await
+            .set_app_handle(app_handle.clone());
+        self.p2p_signaling
+            .lock()
+            .await
+            .set_app_handle(app_handle.clone())
+            .await;
+
         // 如果WebSocket信令服务器已创建，也设置其app_handle
         if let Some(ws_server) = self.websocket_signaling.lock().await.as_ref() {
             ws_server.set_app_handle(app_handle).await;
@@ -257,18 +270,18 @@ impl AppCore {
     }
 
     /// 获取应用状态
-    /// 
+    ///
     /// # 返回
-    /// 
+    ///
     /// 当前应用状态的克隆
     pub async fn get_state(&self) -> AppState {
         self.state.lock().await.clone()
     }
 
     /// 设置应用状态
-    /// 
+    ///
     /// # 参数
-    /// 
+    ///
     /// * `new_state` - 新的应用状态
     pub async fn set_state(&self, new_state: AppState) {
         let mut state = self.state.lock().await;
@@ -312,28 +325,32 @@ impl AppCore {
     }
 
     /// 启动WebSocket信令服务器（创建大厅时调用）
-    /// 
+    ///
     /// # 参数
-    /// 
+    ///
     /// * `virtual_ip` - 虚拟IP地址
     /// * `port` - 监听端口（默认8445）
-    /// 
+    ///
     /// # 返回
-    /// 
+    ///
     /// * `Ok(())` - 启动成功
     /// * `Err(AppError)` - 启动失败
-    pub async fn start_websocket_signaling(&self, virtual_ip: String, port: u16) -> Result<(), AppError> {
+    pub async fn start_websocket_signaling(
+        &self,
+        virtual_ip: String,
+        port: u16,
+    ) -> Result<(), AppError> {
         info!("启动WebSocket信令服务器: {}:{}", virtual_ip, port);
-        
+
         // 创建WebSocket信令服务器
         let ws_server = WebSocketSignalingServer::new(&virtual_ip, port);
-        
+
         // 启动服务器
         ws_server.start().await?;
-        
+
         // 保存服务器实例
         *self.websocket_signaling.lock().await = Some(ws_server);
-        
+
         info!("✅ WebSocket信令服务器启动成功");
         Ok(())
     }
@@ -341,34 +358,40 @@ impl AppCore {
     /// 停止WebSocket信令服务器
     pub async fn stop_websocket_signaling(&self) -> Result<(), AppError> {
         info!("停止WebSocket信令服务器");
-        
+
         if let Some(ws_server) = self.websocket_signaling.lock().await.as_ref() {
             ws_server.stop().await?;
         }
-        
+
         *self.websocket_signaling.lock().await = None;
-        
+
         info!("✅ WebSocket信令服务器已停止");
         Ok(())
     }
 
     /// 切换麦克风状态
-    /// 
+    ///
     /// # 返回
-    /// 
+    ///
     /// * `Ok(bool)` - 新的麦克风状态（true=开启，false=关闭）
     /// * `Err(AppError)` - 切换失败的错误信息
     pub async fn toggle_mic(&self) -> Result<bool, AppError> {
         info!("切换麦克风状态");
-        
+
         // 获取当前麦克风状态
         let voice_service = self.voice_service.lock().await;
         let current_state = voice_service.is_mic_enabled();
         let new_state = !current_state;
-        
+
         // 切换状态
         drop(voice_service);
-        match self.voice_service.lock().await.set_mic_enabled(new_state).await {
+        match self
+            .voice_service
+            .lock()
+            .await
+            .set_mic_enabled(new_state)
+            .await
+        {
             Ok(state) => {
                 info!("麦克风状态已切换: {} -> {}", current_state, state);
                 Ok(state)
@@ -418,7 +441,7 @@ mod tests {
         // 测试应用关闭
         let app_core = AppCore::new().await.unwrap();
         app_core.start().await.unwrap();
-        
+
         let result = app_core.shutdown().await;
         assert!(result.is_ok(), "应用关闭应该成功");
 
@@ -430,7 +453,7 @@ mod tests {
     async fn test_state_transitions() {
         // 测试状态转换
         let app_core = AppCore::new().await.unwrap();
-        
+
         // 初始状态
         assert_eq!(app_core.get_state().await, AppState::Idle);
 
@@ -443,7 +466,9 @@ mod tests {
         assert_eq!(app_core.get_state().await, AppState::InLobby);
 
         // 设置为错误状态
-        app_core.set_state(AppState::Error("测试错误".to_string())).await;
+        app_core
+            .set_state(AppState::Error("测试错误".to_string()))
+            .await;
         assert_eq!(
             app_core.get_state().await,
             AppState::Error("测试错误".to_string())

--- a/src-tauri/src/modules/chat_service.rs
+++ b/src-tauri/src/modules/chat_service.rs
@@ -1,33 +1,55 @@
 /**
- * P2P 聊天服务模块
- * 基于 HTTP over WireGuard 的点对点聊天
- * 不依赖中心服务器，直接在虚拟局域网中传输
+ * P2P chat service.
+ *
+ * The HTTP service is deliberately scoped to the current EasyTier interface.
+ * A signaling-issued, per-lobby token authenticates every request; the TCP
+ * peer address is then mapped to the authoritative player identity received
+ * from signaling. Request fields such as player_id/player_name are never used
+ * for authorization or attribution.
  */
-
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use axum::{
-    extract::{ConnectInfo, Query, State},
-    http::StatusCode,
-    response::sse::{Event, Sse},
+    body::Bytes,
+    extract::{ConnectInfo, DefaultBodyLimit, Query, State},
+    http::{header, HeaderMap, StatusCode},
+    response::sse::{Event, KeepAlive, Sse},
     routing::{get, post},
     Json, Router,
 };
 use futures_util::stream::Stream;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Mutex};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
+
 use super::http_cors::lan_cors_layer;
 
-const CHAT_SERVER_PORT: u16 = 14540; // 聊天服务端口
-const MAX_MESSAGES_PER_PLAYER: usize = 1000; // 每个玩家最多保存1000条消息
+pub const CHAT_SERVER_PORT: u16 = 14540;
+pub const CHAT_TOKEN_HEX_BYTES: usize = 64;
+pub const MAX_HISTORY_MESSAGES: usize = 1000;
+pub const MAX_HISTORY_BYTES: usize = 4 * 1024 * 1024;
+pub const MAX_HTTP_BODY_BYTES: usize = 2 * 1024 * 1024;
+pub const MAX_TEXT_BYTES: usize = 16 * 1024;
+pub const MAX_IMAGE_BYTES: usize = 512 * 1024;
+pub const MAX_IMAGE_CONTENT_BYTES: usize = 256;
+pub const MAX_ANNOUNCE_BYTES: usize = 16 * 1024;
+pub const MAX_VOICE_GROUP_BYTES: usize = 32;
+pub const MAX_CLIPBOARD_BYTES: usize = 16 * 1024;
+pub const MAX_TODO_BYTES: usize = 64 * 1024;
+pub const MAX_WHITEBOARD_BYTES: usize = 64 * 1024;
+pub const MAX_RECALL_BYTES: usize = 128;
+pub const MAX_AVATAR_BYTES: usize = 192 * 1024;
+pub const MAX_ID_BYTES: usize = 128;
+pub const MAX_PLAYER_NAME_BYTES: usize = 256;
+pub const MAX_CHAT_PEERS: usize = 64;
+pub const RECALL_WINDOW_SECS: u64 = 2 * 60;
+pub const CHAT_TOKEN_HEADER: &str = "x-mctier-chat-token";
 
-/// 聊天消息
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub id: String,
@@ -36,41 +58,41 @@ pub struct ChatMessage {
     pub content: String,
     pub message_type: MessageType,
     pub timestamp: u64,
-    pub image_data: Option<Vec<u8>>, // 图片数据（Base64编码后的字节）
+    pub image_data: Option<Vec<u8>>,
 }
 
-/// 消息类型
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum MessageType {
     Text,
     Image,
-    /// 大厅公告（控制消息，不计入聊天记录）
     Announce,
-    /// 语音小队组别（控制消息）
     VoiceGroup,
-    /// 共享剪贴板（控制消息，content 为文本）
     Clipboard,
-    /// 个人待办（控制消息，content 为待办列表 JSON）
     Todo,
-    /// 共享白板（控制消息，content 为单笔画/清空指令 JSON）
     Whiteboard,
-    /// 撤回聊天消息（控制消息，content 为目标消息 ID）
     Recall,
-    /// 头像同步（控制消息，content 为头像 data URL）
     Avatar,
 }
 
-/// 获取消息请求参数
 #[derive(Debug, Deserialize)]
 pub struct GetMessagesQuery {
-    pub since: Option<u64>, // 获取此时间戳之后的消息
+    pub since: Option<u64>,
 }
 
-/// 发送消息请求
+/// Authoritative identity received from the authenticated signaling snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChatPeerIdentity {
+    pub player_id: String,
+    pub player_name: String,
+    pub virtual_ip: String,
+}
+
+/// Player fields are retained for wire compatibility but are ignored by the
+/// receiver in favor of the TCP source IP identity map.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SendMessageRequest {
-    /// 消息ID（由发送方生成并随 POST 传递，保证同一条消息在所有端 ID 一致，便于去重与历史同步）
     #[serde(default)]
     pub id: Option<String>,
     pub player_id: String,
@@ -80,447 +102,681 @@ pub struct SendMessageRequest {
     pub image_data: Option<Vec<u8>>,
 }
 
-/// 聊天服务状态
-pub struct ChatService {
-    /// 本地消息队列（保存自己发送的消息）
+#[derive(Debug, Clone)]
+struct RateLimitKey {
+    player_id: String,
+    ip: IpAddr,
+}
+
+impl PartialEq for RateLimitKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.player_id == other.player_id && self.ip == other.ip
+    }
+}
+
+impl Eq for RateLimitKey {}
+
+impl std::hash::Hash for RateLimitKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.player_id.hash(state);
+        self.ip.hash(state);
+    }
+}
+
+#[derive(Clone)]
+struct AppState {
     local_messages: Arc<RwLock<VecDeque<ChatMessage>>>,
-    /// 虚拟IP地址
-    virtual_ip: Arc<RwLock<Option<String>>>,
-    /// 服务器句柄
-    server_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
-    /// 消息广播通道（用于SSE推送）
+    history_bytes: Arc<RwLock<usize>>,
     message_tx: broadcast::Sender<ChatMessage>,
-    /// 大厅身份名册：player_id -> 虚拟 IP。
-    ///
-    /// 由前端在玩家列表变化时下发（数据源是信令服务器的大厅成员列表），
-    /// 用于校验 `/api/chat/send` 里自称的 `player_id` 是否与其真实来源 IP 相符。
-    peer_roster: Arc<RwLock<HashMap<String, String>>>,
-    /// 允许读取本机聊天记录的成员 IP 集合。
-    ///
-    /// 读取类接口（历史与 SSE 流）不携带 player_id，只能按来源 IP 判断，
-    /// 因此单独维护一份 IP 集合。前端仅在"所有成员虚拟IP均已就绪"时才下发，
-    /// 避免 IP 尚未同步的合法成员被误拒。
-    allowed_readers: Arc<RwLock<HashSet<String>>>,
+    session: Arc<RwLock<Option<ChatSession>>>,
+    rate_limiter: Arc<Mutex<HashMap<RateLimitKey, VecDeque<Instant>>>>,
+}
+
+#[derive(Debug, Clone)]
+struct ChatSession {
+    token: String,
+    epoch: u64,
+    identities: HashMap<IpAddr, ChatPeerIdentity>,
+    local_identity: ChatPeerIdentity,
+    host_id: Option<String>,
+}
+
+pub struct ChatService {
+    local_messages: Arc<RwLock<VecDeque<ChatMessage>>>,
+    history_bytes: Arc<RwLock<usize>>,
+    virtual_ip: Arc<RwLock<Option<String>>>,
+    server_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
+    message_tx: broadcast::Sender<ChatMessage>,
+    session: Arc<RwLock<Option<ChatSession>>>,
+    rate_limiter: Arc<Mutex<HashMap<RateLimitKey, VecDeque<Instant>>>>,
 }
 
 impl ChatService {
     pub fn new() -> Self {
-        // 【优化】创建广播通道，容量增加到500条消息，支持大图片传输
-        let (tx, _rx) = broadcast::channel(500);
-        
+        let (message_tx, _rx) = broadcast::channel(256);
         Self {
             local_messages: Arc::new(RwLock::new(VecDeque::new())),
+            history_bytes: Arc::new(RwLock::new(0)),
             virtual_ip: Arc::new(RwLock::new(None)),
             server_handle: Arc::new(RwLock::new(None)),
-            message_tx: tx,
-            peer_roster: Arc::new(RwLock::new(HashMap::new())),
-            allowed_readers: Arc::new(RwLock::new(HashSet::new())),
+            message_tx,
+            session: Arc::new(RwLock::new(None)),
+            rate_limiter: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    /// 设置虚拟IP地址
     pub fn set_virtual_ip(&self, ip: String) {
-        log::info!("📡 [ChatService] 设置虚拟IP: {}", ip);
         *self.virtual_ip.write() = Some(ip);
     }
 
-    /// 获取虚拟IP地址
     pub fn get_virtual_ip(&self) -> Option<String> {
         self.virtual_ip.read().clone()
     }
 
-    /// 更新大厅身份名册（player_id -> 虚拟 IP）。
-    ///
-    /// 只保留同时具备 ID 与 IP 的条目：缺 IP 的玩家无法参与身份校验，
-    /// 塞进名册反而会把合法消息判成冒名。
-    pub fn set_peer_roster(&self, entries: Vec<(String, String)>) {
-        let roster: HashMap<String, String> = entries
-            .into_iter()
-            .filter(|(id, ip)| !id.trim().is_empty() && !ip.trim().is_empty())
-            .collect();
-        log::info!("🪪 [ChatService] 更新身份名册，共 {} 名玩家", roster.len());
-        *self.peer_roster.write() = roster;
+    pub fn get_chat_token(&self) -> Option<String> {
+        self.session
+            .read()
+            .as_ref()
+            .map(|session| session.token.clone())
     }
 
-    /// 更新允许读取聊天记录的成员 IP 集合（必须含本机：本机要自订阅 SSE 流）
-    pub fn set_allowed_readers(&self, ips: Vec<String>) {
-        let readers: HashSet<String> = ips
-            .into_iter()
-            .filter(|ip| !ip.trim().is_empty())
-            .collect();
-        log::info!("🪪 [ChatService] 更新可读取成员，共 {} 个地址", readers.len());
-        *self.allowed_readers.write() = readers;
+    pub fn get_local_identity(&self) -> Option<ChatPeerIdentity> {
+        self.session
+            .read()
+            .as_ref()
+            .map(|session| session.local_identity.clone())
     }
 
-    /// 清空身份名册与可读取成员（退出大厅时调用，避免影响下一个大厅）
-    pub fn clear_peer_roster(&self) {
-        self.peer_roster.write().clear();
-        self.allowed_readers.write().clear();
-    }
-
-    /// 启动HTTP聊天服务器
-    pub async fn start_server(&self) -> Result<(), Box<dyn std::error::Error>> {
-        // 【修复】启动前先停止可能存在的旧实例，避免端口占用与任务句柄泄漏（重进大厅场景）
-        self.stop_server().await;
-
-        let virtual_ip = match self.get_virtual_ip() {
-            Some(ip) => ip,
-            None => {
-                log::error!("❌ [ChatService] 虚拟IP未设置，无法启动聊天服务器");
-                return Err("虚拟IP未设置".into());
-            }
+    pub fn set_session(
+        &self,
+        token: String,
+        epoch: u64,
+        player_id: String,
+        player_name: String,
+        host_id: Option<String>,
+        peers: Vec<ChatPeerIdentity>,
+    ) -> Result<(), String> {
+        if !is_valid_chat_token(&token) {
+            return Err("聊天令牌格式无效".to_string());
+        }
+        if epoch == 0 {
+            return Err("聊天令牌 epoch 无效".to_string());
+        }
+        let virtual_ip = self
+            .get_virtual_ip()
+            .ok_or_else(|| "虚拟IP未设置".to_string())?;
+        let local = ChatPeerIdentity {
+            player_id,
+            player_name,
+            virtual_ip,
         };
+        let map = build_identity_map(&local, peers)?;
+        validate_host_id(host_id.as_deref(), &map)?;
 
-        log::info!("🔍 [ChatService] 检查虚拟IP是否就绪: {}", virtual_ip);
-        
-        // 等待虚拟IP就绪
-        let mut attempts = 0;
-        let max_attempts = 20;
-        loop {
-            match tokio::net::TcpListener::bind(format!("{}:0", virtual_ip)).await {
-                Ok(test_listener) => {
-                    drop(test_listener);
-                    log::info!("✅ [ChatService] 虚拟IP已就绪");
-                    break;
-                }
-                Err(e) => {
-                    attempts += 1;
-                    if attempts >= max_attempts {
-                        log::error!("❌ [ChatService] 虚拟IP未就绪，超时: {}", e);
-                        return Err(format!("虚拟IP未就绪: {}", e).into());
-                    }
-                    log::warn!("⏳ [ChatService] 虚拟IP尚未就绪，等待中... ({}/{})", attempts, max_attempts);
-                    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-                }
+        let mut session = self.session.write();
+        if let Some(current) = session.as_ref() {
+            if current.local_identity != local {
+                return Err("聊天会话身份发生变化，必须先停止旧会话".to_string());
+            }
+            if epoch < current.epoch {
+                return Err("拒绝过期的聊天令牌 epoch".to_string());
+            }
+            if epoch == current.epoch && token != current.token {
+                return Err("同一聊天 epoch 收到不一致令牌".to_string());
             }
         }
-
-        let addr = format!("{}:{}", virtual_ip, CHAT_SERVER_PORT);
-        log::info!("📍 [ChatService] 聊天服务器将监听虚拟IP: {}", addr);
-
-        let local_messages = self.local_messages.clone();
-        let message_tx = self.message_tx.clone();
-
-        // 创建路由
-        let app = Router::new()
-            .route("/api/chat/messages", get(get_messages))
-            .route("/api/chat/send", post(send_message))
-            .route("/api/chat/stream", get(stream_messages)) // 新增SSE端点
-            .layer(lan_cors_layer())
-            .with_state(AppState {
-                local_messages: local_messages.clone(),
-                message_tx: message_tx.clone(),
-                peer_roster: self.peer_roster.clone(),
-                allowed_readers: self.allowed_readers.clone(),
-            });
-
-        log::info!("🚀 [ChatService] 正在启动聊天服务器...");
-
-        // 绑定端口
-        let listener = match tokio::net::TcpListener::bind(&addr).await {
-            Ok(l) => {
-                log::info!("✅ [ChatService] 成功绑定端口 {}", CHAT_SERVER_PORT);
-                l
-            }
-            Err(e) => {
-                log::error!("❌ [ChatService] 绑定端口失败: {} - 错误: {}", CHAT_SERVER_PORT, e);
-                return Err(format!("绑定端口失败: {}", e).into());
-            }
-        };
-
-        // 启动服务器
-        let server_task = tokio::spawn(async move {
-            log::info!("🌐 [ChatService] 聊天服务器开始监听请求...");
-            // 需要 ConnectInfo 才能拿到对端真实地址，用于校验消息发送者身份
-            let service = app.into_make_service_with_connect_info::<SocketAddr>();
-            if let Err(e) = axum::serve(listener, service).await {
-                log::error!("❌ [ChatService] 服务器运行错误: {}", e);
-            } else {
-                log::info!("🛑 [ChatService] 聊天服务器已正常停止");
-            }
+        *session = Some(ChatSession {
+            token,
+            epoch,
+            identities: map,
+            local_identity: local,
+            host_id,
         });
-
-        *self.server_handle.write() = Some(server_task);
-
-        log::info!("✅ [ChatService] 聊天服务器启动成功！");
-        log::info!("📡 [ChatService] 监听地址: {}:{}（仅虚拟网卡）", virtual_ip, CHAT_SERVER_PORT);
-        log::info!("📡 [ChatService] 虚拟IP: {}", virtual_ip);
-        
-        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-        log::info!("🎉 [ChatService] 聊天服务器已完全就绪");
-
         Ok(())
     }
 
-    /// 停止聊天服务器
+    pub fn update_peer_identities(
+        &self,
+        peers: Vec<ChatPeerIdentity>,
+        host_id: Option<String>,
+    ) -> Result<(), String> {
+        let mut session = self.session.write();
+        let current = session
+            .as_mut()
+            .ok_or_else(|| "聊天会话尚未初始化".to_string())?;
+        let local = current.local_identity.clone();
+        let map = build_identity_map(&local, peers)?;
+        validate_host_id(host_id.as_deref(), &map)?;
+        current.host_id = host_id;
+        current.identities = map;
+        Ok(())
+    }
+
+    pub fn allowed_peer_ips(&self, requested: &[String]) -> Vec<String> {
+        let session = self.session.read();
+        let Some(session) = session.as_ref() else {
+            return Vec::new();
+        };
+        requested
+            .iter()
+            .filter_map(|raw| {
+                let ip = raw.parse::<IpAddr>().ok()?;
+                let identity = session.identities.get(&ip)?;
+                if session.local_identity.player_id == identity.player_id {
+                    return None;
+                }
+                Some(ip.to_string())
+            })
+            .collect()
+    }
+
+    pub fn authoritative_peers(&self) -> Vec<ChatPeerIdentity> {
+        let session = self.session.read();
+        let Some(session) = session.as_ref() else {
+            return Vec::new();
+        };
+        let mut peers = session
+            .identities
+            .values()
+            .filter(|identity| identity.player_id != session.local_identity.player_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        peers.sort_by(|left, right| left.player_id.cmp(&right.player_id));
+        peers
+    }
+
+    pub fn local_is_host(&self) -> bool {
+        self.session.read().as_ref().is_some_and(|session| {
+            session.host_id.as_deref() == Some(session.local_identity.player_id.as_str())
+        })
+    }
+
+    pub fn get_host_id(&self) -> Option<String> {
+        self.session
+            .read()
+            .as_ref()
+            .and_then(|session| session.host_id.clone())
+    }
+
+    pub fn clear_session(&self) {
+        *self.session.write() = None;
+    }
+
+    /// Start only after a signaling-issued token has configured this session.
+    pub async fn start_server(&self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.is_running() {
+            return Ok(());
+        }
+        let session = self
+            .session
+            .read()
+            .clone()
+            .ok_or_else(|| "聊天会话未就绪".to_string())?;
+        if !is_valid_chat_token(&session.token) {
+            return Err("聊天令牌格式无效".into());
+        }
+        let virtual_ip = self
+            .get_virtual_ip()
+            .ok_or_else(|| "虚拟IP未设置".to_string())?;
+        let ip = parse_chat_ipv4(&virtual_ip)
+            .ok_or_else(|| "聊天服务只能绑定可用的 EasyTier 虚拟 IPv4".to_string())?;
+        if session.local_identity.virtual_ip != ip.to_string() {
+            return Err("聊天会话身份与绑定虚拟 IP 不一致".into());
+        }
+
+        let app = Router::new()
+            .route("/api/chat/messages", get(get_messages))
+            .route("/api/chat/send", post(send_message))
+            .route("/api/chat/stream", get(stream_messages))
+            .layer(DefaultBodyLimit::max(MAX_HTTP_BODY_BYTES))
+            .layer(lan_cors_layer())
+            .with_state(AppState {
+                local_messages: Arc::clone(&self.local_messages),
+                history_bytes: Arc::clone(&self.history_bytes),
+                message_tx: self.message_tx.clone(),
+                session: Arc::clone(&self.session),
+                rate_limiter: Arc::clone(&self.rate_limiter),
+            });
+        let listener =
+            tokio::net::TcpListener::bind(SocketAddr::new(IpAddr::V4(ip), CHAT_SERVER_PORT))
+                .await?;
+        let server_task = tokio::spawn(async move {
+            if let Err(error) = axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            {
+                log::error!("聊天服务器运行错误: {}", error);
+            }
+        });
+        *self.server_handle.write() = Some(server_task);
+        Ok(())
+    }
+
     pub async fn stop_server(&self) {
         if let Some(handle) = self.server_handle.write().take() {
             handle.abort();
-            log::info!("🛑 [ChatService] 聊天服务器已停止");
         }
+        self.clear_session();
+        self.clear_local_messages();
+        self.rate_limiter.lock().await.clear();
+        *self.virtual_ip.write() = None;
     }
 
-    /// 检查服务器是否正在运行
     pub fn is_running(&self) -> bool {
         self.server_handle.read().is_some()
     }
 
-    /// 添加本地消息
-    pub fn add_local_message(&self, message: ChatMessage) {
-        let mut messages = self.local_messages.write();
-        messages.push_back(message.clone());
-        
-        // 限制消息数量
-        while messages.len() > MAX_MESSAGES_PER_PLAYER {
-            messages.pop_front();
-        }
-        
-        // 广播消息到所有SSE订阅者
-        let _ = self.message_tx.send(message);
+    pub fn add_local_message(&self, message: ChatMessage) -> bool {
+        store_message(
+            &self.local_messages,
+            &self.history_bytes,
+            &self.message_tx,
+            message,
+        )
     }
 
-    /// 获取本地消息
     pub fn get_local_messages(&self, since: Option<u64>) -> Vec<ChatMessage> {
         let messages = self.local_messages.read();
-        
-        if let Some(timestamp) = since {
-            messages
-                .iter()
-                .filter(|msg| msg.timestamp > timestamp)
-                .cloned()
-                .collect()
-        } else {
-            messages.iter().cloned().collect()
-        }
-    }
-
-    /// 清空本地消息
-    pub fn clear_local_messages(&self) {
-        self.local_messages.write().clear();
-        log::info!("🗑️ [ChatService] 已清空本地消息");
-    }
-}
-
-/// Axum 应用状态
-#[derive(Clone)]
-struct AppState {
-    local_messages: Arc<RwLock<VecDeque<ChatMessage>>>,
-    message_tx: broadcast::Sender<ChatMessage>,
-    peer_roster: Arc<RwLock<HashMap<String, String>>>,
-    allowed_readers: Arc<RwLock<HashSet<String>>>,
-}
-
-/// 判断调用方是否有权读取本机聊天记录。
-///
-/// 集合为空时放行（尚未下发、或对端为旧版本客户端）；非空则要求来源 IP 在册，
-/// 从而阻止被移出大厅但仍留在 EasyTier 虚拟网内的节点继续拉取聊天历史。
-fn is_allowed_reader(allowed: &HashSet<String>, peer_ip: std::net::IpAddr) -> bool {
-    if allowed.is_empty() {
-        return true;
-    }
-    allowed.iter().any(|entry| {
-        entry
-            .parse::<std::net::IpAddr>()
-            .map(|ip| ip == peer_ip)
-            .unwrap_or(false)
-    })
-}
-
-/// 获取消息列表
-async fn get_messages(
-    State(state): State<AppState>,
-    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
-    Query(params): Query<GetMessagesQuery>,
-) -> Result<Json<Vec<ChatMessage>>, StatusCode> {
-    // 非大厅成员不得拉取聊天历史
-    {
-        let allowed = state.allowed_readers.read();
-        if !is_allowed_reader(&allowed, peer_addr.ip()) {
-            log::warn!(
-                "🚫 [ChatService] 拒绝非大厅成员拉取聊天历史：来源 {}",
-                peer_addr.ip()
-            );
-            return Err(StatusCode::FORBIDDEN);
-        }
-    }
-
-    let messages = state.local_messages.read();
-    
-    let result: Vec<ChatMessage> = if let Some(since) = params.since {
         messages
             .iter()
-            .filter(|msg| msg.timestamp > since)
+            .filter(|message| since.is_none_or(|timestamp| message.timestamp > timestamp))
             .cloned()
             .collect()
-    } else {
-        messages.iter().cloned().collect()
-    };
-    
-    log::info!("📋 [ChatService] 收到获取消息请求，返回 {} 条消息", result.len());
+    }
 
-    Ok(Json(result))
+    pub fn clear_local_messages(&self) {
+        self.local_messages.write().clear();
+        *self.history_bytes.write() = 0;
+    }
 }
 
-/// 简单的按玩家滑动窗口限流：防止同大厅恶意成员刷屏。
-/// 规则：每个 player_id 在最近 3 秒内最多 12 条消息，超出则拒绝（429）。
-fn rate_limit_allow(player_id: &str) -> bool {
-    use std::collections::VecDeque;
-    use std::sync::{Mutex, OnceLock};
-    static LIMITER: OnceLock<Mutex<std::collections::HashMap<String, VecDeque<u128>>>> = OnceLock::new();
-    let m = LIMITER.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis()).unwrap_or(0);
-    let window_ms: u128 = 3000;
-    let max_in_window = 12usize;
-    let mut map = match m.lock() {
-        Ok(g) => g,
-        Err(_) => return true, // 锁异常时放行，不影响正常聊天
-    };
-    let dq = map.entry(player_id.to_string()).or_default();
-    while let Some(&front) = dq.front() {
-        if now.saturating_sub(front) > window_ms {
-            dq.pop_front();
-        } else {
-            break;
+fn build_identity_map(
+    local: &ChatPeerIdentity,
+    peers: Vec<ChatPeerIdentity>,
+) -> Result<HashMap<IpAddr, ChatPeerIdentity>, String> {
+    if peers.len() > MAX_CHAT_PEERS {
+        return Err("大厅聊天成员数量超过限制".to_string());
+    }
+    let mut map = HashMap::new();
+    let mut player_ids = HashSet::new();
+    for identity in std::iter::once(local.clone()).chain(peers) {
+        if identity.player_id.is_empty()
+            || identity.player_id.len() > MAX_ID_BYTES
+            || identity.player_id.chars().any(char::is_control)
+            || identity.player_name.is_empty()
+            || identity.player_name.len() > MAX_PLAYER_NAME_BYTES
+            || identity.player_name.chars().any(char::is_control)
+        {
+            return Err("大厅成员身份字段超出限制".to_string());
+        }
+        if !player_ids.insert(identity.player_id.clone()) {
+            return Err("大厅成员玩家ID重复".to_string());
+        }
+        let ip = parse_chat_ipv4(&identity.virtual_ip)
+            .ok_or_else(|| "大厅成员必须使用可用的 EasyTier 虚拟 IPv4".to_string())?;
+        let normalized = ChatPeerIdentity {
+            virtual_ip: ip.to_string(),
+            ..identity
+        };
+        if map.insert(IpAddr::V4(ip), normalized).is_some() {
+            return Err("大厅成员虚拟IP重复".to_string());
         }
     }
-    if dq.len() >= max_in_window {
+    Ok(map)
+}
+
+fn parse_chat_ipv4(raw: &str) -> Option<Ipv4Addr> {
+    let ip = raw.trim().parse::<Ipv4Addr>().ok()?;
+    let octets = ip.octets();
+    if octets[..3] != [10, 126, 126] || octets[3] == 0 || octets[3] == 255 {
+        return None;
+    }
+    Some(ip)
+}
+
+fn validate_host_id(
+    host_id: Option<&str>,
+    identities: &HashMap<IpAddr, ChatPeerIdentity>,
+) -> Result<(), String> {
+    if host_id.is_some_and(|host| {
+        !identities
+            .values()
+            .any(|identity| identity.player_id == host)
+    }) {
+        return Err("房主身份不在当前大厅成员列表中".to_string());
+    }
+    Ok(())
+}
+
+fn is_valid_chat_token(token: &str) -> bool {
+    token.len() == CHAT_TOKEN_HEX_BYTES
+        && token.as_bytes().iter().all(|byte| byte.is_ascii_hexdigit())
+}
+
+pub fn is_message_id_for_player(id: &str, player_id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= MAX_ID_BYTES
+        && !id.chars().any(char::is_control)
+        && [format!("msg-{player_id}-"), format!("recall-{player_id}-")]
+            .iter()
+            .any(|prefix| id.starts_with(prefix) && id.len() > prefix.len())
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    let mut difference = (left.len() ^ right.len()) as u8;
+    let max_len = left.len().max(right.len());
+    for index in 0..max_len {
+        let lhs = left.get(index).copied().unwrap_or(0);
+        let rhs = right.get(index).copied().unwrap_or(0);
+        difference |= lhs ^ rhs;
+    }
+    difference == 0
+}
+
+fn authenticated_identity(
+    headers: &HeaderMap,
+    peer: SocketAddr,
+    state: &AppState,
+) -> Result<ChatPeerIdentity, StatusCode> {
+    let supplied = headers
+        .get(CHAT_TOKEN_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    let session = state.session.read();
+    let session = session.as_ref().ok_or(StatusCode::UNAUTHORIZED)?;
+    if !constant_time_eq(supplied.as_bytes(), session.token.as_bytes()) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    session
+        .identities
+        .get(&peer.ip())
+        .cloned()
+        .ok_or(StatusCode::FORBIDDEN)
+}
+
+fn require_json_body(headers: &HeaderMap, body: &Bytes) -> Result<(), StatusCode> {
+    let mut content_lengths = headers.get_all(header::CONTENT_LENGTH).iter();
+    let content_length = content_lengths
+        .next()
+        .and_then(|value| value.to_str().ok())
+        .ok_or(StatusCode::LENGTH_REQUIRED)?;
+    if content_lengths.next().is_some() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let declared = content_length
+        .parse::<usize>()
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+    if declared != body.len() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    if declared > MAX_HTTP_BODY_BYTES {
+        return Err(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+    let media_type = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim)
+        .unwrap_or("");
+    if !media_type.eq_ignore_ascii_case("application/json") {
+        return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+    Ok(())
+}
+
+async fn allow_request(state: &AppState, identity: &ChatPeerIdentity, ip: IpAddr) -> bool {
+    let key = RateLimitKey {
+        player_id: identity.player_id.clone(),
+        ip,
+    };
+    let now = Instant::now();
+    let mut limiter = state.rate_limiter.lock().await;
+    let entries = limiter.entry(key).or_default();
+    while entries
+        .front()
+        .is_some_and(|timestamp| now.duration_since(*timestamp) > Duration::from_secs(3))
+    {
+        entries.pop_front();
+    }
+    if entries.len() >= 12 {
         return false;
     }
-    dq.push_back(now);
-    // 防止 map 无限增长：超过 256 个发送者时清理空队列
-    if map.len() > 256 {
-        map.retain(|_, v| !v.is_empty());
+    entries.push_back(now);
+    if limiter.len() > 256 {
+        limiter.retain(|_, entries| !entries.is_empty());
     }
     true
 }
 
-/// 校验消息里自称的 `player_id` 是否确实来自该玩家的虚拟 IP。
-///
-/// 攻击场景：同一大厅内任何成员都能直连他人的 14540 端口，此前 `/api/chat/send`
-/// 完全信任请求体里的 `player_id` / `player_name`，因此任意成员都可以伪造成
-/// 房主或其他玩家发言（含 `announce`、`recall`、`avatar` 等控制消息，危害不止于
-/// 聊天内容）。这里把自称身份与 TCP 连接的真实来源地址做绑定。
-///
-/// 判定规则（在"可用性优先"与"防冒名"之间取平衡）：
-/// - 名册为空（尚未下发或旧版本前端）时放行，避免升级过程中聊天直接不可用；
-/// - 名册中不存在该 `player_id` 时放行，交由上层去重/展示逻辑处理（新玩家刚加入、
-///   名册还没同步到本机是正常现象）；
-/// - 名册中存在该 `player_id` 但登记 IP 与来源 IP 不一致时拒绝，这就是冒名。
-///
-/// 消息不经任何中继，均由发送方直连接收方（见 `send_p2p_chat_message`），
-/// 所以来源 IP 就是发送方的真实虚拟 IP，可以直接作为身份凭据。
-fn sender_identity_matches(
-    roster: &std::collections::HashMap<String, String>,
-    player_id: &str,
-    peer_ip: std::net::IpAddr,
-) -> bool {
-    if roster.is_empty() {
-        return true;
+fn validate_request(
+    request: &SendMessageRequest,
+    identity: &ChatPeerIdentity,
+    state: &AppState,
+) -> Result<(), StatusCode> {
+    if request
+        .id
+        .as_deref()
+        .is_some_and(|id| !is_message_id_for_player(id, identity.player_id.as_str()))
+    {
+        return Err(StatusCode::BAD_REQUEST);
     }
-    match roster.get(player_id) {
-        Some(expected_ip) => expected_ip
-            .parse::<std::net::IpAddr>()
-            .map(|ip| ip == peer_ip)
-            .unwrap_or(true),
-        None => true,
-    }
-}
-
-/// 发送消息（接收其他玩家发送的消息）
-async fn send_message(
-    State(state): State<AppState>,
-    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
-    Json(req): Json<SendMessageRequest>,
-) -> Result<Json<ChatMessage>, StatusCode> {
-    // 身份绑定：拒绝冒用他人 player_id 的消息（含控制类消息）
-    if !req.player_id.is_empty() {
-        let roster = state.peer_roster.read();
-        if !sender_identity_matches(&roster, &req.player_id, peer_addr.ip()) {
-            log::warn!(
-                "🚫 [ChatService] 拒绝冒名消息：自称 {} 但来源为 {}",
-                req.player_id,
-                peer_addr.ip()
-            );
-            return Err(StatusCode::FORBIDDEN);
+    let content_bytes = request.content.as_bytes().len();
+    match request.message_type {
+        MessageType::Text => {
+            if content_bytes == 0 || content_bytes > MAX_TEXT_BYTES || request.image_data.is_some()
+            {
+                return Err(StatusCode::PAYLOAD_TOO_LARGE);
+            }
+        }
+        MessageType::Image => {
+            if content_bytes > MAX_IMAGE_CONTENT_BYTES {
+                return Err(StatusCode::PAYLOAD_TOO_LARGE);
+            }
+            let image = request.image_data.as_ref().ok_or(StatusCode::BAD_REQUEST)?;
+            if image.is_empty() || image.len() > MAX_IMAGE_BYTES {
+                return Err(StatusCode::PAYLOAD_TOO_LARGE);
+            }
+        }
+        MessageType::Announce => {
+            if content_bytes > MAX_ANNOUNCE_BYTES || request.image_data.is_some() {
+                return Err(StatusCode::PAYLOAD_TOO_LARGE);
+            }
+            if state
+                .session
+                .read()
+                .as_ref()
+                .and_then(|session| session.host_id.as_deref())
+                != Some(identity.player_id.as_str())
+            {
+                return Err(StatusCode::FORBIDDEN);
+            }
+        }
+        MessageType::VoiceGroup => {
+            if content_bytes > MAX_VOICE_GROUP_BYTES || request.image_data.is_some() {
+                return Err(StatusCode::PAYLOAD_TOO_LARGE);
+            }
+            let group = request
+                .content
+                .parse::<u8>()
+                .map_err(|_| StatusCode::BAD_REQUEST)?;
+            if group > 4 {
+                return Err(StatusCode::BAD_REQUEST);
+            }
+        }
+        MessageType::Clipboard => {
+            if content_bytes > MAX_CLIPBOARD_BYTES || request.image_data.is_some() {
+                return Err(StatusCode::PAYLOAD_TOO_LARGE);
+            }
+        }
+        MessageType::Todo => {
+            if content_bytes > MAX_TODO_BYTES || request.image_data.is_some() {
+                return Err(StatusCode::PAYLOAD_TOO_LARGE);
+            }
+        }
+        MessageType::Whiteboard => {
+            if content_bytes > MAX_WHITEBOARD_BYTES || request.image_data.is_some() {
+                return Err(StatusCode::PAYLOAD_TOO_LARGE);
+            }
+        }
+        MessageType::Recall => {
+            if content_bytes == 0
+                || content_bytes > MAX_RECALL_BYTES
+                || request.image_data.is_some()
+            {
+                return Err(StatusCode::BAD_REQUEST);
+            }
+            let messages = state.local_messages.read();
+            let target = messages
+                .iter()
+                .find(|message| message.id == request.content)
+                .ok_or(StatusCode::FORBIDDEN)?;
+            if target.player_id != identity.player_id
+                || unix_seconds().saturating_sub(target.timestamp) > RECALL_WINDOW_SECS
+            {
+                return Err(StatusCode::FORBIDDEN);
+            }
+        }
+        MessageType::Avatar => {
+            if content_bytes > MAX_AVATAR_BYTES
+                || request.image_data.is_some()
+                || (!request.content.is_empty() && !request.content.starts_with("data:image/"))
+            {
+                return Err(StatusCode::PAYLOAD_TOO_LARGE);
+            }
         }
     }
+    Ok(())
+}
 
-    // 限流：防止恶意成员刷屏（控制类消息如 voicegroup 不计入更严格限制，这里统一按 player 限流）
-    if !req.player_id.is_empty() && !rate_limit_allow(&req.player_id) {
-        log::warn!("⚠️ [ChatService] 玩家 {} 发送过于频繁，已限流", req.player_id);
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn message_size(message: &ChatMessage) -> Option<usize> {
+    serde_json::to_vec(message).ok().map(|bytes| bytes.len())
+}
+
+fn store_message(
+    local_messages: &Arc<RwLock<VecDeque<ChatMessage>>>,
+    history_bytes: &Arc<RwLock<usize>>,
+    message_tx: &broadcast::Sender<ChatMessage>,
+    message: ChatMessage,
+) -> bool {
+    let Some(size) = message_size(&message) else {
+        return false;
+    };
+    if size > MAX_HISTORY_BYTES {
+        return false;
+    }
+    let mut messages = local_messages.write();
+    let mut bytes = history_bytes.write();
+    if messages.iter().any(|stored| stored.id == message.id) {
+        return false;
+    }
+    while messages.len() >= MAX_HISTORY_MESSAGES || *bytes + size > MAX_HISTORY_BYTES {
+        if let Some(oldest) = messages.pop_front() {
+            *bytes = bytes.saturating_sub(message_size(&oldest).unwrap_or(0));
+        } else {
+            break;
+        }
+    }
+    *bytes += size;
+    messages.push_back(message.clone());
+    let _ = message_tx.send(message);
+    true
+}
+
+async fn get_messages(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(params): Query<GetMessagesQuery>,
+) -> Result<Json<Vec<ChatMessage>>, StatusCode> {
+    let identity = authenticated_identity(&headers, peer, &state)?;
+    if !allow_request(&state, &identity, peer.ip()).await {
         return Err(StatusCode::TOO_MANY_REQUESTS);
     }
-    log::info!("💬 [ChatService] 收到消息: {} - {}", req.player_name, req.content);
-    
-    let message = ChatMessage {
-        id: req.id.clone().unwrap_or_else(|| format!("msg-{}-{}", req.player_id, SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis())),
-        player_id: req.player_id,
-        player_name: req.player_name,
-        content: req.content,
-        message_type: req.message_type,
-        timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs(),
-        image_data: req.image_data,
-    };
-    
-    // 保存到本地消息队列
-    let mut messages = state.local_messages.write();
-    messages.push_back(message.clone());
-    
-    // 限制消息数量
-    while messages.len() > MAX_MESSAGES_PER_PLAYER {
-        messages.pop_front();
+    let messages = state.local_messages.read();
+    let result = messages
+        .iter()
+        .filter(|message| {
+            params
+                .since
+                .is_none_or(|timestamp| message.timestamp > timestamp)
+        })
+        .cloned()
+        .collect();
+    Ok(Json(result))
+}
+
+async fn send_message(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Json<ChatMessage>, StatusCode> {
+    let identity = authenticated_identity(&headers, peer, &state)?;
+    if !allow_request(&state, &identity, peer.ip()).await {
+        return Err(StatusCode::TOO_MANY_REQUESTS);
     }
-    
-    // 广播消息到所有SSE订阅者
-    let _ = state.message_tx.send(message.clone());
-    
+    require_json_body(&headers, &body)?;
+    let request =
+        serde_json::from_slice::<SendMessageRequest>(&body).map_err(|_| StatusCode::BAD_REQUEST)?;
+    validate_request(&request, &identity, &state)?;
+    let message = ChatMessage {
+        id: request
+            .id
+            .unwrap_or_else(|| format!("msg-{}-{}", identity.player_id, uuid::Uuid::new_v4())),
+        player_id: identity.player_id,
+        player_name: identity.player_name,
+        content: request.content,
+        message_type: request.message_type,
+        timestamp: unix_seconds(),
+        image_data: request.image_data,
+    };
+    if !store_message(
+        &state.local_messages,
+        &state.history_bytes,
+        &state.message_tx,
+        message.clone(),
+    ) {
+        return Err(StatusCode::PAYLOAD_TOO_LARGE);
+    }
     Ok(Json(message))
 }
 
-/// SSE流式推送消息
 async fn stream_messages(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
-    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
 ) -> Result<Sse<impl Stream<Item = Result<Event, std::convert::Infallible>>>, StatusCode> {
-    // 非大厅成员不得订阅本机消息流
+    let identity = authenticated_identity(&headers, peer, &state)?;
+    if state
+        .session
+        .read()
+        .as_ref()
+        .is_none_or(|session| session.local_identity.player_id != identity.player_id)
     {
-        let allowed = state.allowed_readers.read();
-        if !is_allowed_reader(&allowed, peer_addr.ip()) {
-            log::warn!(
-                "🚫 [ChatService] 拒绝非大厅成员订阅消息流：来源 {}",
-                peer_addr.ip()
-            );
-            return Err(StatusCode::FORBIDDEN);
-        }
+        return Err(StatusCode::FORBIDDEN);
     }
-
-    log::info!("📡 [ChatService] 新的SSE连接建立");
-    
-    let rx = state.message_tx.subscribe();
-    let stream = BroadcastStream::new(rx);
-    
-    let stream = stream.filter_map(|result| {
-        match result {
-            Ok(message) => {
-                // 将消息序列化为JSON
-                match serde_json::to_string(&message) {
-                    Ok(json) => Some(Ok(Event::default().data(json))),
-                    Err(e) => {
-                        log::error!("❌ [ChatService] 序列化消息失败: {}", e);
-                        None
-                    }
-                }
-            }
-            Err(e) => {
-                log::warn!("⚠️ [ChatService] 广播接收错误: {}", e);
-                None
-            }
-        }
+    if !allow_request(&state, &identity, peer.ip()).await {
+        return Err(StatusCode::TOO_MANY_REQUESTS);
+    }
+    let receiver = state.message_tx.subscribe();
+    let stream = BroadcastStream::new(receiver).filter_map(|result| match result {
+        Ok(message) => serde_json::to_string(&message)
+            .ok()
+            .map(|json| Ok(Event::default().data(json))),
+        Err(_) => None,
     });
-    
     Ok(Sse::new(stream).keep_alive(
-        axum::response::sse::KeepAlive::new()
-            .interval(std::time::Duration::from_secs(15))
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
             .text("keep-alive"),
     ))
 }
@@ -528,119 +784,199 @@ async fn stream_messages(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::IpAddr;
 
-    fn roster(entries: &[(&str, &str)]) -> HashMap<String, String> {
-        entries
-            .iter()
-            .map(|(id, ip)| (id.to_string(), ip.to_string()))
-            .collect()
-    }
-
-    fn ip(value: &str) -> IpAddr {
-        value.parse().expect("测试用 IP 应可解析")
+    fn identity(ip: &str, id: &str) -> ChatPeerIdentity {
+        ChatPeerIdentity {
+            player_id: id.to_string(),
+            player_name: id.to_string(),
+            virtual_ip: ip.to_string(),
+        }
     }
 
     #[test]
-    fn rejects_a_member_impersonating_another_player() {
-        // 大厅成员 10.126.126.9 自称是房主 host-1（真实 IP 为 .1）
-        let table = roster(&[("host-1", "10.126.126.1"), ("evil-9", "10.126.126.9")]);
-        assert!(
-            !sender_identity_matches(&table, "host-1", ip("10.126.126.9")),
-            "冒用他人 player_id 必须被拒绝，否则任意成员都能伪造房主公告"
-        );
+    fn token_validation_requires_32_bytes_hex() {
+        assert!(is_valid_chat_token(&"a".repeat(CHAT_TOKEN_HEX_BYTES)));
+        assert!(!is_valid_chat_token(&"a".repeat(CHAT_TOKEN_HEX_BYTES - 1)));
+        assert!(!is_valid_chat_token(&format!(
+            "{}g",
+            "a".repeat(CHAT_TOKEN_HEX_BYTES - 1)
+        )));
     }
 
     #[test]
-    fn accepts_a_player_sending_from_its_own_ip() {
-        let table = roster(&[("host-1", "10.126.126.1"), ("peer-2", "10.126.126.2")]);
-        assert!(sender_identity_matches(&table, "peer-2", ip("10.126.126.2")));
-        assert!(sender_identity_matches(&table, "host-1", ip("10.126.126.1")));
+    fn token_comparison_is_exact() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abc\0"));
     }
 
     #[test]
-    fn accepts_everything_when_the_roster_is_not_ready() {
-        // 名册尚未下发（刚进大厅）或对端为旧版本前端时，不能让聊天直接不可用
-        let table = roster(&[]);
-        assert!(sender_identity_matches(&table, "host-1", ip("10.126.126.9")));
+    fn identity_map_rejects_duplicate_or_loopback_ips() {
+        assert!(build_identity_map(
+            &identity("10.126.126.1", "one"),
+            vec![identity("10.126.126.1", "two")],
+        )
+        .is_err());
+        assert!(build_identity_map(&identity("127.0.0.1", "one"), Vec::new()).is_err());
+        assert!(build_identity_map(&identity("169.254.1.1", "one"), Vec::new()).is_err());
+        assert!(build_identity_map(&identity("224.0.0.1", "one"), Vec::new()).is_err());
+        assert!(build_identity_map(&identity("10.126.125.1", "one"), Vec::new()).is_err());
+        assert!(build_identity_map(&identity("192.168.1.10", "one"), Vec::new()).is_err());
+        assert!(build_identity_map(&identity("8.8.8.8", "one"), Vec::new()).is_err());
+        assert!(build_identity_map(&identity("2001:db8::1", "one"), Vec::new()).is_err());
+        assert!(build_identity_map(
+            &identity("10.126.126.1", "one"),
+            vec![identity("10.126.126.2", "one")],
+        )
+        .is_err());
     }
 
     #[test]
-    fn accepts_players_that_are_not_in_the_local_roster_yet() {
-        // 新玩家刚加入、名册还没同步到本机是正常现象，不应误判为冒名
-        let table = roster(&[("host-1", "10.126.126.1")]);
-        assert!(sender_identity_matches(&table, "newcomer-7", ip("10.126.126.7")));
+    fn message_ids_are_bound_to_the_authoritative_sender() {
+        assert!(is_message_id_for_player("msg-player-123", "player"));
+        assert!(is_message_id_for_player("recall-player-123", "player"));
+        assert!(!is_message_id_for_player("msg-other-123", "player"));
+        assert!(!is_message_id_for_player("msg-player-", "player"));
     }
 
     #[test]
-    fn accepts_when_the_registered_ip_is_unparsable() {
-        // 名册里的 IP 异常时放行，避免脏数据把合法消息全部拦掉
-        let table = roster(&[("host-1", "not-an-ip")]);
-        assert!(sender_identity_matches(&table, "host-1", ip("10.126.126.1")));
-    }
-
-    #[test]
-    fn set_peer_roster_drops_entries_without_an_ip() {
+    fn session_rejects_epoch_rollback_and_equivocation() {
         let service = ChatService::new();
-        service.set_peer_roster(vec![
-            ("host-1".to_string(), "10.126.126.1".to_string()),
-            ("no-ip".to_string(), String::new()),
-            (String::new(), "10.126.126.5".to_string()),
-            ("blank-ip".to_string(), "   ".to_string()),
-        ]);
-        let table = service.peer_roster.read().clone();
-        assert_eq!(table.len(), 1, "缺 ID 或缺 IP 的条目不得进入名册：{:?}", table);
-        assert_eq!(table.get("host-1").map(String::as_str), Some("10.126.126.1"));
+        service.set_virtual_ip("10.126.126.1".to_string());
+        service
+            .set_session(
+                "a".repeat(CHAT_TOKEN_HEX_BYTES),
+                2,
+                "local".to_string(),
+                "Local".to_string(),
+                Some("local".to_string()),
+                vec![identity("10.126.126.2", "peer")],
+            )
+            .unwrap();
+        assert!(service
+            .set_session(
+                "b".repeat(CHAT_TOKEN_HEX_BYTES),
+                1,
+                "local".to_string(),
+                "Local".to_string(),
+                Some("local".to_string()),
+                vec![identity("10.126.126.2", "peer")],
+            )
+            .is_err());
+        assert!(service
+            .set_session(
+                "b".repeat(CHAT_TOKEN_HEX_BYTES),
+                2,
+                "local".to_string(),
+                "Local".to_string(),
+                Some("local".to_string()),
+                vec![identity("10.126.126.2", "peer")],
+            )
+            .is_err());
     }
 
     #[test]
-    fn clear_peer_roster_resets_identity_checks() {
+    fn history_is_bounded_by_total_bytes() {
+        let messages = Arc::new(RwLock::new(VecDeque::new()));
+        let bytes = Arc::new(RwLock::new(0));
+        let (tx, _) = broadcast::channel(8);
+        for index in 0..20 {
+            let message = ChatMessage {
+                id: format!("{index}"),
+                player_id: "one".to_string(),
+                player_name: "one".to_string(),
+                content: "x".repeat(300_000),
+                message_type: MessageType::Text,
+                timestamp: index,
+                image_data: None,
+            };
+            assert!(store_message(&messages, &bytes, &tx, message));
+        }
+        assert!(*bytes.read() <= MAX_HISTORY_BYTES);
+        assert!(messages.read().len() < 20);
+    }
+
+    #[test]
+    fn duplicate_message_ids_are_not_stored_twice() {
+        let messages = Arc::new(RwLock::new(VecDeque::new()));
+        let bytes = Arc::new(RwLock::new(0));
+        let (tx, _) = broadcast::channel(8);
+        let message = ChatMessage {
+            id: "msg-one-1".to_string(),
+            player_id: "one".to_string(),
+            player_name: "one".to_string(),
+            content: "hello".to_string(),
+            message_type: MessageType::Text,
+            timestamp: 1,
+            image_data: None,
+        };
+        assert!(store_message(&messages, &bytes, &tx, message.clone()));
+        assert!(!store_message(&messages, &bytes, &tx, message));
+        assert_eq!(messages.read().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn stopping_service_clears_session_history_and_bind_ip() {
         let service = ChatService::new();
-        service.set_peer_roster(vec![("host-1".to_string(), "10.126.126.1".to_string())]);
-        service.set_allowed_readers(vec!["10.126.126.1".to_string()]);
-        service.clear_peer_roster();
-        assert!(
-            service.peer_roster.read().is_empty(),
-            "退出大厅后必须清空名册，否则旧名册会影响下一个大厅"
-        );
-        assert!(
-            service.allowed_readers.read().is_empty(),
-            "退出大厅后必须一并清空可读取成员"
-        );
+        service.set_virtual_ip("10.126.126.1".to_string());
+        service
+            .set_session(
+                "a".repeat(CHAT_TOKEN_HEX_BYTES),
+                1,
+                "local".to_string(),
+                "Local".to_string(),
+                Some("local".to_string()),
+                Vec::new(),
+            )
+            .unwrap();
+        assert!(service.add_local_message(ChatMessage {
+            id: "msg-local-1".to_string(),
+            player_id: "local".to_string(),
+            player_name: "Local".to_string(),
+            content: "hello".to_string(),
+            message_type: MessageType::Text,
+            timestamp: 1,
+            image_data: None,
+        }));
+
+        service.stop_server().await;
+
+        assert!(service.get_chat_token().is_none());
+        assert!(service.get_virtual_ip().is_none());
+        assert!(service.get_local_messages(None).is_empty());
     }
 
     #[test]
-    fn rejects_history_reads_from_a_peer_that_left_the_lobby() {
-        // 被移出大厅的成员仍在虚拟网内，但不应还能拉取聊天历史或订阅消息流
-        let allowed: HashSet<String> =
-            ["10.126.126.1", "10.126.126.2"].iter().map(|s| s.to_string()).collect();
-        assert!(!is_allowed_reader(&allowed, ip("10.126.126.9")));
-    }
-
-    #[test]
-    fn allows_history_reads_from_members_including_self() {
-        // 本机要自订阅 SSE 流，因此本机地址必须在册
-        let allowed: HashSet<String> =
-            ["10.126.126.1", "10.126.126.2"].iter().map(|s| s.to_string()).collect();
-        assert!(is_allowed_reader(&allowed, ip("10.126.126.1")));
-        assert!(is_allowed_reader(&allowed, ip("10.126.126.2")));
-    }
-
-    #[test]
-    fn allows_history_reads_before_the_reader_list_is_pushed() {
-        // 名单未就绪（刚进大厅、成员IP 尚未补齐）时放行，避免聊天历史直接读不到
-        assert!(is_allowed_reader(&HashSet::new(), ip("10.126.126.9")));
-    }
-
-    #[test]
-    fn set_allowed_readers_drops_blank_entries() {
-        let service = ChatService::new();
-        service.set_allowed_readers(vec![
-            "10.126.126.1".to_string(),
-            String::new(),
-            "   ".to_string(),
-        ]);
-        let readers = service.allowed_readers.read().clone();
-        assert_eq!(readers.len(), 1, "空白地址不得进入名单：{:?}", readers);
+    fn request_identity_fields_do_not_authorize_recall() {
+        let state = AppState {
+            local_messages: Arc::new(RwLock::new(VecDeque::from([ChatMessage {
+                id: "target".to_string(),
+                player_id: "owner".to_string(),
+                player_name: "Owner".to_string(),
+                content: "hello".to_string(),
+                message_type: MessageType::Text,
+                timestamp: unix_seconds(),
+                image_data: None,
+            }]))),
+            history_bytes: Arc::new(RwLock::new(0)),
+            message_tx: broadcast::channel(8).0,
+            session: Arc::new(RwLock::new(Some(ChatSession {
+                token: "a".repeat(CHAT_TOKEN_HEX_BYTES),
+                epoch: 1,
+                identities: HashMap::new(),
+                local_identity: identity("10.126.126.1", "owner"),
+                host_id: Some("owner".to_string()),
+            }))),
+            rate_limiter: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let request = SendMessageRequest {
+            id: None,
+            player_id: "owner".to_string(),
+            player_name: "Owner".to_string(),
+            content: "target".to_string(),
+            message_type: MessageType::Recall,
+            image_data: None,
+        };
+        assert!(validate_request(&request, &identity("10.126.126.2", "attacker"), &state).is_err());
     }
 }

--- a/src-tauri/src/modules/config_manager.rs
+++ b/src-tauri/src/modules/config_manager.rs
@@ -36,6 +36,7 @@ pub struct AutoLobbyConfig {
     /// 大厅名称
     pub lobby_name: Option<String>,
     /// 大厅密码
+    #[serde(default, skip_serializing)]
     pub lobby_password: Option<String>,
     /// 玩家名称
     pub player_name: Option<String>,
@@ -71,7 +72,7 @@ pub struct EasyTierAdvancedConfig {
     // ========== 配置来源 ==========
     /// 是否使用全局配置（仅用于大厅配置）
     pub use_global_config: bool,
-    
+
     // ========== 网络模式 ==========
     /// 是否启用无 TUN 模式（不创建虚拟网卡）
     pub no_tun: bool,
@@ -79,7 +80,7 @@ pub struct EasyTierAdvancedConfig {
     pub dhcp: bool,
     /// 手动指定的虚拟 IPv4 地址
     pub ipv4: Option<String>,
-    
+
     // ========== 代理和转发 ==========
     /// 是否启用 SOCKS5 代理
     pub enable_socks5: bool,
@@ -91,13 +92,13 @@ pub struct EasyTierAdvancedConfig {
     pub proxy_forward_by_system: bool,
     /// 子网代理 CIDR 列表（导出本地网络）
     pub proxy_networks: Vec<String>,
-    
+
     // ========== 出口节点 ==========
     /// 是否启用作为出口节点
     pub enable_as_exit_node: bool,
     /// 出口节点列表（使用其他节点作为出口）
     pub exit_nodes: Vec<String>,
-    
+
     // ========== 性能优化 ==========
     /// 是否启用多线程
     pub multi_thread: bool,
@@ -107,7 +108,7 @@ pub struct EasyTierAdvancedConfig {
     pub latency_first: bool,
     /// 是否启用 smoltcp 堆栈
     pub use_smoltcp: bool,
-    
+
     // ========== 协议优化 ==========
     /// 是否启用 KCP 代理
     pub enable_kcp_proxy: bool,
@@ -119,13 +120,13 @@ pub struct EasyTierAdvancedConfig {
     pub disable_quic_input: bool,
     /// QUIC 监听端口
     pub quic_listen_port: Option<u16>,
-    
+
     // ========== 加密和安全 ==========
     /// 是否禁用加密
     pub disable_encryption: bool,
     /// 加密算法（aes-gcm, aes-256-gcm, xor, chacha20）
     pub encryption_algorithm: Option<String>,
-    
+
     // ========== 网络设备 ==========
     /// 是否绑定到物理设备
     pub bind_device: bool,
@@ -133,7 +134,7 @@ pub struct EasyTierAdvancedConfig {
     pub dev_name: Option<String>,
     /// MTU 大小
     pub mtu: Option<u32>,
-    
+
     // ========== P2P 配置 ==========
     /// 是否仅使用 P2P 连接
     pub p2p_only: bool,
@@ -145,7 +146,7 @@ pub struct EasyTierAdvancedConfig {
     pub disable_tcp_hole_punching: bool,
     /// 是否禁用对称 NAT 打洞
     pub disable_sym_hole_punching: bool,
-    
+
     // ========== 中继配置 ==========
     /// 中继网络白名单（支持通配符）
     pub relay_network_whitelist: Vec<String>,
@@ -157,15 +158,15 @@ pub struct EasyTierAdvancedConfig {
     pub enable_relay_foreign_network_kcp: bool,
     /// 外部网络流量转发速率限制（BPS）
     pub foreign_relay_bps_limit: Option<u64>,
-    
+
     // ========== 路由配置 ==========
     /// 手动分配的路由 CIDR
     pub manual_routes: Vec<String>,
-    
+
     // ========== 压缩 ==========
     /// 压缩算法（none, zstd）
     pub compression: Option<String>,
-    
+
     // ========== 监听器配置 ==========
     /// 监听器列表
     pub listeners: Vec<String>,
@@ -175,31 +176,31 @@ pub struct EasyTierAdvancedConfig {
     pub no_listener: bool,
     /// 默认协议
     pub default_protocol: Option<String>,
-    
+
     // ========== DNS 配置 ==========
     /// 是否启用魔法 DNS
     pub accept_dns: bool,
     /// 顶级域名区域
     pub tld_dns_zone: Option<String>,
-    
+
     // ========== 端口白名单 ==========
     /// TCP 端口白名单
     pub tcp_whitelist: Vec<String>,
     /// UDP 端口白名单
     pub udp_whitelist: Vec<String>,
-    
+
     // ========== IPv6 ==========
     /// 是否禁用 IPv6
     pub disable_ipv6: bool,
     /// 虚拟 IPv6 地址
     pub ipv6: Option<String>,
-    
+
     // ========== STUN 服务器 ==========
     /// 自定义 STUN 服务器列表
     pub stun_servers: Vec<String>,
     /// 自定义 IPv6 STUN 服务器列表
     pub stun_servers_v6: Vec<String>,
-    
+
     // ========== 私有模式 ==========
     /// 是否启用私有模式
     pub private_mode: bool,
@@ -210,87 +211,87 @@ impl Default for EasyTierAdvancedConfig {
         Self {
             // 配置来源
             use_global_config: true,
-            
+
             // 网络模式
             no_tun: false,
             dhcp: true,
             ipv4: None,
-            
+
             // 代理和转发
             enable_socks5: false,
             socks5_port: None,
             port_forward_rules: Vec::new(),
             proxy_forward_by_system: false,
             proxy_networks: Vec::new(),
-            
+
             // 出口节点
             enable_as_exit_node: false,
             exit_nodes: Vec::new(),
-            
+
             // 性能优化
             multi_thread: true,
             multi_thread_count: Some(2),
             latency_first: true,
             use_smoltcp: false,
-            
+
             // 协议优化
             enable_kcp_proxy: false,
             disable_kcp_input: false,
             enable_quic_proxy: false,
             disable_quic_input: false,
             quic_listen_port: None,
-            
+
             // 加密和安全
             disable_encryption: false,
             encryption_algorithm: None,
-            
+
             // 网络设备
             bind_device: false,
             dev_name: Some("MCTier_Net".to_string()),
             mtu: None,
-            
+
             // P2P 配置
             p2p_only: false,
             disable_p2p: false,
             disable_udp_hole_punching: false,
             disable_tcp_hole_punching: false,
             disable_sym_hole_punching: false,
-            
+
             // 中继配置
             relay_network_whitelist: Vec::new(),
             relay_all_peer_rpc: false,
             disable_relay_kcp: false,
             enable_relay_foreign_network_kcp: false,
             foreign_relay_bps_limit: None,
-            
+
             // 路由配置
             manual_routes: Vec::new(),
-            
+
             // 压缩
             compression: None,
-            
+
             // 监听器配置
             listeners: Vec::new(),
             mapped_listeners: Vec::new(),
             no_listener: false,
             default_protocol: None,
-            
+
             // DNS 配置
             accept_dns: false,
             tld_dns_zone: None,
-            
+
             // 端口白名单
             tcp_whitelist: Vec::new(),
             udp_whitelist: Vec::new(),
-            
+
             // IPv6
             disable_ipv6: false,
             ipv6: None,
-            
+
             // STUN 服务器
             stun_servers: Vec::new(),
             stun_servers_v6: Vec::new(),
-            
+
             // 私有模式
             private_mode: false,
         }
@@ -310,7 +311,7 @@ pub struct ExitNodeConfig {
     pub exit_nodes: Vec<String>,
     /// 子网代理CIDR列表（用于共享本地子网）
     pub subnet_proxy_cidrs: Vec<String>,
-    
+
     // ========== 新增高级配置 ==========
     /// 是否启用 SOCKS5 代理
     pub enable_socks5: bool,
@@ -442,9 +443,9 @@ pub struct ConfigManager {
 impl Default for ConfigManager {
     fn default() -> Self {
         // 获取默认配置路径
-        let config_path = Self::get_config_path()
-            .unwrap_or_else(|_| PathBuf::from("mctier_config.json"));
-        
+        let config_path =
+            Self::get_config_path().unwrap_or_else(|_| PathBuf::from("mctier_config.json"));
+
         Self {
             config_path,
             config: UserConfig::default(),
@@ -457,7 +458,7 @@ impl ConfigManager {
     const CONFIG_FILE_NAME: &'static str = "mctier_config.json";
 
     /// 加载配置管理器（静态方法）
-    /// 
+    ///
     /// # 返回
     /// * `Ok(ConfigManager)` - 成功加载配置管理器
     /// * `Err(AppError)` - 加载失败
@@ -466,18 +467,18 @@ impl ConfigManager {
     }
 
     /// 创建新的配置管理器实例
-    /// 
+    ///
     /// # 返回
     /// * `Ok(ConfigManager)` - 成功创建配置管理器
     /// * `Err(AppError)` - 创建失败
-    /// 
+    ///
     /// # 说明
     /// 此方法会尝试从配置文件加载配置，如果文件不存在或损坏，则使用默认配置
     pub async fn new() -> Result<Self, AppError> {
         let config_path = Self::get_config_path()?;
-        
+
         log::info!("配置文件路径: {:?}", config_path);
-        
+
         // 尝试加载配置，如果失败则使用默认配置
         let config = match Self::load_from_file(&config_path).await {
             Ok(cfg) => {
@@ -497,7 +498,7 @@ impl ConfigManager {
     }
 
     /// 获取配置文件路径
-    /// 
+    ///
     /// # 返回
     /// * `Ok(PathBuf)` - 配置文件路径
     /// * `Err(AppError)` - 获取失败
@@ -508,15 +509,15 @@ impl ConfigManager {
 
         // 创建应用配置目录
         let app_config_dir = config_dir.join("mctier");
-        
+
         Ok(app_config_dir.join(Self::CONFIG_FILE_NAME))
     }
 
     /// 从文件加载配置
-    /// 
+    ///
     /// # 参数
     /// * `path` - 配置文件路径
-    /// 
+    ///
     /// # 返回
     /// * `Ok(UserConfig)` - 成功加载的配置
     /// * `Err(AppError)` - 加载失败
@@ -527,57 +528,55 @@ impl ConfigManager {
         }
 
         // 读取文件内容
-        let content = fs::read_to_string(path).await.map_err(|e| {
-            AppError::ConfigError(format!("读取配置文件失败: {}", e))
-        })?;
+        let content = fs::read_to_string(path)
+            .await
+            .map_err(|e| AppError::ConfigError(format!("读取配置文件失败: {}", e)))?;
 
         // 解析 JSON
-        let config: UserConfig = serde_json::from_str(&content).map_err(|e| {
-            AppError::ConfigError(format!("解析配置文件失败: {}", e))
-        })?;
+        let config: UserConfig = serde_json::from_str(&content)
+            .map_err(|e| AppError::ConfigError(format!("解析配置文件失败: {}", e)))?;
 
         Ok(config)
     }
 
     /// 保存配置到文件
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 保存成功
     /// * `Err(AppError)` - 保存失败
     pub async fn save(&self) -> Result<(), AppError> {
         // 确保配置目录存在
         if let Some(parent) = self.config_path.parent() {
-            fs::create_dir_all(parent).await.map_err(|e| {
-                AppError::ConfigError(format!("创建配置目录失败: {}", e))
-            })?;
+            fs::create_dir_all(parent)
+                .await
+                .map_err(|e| AppError::ConfigError(format!("创建配置目录失败: {}", e)))?;
         }
 
         // 序列化配置为 JSON（格式化输出，便于阅读）
-        let json_content = serde_json::to_string_pretty(&self.config).map_err(|e| {
-            AppError::ConfigError(format!("序列化配置失败: {}", e))
-        })?;
+        let json_content = serde_json::to_string_pretty(&self.config)
+            .map_err(|e| AppError::ConfigError(format!("序列化配置失败: {}", e)))?;
 
         // 写入文件（使用临时文件 + 原子重命名，防止写入过程中断导致文件损坏）
         let temp_path = self.config_path.with_extension("json.tmp");
-        
-        let mut file = fs::File::create(&temp_path).await.map_err(|e| {
-            AppError::ConfigError(format!("创建临时配置文件失败: {}", e))
-        })?;
 
-        file.write_all(json_content.as_bytes()).await.map_err(|e| {
-            AppError::ConfigError(format!("写入配置文件失败: {}", e))
-        })?;
+        let mut file = fs::File::create(&temp_path)
+            .await
+            .map_err(|e| AppError::ConfigError(format!("创建临时配置文件失败: {}", e)))?;
 
-        file.sync_all().await.map_err(|e| {
-            AppError::ConfigError(format!("同步配置文件失败: {}", e))
-        })?;
+        file.write_all(json_content.as_bytes())
+            .await
+            .map_err(|e| AppError::ConfigError(format!("写入配置文件失败: {}", e)))?;
+
+        file.sync_all()
+            .await
+            .map_err(|e| AppError::ConfigError(format!("同步配置文件失败: {}", e)))?;
 
         drop(file);
 
         // 原子重命名
-        fs::rename(&temp_path, &self.config_path).await.map_err(|e| {
-            AppError::ConfigError(format!("重命名配置文件失败: {}", e))
-        })?;
+        fs::rename(&temp_path, &self.config_path)
+            .await
+            .map_err(|e| AppError::ConfigError(format!("重命名配置文件失败: {}", e)))?;
 
         log::info!("配置已保存到: {:?}", self.config_path);
 
@@ -585,7 +584,7 @@ impl ConfigManager {
     }
 
     /// 获取当前配置的引用
-    /// 
+    ///
     /// # 返回
     /// 当前配置的不可变引用
     pub fn get_config(&self) -> &UserConfig {
@@ -593,7 +592,7 @@ impl ConfigManager {
     }
 
     /// 获取当前配置的克隆
-    /// 
+    ///
     /// # 返回
     /// 当前配置的克隆副本
     pub fn get_config_clone(&self) -> UserConfig {
@@ -601,14 +600,14 @@ impl ConfigManager {
     }
 
     /// 更新配置
-    /// 
+    ///
     /// # 参数
     /// * `updater` - 配置更新函数，接收可变配置引用
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 更新成功
     /// * `Err(AppError)` - 更新失败
-    /// 
+    ///
     /// # 示例
     /// ```rust
     /// manager.update_config(|config| {
@@ -621,237 +620,255 @@ impl ConfigManager {
     {
         // 应用更新
         updater(&mut self.config);
-        
+
         // 立即保存到文件
         self.save().await?;
-        
+
         log::info!("配置已更新并保存");
-        
+
         Ok(())
     }
 
     /// 设置玩家名称
-    /// 
+    ///
     /// # 参数
     /// * `name` - 玩家名称
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_player_name(&mut self, name: String) -> Result<(), AppError> {
         self.update_config(|config| {
             config.player_name = Some(name);
-        }).await
+        })
+        .await
     }
 
     /// 设置首选服务器
-    /// 
+    ///
     /// # 参数
     /// * `server` - 服务器地址
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_preferred_server(&mut self, server: String) -> Result<(), AppError> {
         self.update_config(|config| {
             config.preferred_server = Some(server);
-        }).await
+        })
+        .await
     }
 
     /// 设置麦克风快捷键
-    /// 
+    ///
     /// # 参数
     /// * `hotkey` - 快捷键字符串
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_mic_hotkey(&mut self, hotkey: String) -> Result<(), AppError> {
         self.update_config(|config| {
             config.mic_hotkey = Some(hotkey);
-        }).await
+        })
+        .await
     }
 
     /// 设置窗口位置
-    /// 
+    ///
     /// # 参数
     /// * `position` - 窗口位置信息
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_window_position(&mut self, position: WindowPosition) -> Result<(), AppError> {
         self.update_config(|config| {
             config.window_position = Some(position);
-        }).await
+        })
+        .await
     }
 
     /// 设置音频设备 ID
-    /// 
+    ///
     /// # 参数
     /// * `device_id` - 音频设备 ID
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_audio_device_id(&mut self, device_id: String) -> Result<(), AppError> {
         self.update_config(|config| {
             config.audio_device_id = Some(device_id);
-        }).await
+        })
+        .await
     }
 
     /// 设置窗口透明度
-    /// 
+    ///
     /// # 参数
     /// * `opacity` - 透明度值 (0.0-1.0)
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_opacity(&mut self, opacity: f64) -> Result<(), AppError> {
         // 验证透明度范围
         let clamped_opacity = opacity.clamp(0.0, 1.0);
-        
+
         self.update_config(|config| {
             config.opacity = Some(clamped_opacity);
-        }).await
+        })
+        .await
     }
 
     /// 设置窗口是否置顶
-    /// 
+    ///
     /// # 参数
     /// * `always_on_top` - 是否置顶
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_always_on_top(&mut self, always_on_top: bool) -> Result<(), AppError> {
         self.update_config(|config| {
             config.always_on_top = Some(always_on_top);
-        }).await
+        })
+        .await
     }
 
     /// 设置是否记住窗口位置
-    /// 
+    ///
     /// # 参数
     /// * `remember` - 是否记住
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_remember_window_position(&mut self, remember: bool) -> Result<(), AppError> {
         self.update_config(|config| {
             config.remember_window_position = Some(remember);
-        }).await
+        })
+        .await
     }
 
     /// 设置关闭窗口时是否最小化到系统托盘
-    /// 
+    ///
     /// # 参数
     /// * `close_to_tray` - 是否最小化到托盘
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_close_to_tray(&mut self, close_to_tray: bool) -> Result<(), AppError> {
         self.update_config(|config| {
             config.close_to_tray = Some(close_to_tray);
-        }).await
+        })
+        .await
     }
 
     /// 设置启动后是否自动隐藏到系统托盘
-    /// 
+    ///
     /// # 参数
     /// * `start_minimized` - 是否启动后自动隐藏到托盘
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_start_minimized(&mut self, start_minimized: bool) -> Result<(), AppError> {
         self.update_config(|config| {
             config.start_minimized = Some(start_minimized);
-        }).await
+        })
+        .await
     }
 
     /// 设置语音音量
-    /// 
+    ///
     /// # 参数
     /// * `volume` - 音量值 (0.0-1.0)
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_voice_volume(&mut self, volume: f64) -> Result<(), AppError> {
         // 验证音量范围
         let clamped_volume = volume.clamp(0.0, 1.0);
-        
+
         self.update_config(|config| {
             config.voice_volume = Some(clamped_volume);
-        }).await
+        })
+        .await
     }
 
     /// 设置是否启用 GPU 渲染
-    /// 
+    ///
     /// # 参数
     /// * `enable` - 是否启用
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
     pub async fn set_enable_gpu_rendering(&mut self, enable: bool) -> Result<(), AppError> {
         self.update_config(|config| {
             config.enable_gpu_rendering = Some(enable);
-        }).await
+        })
+        .await
     }
 
     /// 设置自定义 EasyTier 节点列表
-    /// 
+    ///
     /// # 参数
     /// * `nodes` - 节点列表
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 设置成功
     /// * `Err(AppError)` - 设置失败
-    pub async fn set_custom_easytier_nodes(&mut self, nodes: Vec<EasyTierNode>) -> Result<(), AppError> {
+    pub async fn set_custom_easytier_nodes(
+        &mut self,
+        nodes: Vec<EasyTierNode>,
+    ) -> Result<(), AppError> {
         self.update_config(|config| {
             config.custom_easytier_nodes = Some(nodes);
-        }).await
+        })
+        .await
     }
 
     /// 重置为默认配置
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 重置成功
     /// * `Err(AppError)` - 重置失败
     pub async fn reset_to_default(&mut self) -> Result<(), AppError> {
         self.config = UserConfig::default();
         self.save().await?;
-        
+
         log::info!("配置已重置为默认值");
-        
+
         Ok(())
     }
 
     /// 备份当前配置文件
-    /// 
+    ///
     /// # 返回
     /// * `Ok(PathBuf)` - 备份文件路径
     /// * `Err(AppError)` - 备份失败
     pub async fn backup_config(&self) -> Result<PathBuf, AppError> {
         if !self.config_path.exists() {
-            return Err(AppError::ConfigError("配置文件不存在，无法备份".to_string()));
+            return Err(AppError::ConfigError(
+                "配置文件不存在，无法备份".to_string(),
+            ));
         }
 
         // 生成备份文件名（带时间戳）
         let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
-        let backup_path = self.config_path.with_file_name(
-            format!("mctier_config_backup_{}.json", timestamp)
-        );
+        let backup_path = self
+            .config_path
+            .with_file_name(format!("mctier_config_backup_{}.json", timestamp));
 
         // 复制文件
-        fs::copy(&self.config_path, &backup_path).await.map_err(|e| {
-            AppError::ConfigError(format!("备份配置文件失败: {}", e))
-        })?;
+        fs::copy(&self.config_path, &backup_path)
+            .await
+            .map_err(|e| AppError::ConfigError(format!("备份配置文件失败: {}", e)))?;
 
         log::info!("配置已备份到: {:?}", backup_path);
 
@@ -859,23 +876,22 @@ impl ConfigManager {
     }
 
     /// 导出配置到指定路径
-    /// 
+    ///
     /// # 参数
     /// * `export_path` - 导出文件路径
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 导出成功
     /// * `Err(AppError)` - 导出失败
     pub async fn export_config(&self, export_path: PathBuf) -> Result<(), AppError> {
         // 序列化配置为 JSON（格式化输出）
-        let json_content = serde_json::to_string_pretty(&self.config).map_err(|e| {
-            AppError::ConfigError(format!("序列化配置失败: {}", e))
-        })?;
+        let json_content = serde_json::to_string_pretty(&self.config)
+            .map_err(|e| AppError::ConfigError(format!("序列化配置失败: {}", e)))?;
 
         // 写入文件
-        fs::write(&export_path, json_content).await.map_err(|e| {
-            AppError::ConfigError(format!("导出配置文件失败: {}", e))
-        })?;
+        fs::write(&export_path, json_content)
+            .await
+            .map_err(|e| AppError::ConfigError(format!("导出配置文件失败: {}", e)))?;
 
         log::info!("配置已导出到: {:?}", export_path);
 
@@ -883,27 +899,26 @@ impl ConfigManager {
     }
 
     /// 从指定路径导入配置
-    /// 
+    ///
     /// # 参数
     /// * `import_path` - 导入文件路径
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 导入成功
     /// * `Err(AppError)` - 导入失败
     pub async fn import_config(&mut self, import_path: PathBuf) -> Result<(), AppError> {
         // 读取文件内容
-        let content = fs::read_to_string(&import_path).await.map_err(|e| {
-            AppError::ConfigError(format!("读取导入文件失败: {}", e))
-        })?;
+        let content = fs::read_to_string(&import_path)
+            .await
+            .map_err(|e| AppError::ConfigError(format!("读取导入文件失败: {}", e)))?;
 
         // 解析 JSON
-        let imported_config: UserConfig = serde_json::from_str(&content).map_err(|e| {
-            AppError::ConfigError(format!("解析导入文件失败: {}", e))
-        })?;
+        let imported_config: UserConfig = serde_json::from_str(&content)
+            .map_err(|e| AppError::ConfigError(format!("解析导入文件失败: {}", e)))?;
 
         // 更新配置
         self.config = imported_config;
-        
+
         // 保存到配置文件
         self.save().await?;
 
@@ -930,7 +945,7 @@ mod tests {
     #[tokio::test]
     async fn test_default_config() {
         let config = UserConfig::default();
-        
+
         assert!(config.player_name.is_none());
         assert!(config.preferred_server.is_none());
         assert_eq!(config.mic_hotkey, Some("Ctrl+M".to_string()));
@@ -942,7 +957,7 @@ mod tests {
     #[tokio::test]
     async fn test_default_window_position() {
         let pos = WindowPosition::default();
-        
+
         assert_eq!(pos.x, 100);
         assert_eq!(pos.y, 100);
         assert_eq!(pos.width, 300);
@@ -971,7 +986,10 @@ mod tests {
 
         // 验证配置内容
         assert_eq!(loaded_config.player_name, Some("测试玩家".to_string()));
-        assert_eq!(loaded_config.preferred_server, Some("tcp://test:11010".to_string()));
+        assert_eq!(
+            loaded_config.preferred_server,
+            Some("tcp://test:11010".to_string())
+        );
     }
 
     #[tokio::test]
@@ -980,10 +998,13 @@ mod tests {
         let mut manager = create_test_config_manager(&temp_dir).await;
 
         // 更新配置
-        manager.update_config(|config| {
-            config.player_name = Some("新玩家".to_string());
-            config.mic_hotkey = Some("Ctrl+Shift+M".to_string());
-        }).await.unwrap();
+        manager
+            .update_config(|config| {
+                config.player_name = Some("新玩家".to_string());
+                config.mic_hotkey = Some("Ctrl+Shift+M".to_string());
+            })
+            .await
+            .unwrap();
 
         // 验证配置已更新
         assert_eq!(manager.config.player_name, Some("新玩家".to_string()));
@@ -1001,7 +1022,10 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let mut manager = create_test_config_manager(&temp_dir).await;
 
-        manager.set_player_name("玩家123".to_string()).await.unwrap();
+        manager
+            .set_player_name("玩家123".to_string())
+            .await
+            .unwrap();
 
         assert_eq!(manager.config.player_name, Some("玩家123".to_string()));
     }
@@ -1011,9 +1035,15 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let mut manager = create_test_config_manager(&temp_dir).await;
 
-        manager.set_preferred_server("tcp://server:11010".to_string()).await.unwrap();
+        manager
+            .set_preferred_server("tcp://server:11010".to_string())
+            .await
+            .unwrap();
 
-        assert_eq!(manager.config.preferred_server, Some("tcp://server:11010".to_string()));
+        assert_eq!(
+            manager.config.preferred_server,
+            Some("tcp://server:11010".to_string())
+        );
     }
 
     #[tokio::test]
@@ -1057,7 +1087,9 @@ mod tests {
         let config_path = temp_dir.path().join("corrupted.json");
 
         // 写入损坏的 JSON
-        fs::write(&config_path, "{invalid json content}").await.unwrap();
+        fs::write(&config_path, "{invalid json content}")
+            .await
+            .unwrap();
 
         // 尝试加载应该失败
         let result = ConfigManager::load_from_file(&config_path).await;

--- a/src-tauri/src/modules/easytier_advanced_commands.rs
+++ b/src-tauri/src/modules/easytier_advanced_commands.rs
@@ -1,17 +1,17 @@
 // EasyTier 高级配置命令模块
-// 
+//
 // 此模块提供全局和大厅级别的 EasyTier 高级配置管理命令
 
-use tauri::State;
 use crate::modules::tauri_commands::AppState;
+use tauri::State;
 
 // ==================== EasyTier 高级配置命令 ====================
 
 /// 保存全局 EasyTier 高级配置
-/// 
+///
 /// # 参数
 /// * `config_json` - 配置 JSON 对象
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 保存成功
 /// * `Err(String)` - 错误信息
@@ -21,53 +21,59 @@ pub async fn save_global_easytier_advanced_config(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     use crate::modules::config_manager::EasyTierAdvancedConfig;
-    
+
     log::info!("保存全局 EasyTier 高级配置");
     log::debug!("配置内容: {:?}", config_json);
-    
+
     // 解析配置
-    let config: EasyTierAdvancedConfig = serde_json::from_value(config_json)
-        .map_err(|e| format!("解析配置失败: {}", e))?;
-    
+    let config: EasyTierAdvancedConfig =
+        serde_json::from_value(config_json).map_err(|e| format!("解析配置失败: {}", e))?;
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut cfg_mgr = config_manager.lock().await;
-    
-    cfg_mgr.update_config(|user_config| {
-        user_config.global_easytier_advanced_config = Some(config);
-    }).await.map_err(|e| format!("保存全局 EasyTier 高级配置失败: {}", e))?;
-    
+
+    cfg_mgr
+        .update_config(|user_config| {
+            user_config.global_easytier_advanced_config = Some(config);
+        })
+        .await
+        .map_err(|e| format!("保存全局 EasyTier 高级配置失败: {}", e))?;
+
     log::info!("全局 EasyTier 高级配置保存成功");
     Ok(())
 }
 
 /// 获取全局 EasyTier 高级配置
-/// 
+///
 /// # 返回
 /// * `Ok(serde_json::Value)` - 全局 EasyTier 高级配置
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn get_global_easytier_advanced_config(state: State<'_, AppState>) -> Result<serde_json::Value, String> {
+pub async fn get_global_easytier_advanced_config(
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
     log::info!("获取全局 EasyTier 高级配置");
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let cfg_mgr = config_manager.lock().await;
     let config = cfg_mgr.get_config();
-    
-    let advanced_config = config.global_easytier_advanced_config.clone()
+
+    let advanced_config = config
+        .global_easytier_advanced_config
+        .clone()
         .unwrap_or_else(|| crate::modules::config_manager::EasyTierAdvancedConfig::default());
-    
+
     // 序列化为 JSON
-    serde_json::to_value(&advanced_config)
-        .map_err(|e| format!("序列化配置失败: {}", e))
+    serde_json::to_value(&advanced_config).map_err(|e| format!("序列化配置失败: {}", e))
 }
 
 /// 保存大厅 EasyTier 高级配置
-/// 
+///
 /// # 参数
 /// * `config_json` - 配置 JSON 对象
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 保存成功
 /// * `Err(String)` - 错误信息
@@ -77,31 +83,37 @@ pub async fn save_lobby_easytier_advanced_config(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     use crate::modules::config_manager::EasyTierAdvancedConfig;
-    
+
     log::info!("========================================");
     log::info!("保存大厅 EasyTier 高级配置");
-    log::info!("前端传入的配置 JSON: {}", serde_json::to_string_pretty(&config_json).unwrap_or_default());
-    
+    log::info!(
+        "前端传入的配置 JSON: {}",
+        serde_json::to_string_pretty(&config_json).unwrap_or_default()
+    );
+
     // 解析配置
-    let config: EasyTierAdvancedConfig = serde_json::from_value(config_json.clone())
-        .map_err(|e| format!("解析配置失败: {}", e))?;
-    
+    let config: EasyTierAdvancedConfig =
+        serde_json::from_value(config_json.clone()).map_err(|e| format!("解析配置失败: {}", e))?;
+
     log::info!("解析后的配置:");
     log::info!("  - use_global_config: {}", config.use_global_config);
     log::info!("  - dev_name: {:?}", config.dev_name);
     log::info!("  - no_tun: {}", config.no_tun);
     log::info!("  - dhcp: {}", config.dhcp);
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut cfg_mgr = config_manager.lock().await;
-    
-    cfg_mgr.update_config(|user_config| {
-        user_config.lobby_easytier_advanced_config = Some(config.clone());
-    }).await.map_err(|e| format!("保存大厅 EasyTier 高级配置失败: {}", e))?;
-    
+
+    cfg_mgr
+        .update_config(|user_config| {
+            user_config.lobby_easytier_advanced_config = Some(config.clone());
+        })
+        .await
+        .map_err(|e| format!("保存大厅 EasyTier 高级配置失败: {}", e))?;
+
     log::info!("✅ 大厅 EasyTier 高级配置已保存到配置文件");
-    
+
     // 验证保存后的配置
     let saved_config = cfg_mgr.get_config().lobby_easytier_advanced_config.clone();
     if let Some(ref saved) = saved_config {
@@ -110,52 +122,60 @@ pub async fn save_lobby_easytier_advanced_config(
         log::info!("  - dev_name: {:?}", saved.dev_name);
     }
     log::info!("========================================");
-    
+
     Ok(())
 }
 
 /// 获取大厅 EasyTier 高级配置
-/// 
+///
 /// # 返回
 /// * `Ok(serde_json::Value)` - 大厅 EasyTier 高级配置
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn get_lobby_easytier_advanced_config(state: State<'_, AppState>) -> Result<serde_json::Value, String> {
+pub async fn get_lobby_easytier_advanced_config(
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
     log::info!("获取大厅 EasyTier 高级配置");
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let cfg_mgr = config_manager.lock().await;
     let config = cfg_mgr.get_config();
-    
-    let advanced_config = config.lobby_easytier_advanced_config.clone()
+
+    let advanced_config = config
+        .lobby_easytier_advanced_config
+        .clone()
         .unwrap_or_else(|| crate::modules::config_manager::EasyTierAdvancedConfig::default());
-    
+
     // 序列化为 JSON
-    serde_json::to_value(&advanced_config)
-        .map_err(|e| format!("序列化配置失败: {}", e))
+    serde_json::to_value(&advanced_config).map_err(|e| format!("序列化配置失败: {}", e))
 }
 
 /// 清除大厅 EasyTier 高级配置（重置为默认）
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 清除成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn clear_lobby_easytier_advanced_config(state: State<'_, AppState>) -> Result<(), String> {
+pub async fn clear_lobby_easytier_advanced_config(
+    state: State<'_, AppState>,
+) -> Result<(), String> {
     log::info!("========================================");
     log::info!("清除大厅 EasyTier 高级配置");
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut cfg_mgr = config_manager.lock().await;
-    
-    cfg_mgr.update_config(|user_config| {
-        user_config.lobby_easytier_advanced_config = None;
-    }).await.map_err(|e| format!("清除大厅 EasyTier 高级配置失败: {}", e))?;
-    
+
+    cfg_mgr
+        .update_config(|user_config| {
+            user_config.lobby_easytier_advanced_config = None;
+        })
+        .await
+        .map_err(|e| format!("清除大厅 EasyTier 高级配置失败: {}", e))?;
+
     log::info!("✅ 大厅 EasyTier 高级配置已清除");
     log::info!("========================================");
-    
+
     Ok(())
 }

--- a/src-tauri/src/modules/error.rs
+++ b/src-tauri/src/modules/error.rs
@@ -91,16 +91,16 @@ pub fn log_error_with_details(error: &AppError, context: &str, details: &str) {
 }
 
 /// 异步重试机制
-/// 
+///
 /// # 参数
 /// * `operation` - 要执行的异步操作
 /// * `max_retries` - 最大重试次数
 /// * `delay_ms` - 每次重试之间的延迟（毫秒）
-/// 
+///
 /// # 返回
 /// * `Ok(T)` - 操作成功返回结果
 /// * `Err(E)` - 所有重试都失败后返回最后一次的错误
-/// 
+///
 /// # 示例
 /// ```rust
 /// let result = with_retry(
@@ -120,7 +120,7 @@ where
     E: fmt::Display,
 {
     let mut attempts = 0;
-    
+
     loop {
         match operation().await {
             Ok(result) => {
@@ -131,19 +131,14 @@ where
             }
             Err(e) => {
                 attempts += 1;
-                
+
                 if attempts > max_retries {
                     log::error!("操作失败，已达到最大重试次数 {}: {}", max_retries, e);
                     return Err(e);
                 }
-                
-                log::warn!(
-                    "操作失败，正在重试 {}/{}: {}",
-                    attempts,
-                    max_retries,
-                    e
-                );
-                
+
+                log::warn!("操作失败，正在重试 {}/{}: {}", attempts, max_retries, e);
+
                 tokio::time::sleep(Duration::from_millis(delay_ms)).await;
             }
         }
@@ -151,16 +146,16 @@ where
 }
 
 /// 异步重试机制（带指数退避）
-/// 
+///
 /// # 参数
 /// * `operation` - 要执行的异步操作
 /// * `max_retries` - 最大重试次数
 /// * `initial_delay_ms` - 初始延迟（毫秒）
-/// 
+///
 /// # 返回
 /// * `Ok(T)` - 操作成功返回结果
 /// * `Err(E)` - 所有重试都失败后返回最后一次的错误
-/// 
+///
 /// # 说明
 /// 每次重试的延迟时间会翻倍（指数退避），例如：
 /// - 第1次重试: initial_delay_ms
@@ -178,7 +173,7 @@ where
 {
     let mut attempts = 0;
     let mut delay = initial_delay_ms;
-    
+
     loop {
         match operation().await {
             Ok(result) => {
@@ -189,12 +184,12 @@ where
             }
             Err(e) => {
                 attempts += 1;
-                
+
                 if attempts > max_retries {
                     log::error!("操作失败，已达到最大重试次数 {}: {}", max_retries, e);
                     return Err(e);
                 }
-                
+
                 log::warn!(
                     "操作失败，正在重试 {}/{}（延迟 {}ms）: {}",
                     attempts,
@@ -202,9 +197,9 @@ where
                     delay,
                     e
                 );
-                
+
                 tokio::time::sleep(Duration::from_millis(delay)).await;
-                
+
                 // 指数退避：每次延迟时间翻倍
                 delay *= 2;
             }
@@ -226,7 +221,7 @@ mod tests {
     fn test_io_error_conversion() {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "文件未找到");
         let app_err: AppError = io_err.into();
-        
+
         match app_err {
             AppError::IoError(msg) => assert!(msg.contains("文件未找到")),
             _ => panic!("错误类型转换失败"),
@@ -238,9 +233,9 @@ mod tests {
         let json_str = "{invalid json}";
         let json_err = serde_json::from_str::<serde_json::Value>(json_str).unwrap_err();
         let app_err: AppError = json_err.into();
-        
+
         match app_err {
-            AppError::SerializationError(_) => {},
+            AppError::SerializationError(_) => {}
             _ => panic!("错误类型转换失败"),
         }
     }
@@ -248,7 +243,7 @@ mod tests {
     #[tokio::test]
     async fn test_with_retry_success_first_attempt() {
         let mut call_count = 0;
-        
+
         let result = with_retry(
             || {
                 call_count += 1;
@@ -258,7 +253,7 @@ mod tests {
             100,
         )
         .await;
-        
+
         assert_eq!(result, Ok(42));
         assert_eq!(call_count, 1);
     }
@@ -266,7 +261,7 @@ mod tests {
     #[tokio::test]
     async fn test_with_retry_success_after_retries() {
         let mut call_count = 0;
-        
+
         let result = with_retry(
             || {
                 call_count += 1;
@@ -282,7 +277,7 @@ mod tests {
             10,
         )
         .await;
-        
+
         assert_eq!(result, Ok(42));
         assert_eq!(call_count, 3);
     }
@@ -290,7 +285,7 @@ mod tests {
     #[tokio::test]
     async fn test_with_retry_failure_after_max_retries() {
         let mut call_count = 0;
-        
+
         let result = with_retry(
             || {
                 call_count += 1;
@@ -300,7 +295,7 @@ mod tests {
             10,
         )
         .await;
-        
+
         assert!(result.is_err());
         assert_eq!(call_count, 4); // 初始尝试 + 3次重试
     }
@@ -309,7 +304,7 @@ mod tests {
     async fn test_with_retry_exponential_backoff() {
         let mut call_count = 0;
         let start = std::time::Instant::now();
-        
+
         let result = with_retry_exponential_backoff(
             || {
                 call_count += 1;
@@ -325,9 +320,9 @@ mod tests {
             10,
         )
         .await;
-        
+
         let elapsed = start.elapsed();
-        
+
         assert_eq!(result, Ok(42));
         assert_eq!(call_count, 3);
         // 第1次重试: 10ms, 第2次重试: 20ms, 总共至少 30ms

--- a/src-tauri/src/modules/file_transfer.rs
+++ b/src-tauri/src/modules/file_transfer.rs
@@ -3,16 +3,17 @@
  * 基于 WireGuard 虚拟网络的高性能文件传输
  * 使用标准 HTTP 协议，支持断点续传和多线程下载
  */
-
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs::OpenOptions;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use super::http_cors::lan_cors_layer;
 use axum::{
     body::Body,
-    extract::{ConnectInfo, Path as AxumPath, Query, State},
+    extract::{ConnectInfo, DefaultBodyLimit, Path as AxumPath, Query, State},
     http::{header, HeaderMap, StatusCode},
     response::Response,
     routing::{get, post},
@@ -23,11 +24,22 @@ use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
-use super::http_cors::lan_cors_layer;
+use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+use uuid::Uuid;
 use zip::write::SimpleFileOptions;
 
 const FILE_SERVER_PORT: u16 = 14539; // 固定端口，方便其他节点访问
 const CHUNK_SIZE: usize = 1024 * 1024; // 1MB chunks
+const MAX_JSON_BODY_BYTES: usize = 64 * 1024;
+const MAX_BATCH_FILES: usize = 256;
+const MAX_BATCH_SOURCE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const MAX_BATCH_ZIP_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const ZIP_OUTPUT_LIMIT_ERROR: &str = "ZIP output exceeds configured size limit";
+const SHARE_INVALID_ERROR: &str = "share is no longer available";
+const MAX_PASSWORD_FAILURES: usize = 10;
+const MAX_PASSWORD_FAILURE_KEYS: usize = 4096;
+const PASSWORD_FAILURE_WINDOW: Duration = Duration::from_secs(30);
+pub const LOBBY_TOKEN_HEADER: &str = "x-mctier-lobby-token";
 
 /// 共享文件夹信息
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,10 +48,12 @@ pub struct SharedFolder {
     pub name: String,
     pub path: String,
     pub password: Option<String>,
-    pub expire_time: Option<u64>, // Unix timestamp
+    pub expire_time: Option<u64>,           // Unix timestamp
     pub compress_before_send: Option<bool>, // 是否启用"先压后发"策略
     pub owner_id: String,
     pub created_at: u64,
+    #[serde(skip)]
+    expiry_token: Uuid,
 }
 
 /// 可安全暴露给远程节点的共享摘要。
@@ -55,29 +69,6 @@ pub struct SharedFolderSummary {
     pub compress_before_send: Option<bool>,
     pub owner_id: String,
     pub created_at: u64,
-    /// 仅用于兼容尚未升级的旧节点：旧版 `/api/shares` 会直接返回 `password`，
-    /// 却没有 `has_password` 字段。反序列化时读入该值仅为推断"是否需要密码"，
-    /// 绝不会再次序列化出去，也不会向 UI 暴露。
-    #[serde(default, rename = "password", skip_serializing)]
-    pub legacy_password: Option<String>,
-}
-
-impl SharedFolderSummary {
-    /// 归一化来自远程节点的共享摘要。
-    ///
-    /// 新节点直接提供 `has_password`；旧节点只提供明文 `password`，此时据其推断
-    /// `has_password`，避免旧节点的加密共享在新客户端上被误判为"无需密码"
-    /// （那会导致锁图标消失并跳过密码校验）。返回值不再携带任何密码内容。
-    pub fn normalized(mut self) -> Self {
-        if !self.has_password {
-            self.has_password = self
-                .legacy_password
-                .as_deref()
-                .is_some_and(|password| !password.is_empty());
-        }
-        self.legacy_password = None;
-        self
-    }
 }
 
 impl From<&SharedFolder> for SharedFolderSummary {
@@ -88,12 +79,11 @@ impl From<&SharedFolder> for SharedFolderSummary {
             has_password: share
                 .password
                 .as_deref()
-                .is_some_and(|password| !password.is_empty()),
+                .is_some_and(|password| !password.trim().is_empty()),
             expire_time: share.expire_time,
             compress_before_send: share.compress_before_send,
             owner_id: share.owner_id.clone(),
             created_at: share.created_at,
-            legacy_password: None,
         }
     }
 }
@@ -149,13 +139,15 @@ pub struct FileTransferService {
     /// 服务器句柄
     server_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
     /// 过期定时器句柄
-    expiry_timers: Arc<DashMap<String, tokio::task::JoinHandle<()>>>,
-    /// 允许访问共享的大厅成员虚拟 IP 集合。
-    ///
-    /// 由前端在玩家列表变化时下发（数据源为信令服务器的大厅成员列表）。
-    /// EasyTier 网络的网络名与密钥在大厅存续期间不变，被房主移出大厅的玩家
-    /// 仍可能留在虚拟网内，若不校验来源就仍能继续浏览与下载共享内容。
-    allowed_peers: Arc<RwLock<HashSet<String>>>,
+    expiry_timers: Arc<DashMap<String, ExpiryTimer>>,
+    /// 信令服务器签发的当前大厅凭据；成员变化时会轮换。
+    lobby_token: Arc<RwLock<Option<String>>>,
+}
+
+struct ExpiryTimer {
+    deadline: u64,
+    token: Uuid,
+    handle: tokio::task::JoinHandle<()>,
 }
 
 impl FileTransferService {
@@ -165,7 +157,7 @@ impl FileTransferService {
             virtual_ip: Arc::new(RwLock::new(None)),
             server_handle: Arc::new(RwLock::new(None)),
             expiry_timers: Arc::new(DashMap::new()),
-            allowed_peers: Arc::new(RwLock::new(HashSet::new())),
+            lobby_token: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -180,19 +172,16 @@ impl FileTransferService {
         self.virtual_ip.read().clone()
     }
 
-    /// 更新允许访问共享的大厅成员 IP 集合（含自己，便于本机自查）
-    pub fn set_allowed_peers(&self, ips: Vec<String>) {
-        let peers: HashSet<String> = ips
-            .into_iter()
-            .filter(|ip| !ip.trim().is_empty())
-            .collect();
-        log::info!("🪪 [FileShare] 更新可访问成员，共 {} 个地址", peers.len());
-        *self.allowed_peers.write() = peers;
+    pub fn set_lobby_token(&self, token: String) -> Result<(), String> {
+        if token.len() != 64 || !token.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err("文件服务大厅凭据格式无效".to_string());
+        }
+        *self.lobby_token.write() = Some(token);
+        Ok(())
     }
 
-    /// 清空允许访问的成员集合（退出大厅时调用）
-    pub fn clear_allowed_peers(&self) {
-        self.allowed_peers.write().clear();
+    pub fn clear_lobby_token(&self) {
+        *self.lobby_token.write() = None;
     }
 
     /// 启动HTTP文件服务器
@@ -205,14 +194,15 @@ impl FileTransferService {
             }
         };
 
+        let addr = overlay_socket_addr(&virtual_ip, FILE_SERVER_PORT)?;
         log::info!("🔍 检查虚拟IP是否就绪: {}", virtual_ip);
-        
+
         // 等待虚拟IP就绪（最多等待10秒）
         let mut attempts = 0;
         let max_attempts = 20; // 20次 * 500ms = 10秒
         loop {
             // 尝试绑定到虚拟IP的一个临时端口，测试IP是否可用
-            match tokio::net::TcpListener::bind(format!("{}:0", virtual_ip)).await {
+            match tokio::net::TcpListener::bind(SocketAddr::new(addr.ip(), 0)).await {
                 Ok(test_listener) => {
                     drop(test_listener);
                     log::info!("✅ 虚拟IP已就绪");
@@ -224,20 +214,21 @@ impl FileTransferService {
                         log::error!("❌ 虚拟IP未就绪，超时: {}", e);
                         return Err(format!("虚拟IP未就绪: {}", e).into());
                     }
-                    log::warn!("⏳ 虚拟IP尚未就绪，等待中... ({}/{})", attempts, max_attempts);
+                    log::warn!(
+                        "⏳ 虚拟IP尚未就绪，等待中... ({}/{})",
+                        attempts,
+                        max_attempts
+                    );
                     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                 }
             }
         }
 
-        let addr: SocketAddr = format!("{}:{}", virtual_ip, FILE_SERVER_PORT)
-            .parse()
-            .map_err(|e| {
-                log::error!("❌ 无效的地址格式: {}:{} - {}", virtual_ip, FILE_SERVER_PORT, e);
-                format!("无效的地址: {}", e)
-            })?;
-
-        log::info!("📍 HTTP服务器将仅监听虚拟网卡: {}:{}", virtual_ip, FILE_SERVER_PORT);
+        log::info!(
+            "📍 HTTP服务器将仅监听虚拟网卡: {}:{}",
+            virtual_ip,
+            FILE_SERVER_PORT
+        );
         log::info!("📍 虚拟IP: {}", virtual_ip);
 
         let shared_folders = self.shared_folders.clone();
@@ -247,12 +238,18 @@ impl FileTransferService {
             .route("/api/shares", get(list_shares))
             .route("/api/shares/:share_id/files", get(list_files))
             .route("/api/shares/:share_id/verify", post(verify_password))
-            .route("/api/shares/:share_id/download/*file_path", get(download_file))
+            .route(
+                "/api/shares/:share_id/download/*file_path",
+                get(download_file),
+            )
             .route("/api/shares/:share_id/batch-download", post(batch_download))
+            .layer(DefaultBodyLimit::max(MAX_JSON_BODY_BYTES))
             .layer(lan_cors_layer())
             .with_state(AppState {
                 shared_folders: shared_folders.clone(),
-                allowed_peers: self.allowed_peers.clone(),
+                batch_slots: Arc::new(Semaphore::new(1)),
+                password_failures: Arc::new(Mutex::new(HashMap::new())),
+                lobby_token: self.lobby_token.clone(),
             });
 
         log::info!("🚀 正在启动HTTP文件服务器...");
@@ -275,9 +272,12 @@ impl FileTransferService {
         // 启动服务器
         let server_task = tokio::spawn(async move {
             log::info!("🌐 HTTP文件服务器开始监听请求...");
-            // 需要 ConnectInfo 才能拿到对端真实地址，用于校验调用方是否仍是大厅成员
-            let service = app.into_make_service_with_connect_info::<SocketAddr>();
-            if let Err(e) = axum::serve(listener, service).await {
+            if let Err(e) = axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            {
                 log::error!("❌ HTTP服务器运行错误: {}", e);
             } else {
                 log::info!("🛑 HTTP服务器已正常停止");
@@ -287,10 +287,18 @@ impl FileTransferService {
         *self.server_handle.write() = Some(server_task);
 
         log::info!("✅ HTTP文件服务器启动成功！");
-        log::info!("📡 监听地址: {}:{}（仅虚拟网卡）", virtual_ip, FILE_SERVER_PORT);
+        log::info!(
+            "📡 监听地址: {}:{}（仅虚拟网卡）",
+            virtual_ip,
+            FILE_SERVER_PORT
+        );
         log::info!("📡 虚拟IP: {}", virtual_ip);
-        log::debug!("📡 其他玩家可以通过 http://{}:{} 访问您的共享", virtual_ip, FILE_SERVER_PORT);
-        
+        log::debug!(
+            "📡 其他玩家可以通过 http://{}:{} 访问您的共享",
+            virtual_ip,
+            FILE_SERVER_PORT
+        );
+
         // 等待一小段时间，确保服务器完全启动
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
         log::info!("🎉 HTTP文件服务器已完全就绪");
@@ -312,73 +320,112 @@ impl FileTransferService {
     }
 
     /// 添加共享文件夹
-    pub fn add_share(&self, share: SharedFolder) -> Result<(), String> {
-        // 检查路径是否存在
-        if !Path::new(&share.path).exists() {
-            return Err("文件夹不存在".to_string());
+    pub fn add_share(&self, mut share: SharedFolder) -> Result<(), String> {
+        let share_path = Path::new(&share.path);
+        if !share_path.is_absolute() {
+            return Err("共享路径必须是绝对路径".to_string());
+        }
+        let metadata =
+            std::fs::symlink_metadata(share_path).map_err(|_| "文件夹不存在".to_string())?;
+        if is_link_or_reparse_point(&metadata) || !metadata.is_dir() {
+            return Err("共享路径必须是实际目录，不能是符号链接或reparse point".to_string());
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if is_expired(share.expire_time, now) {
+            return Err("共享已过期".to_string());
         }
 
         let share_id = share.id.clone();
+        let expiry_token = Uuid::new_v4();
+        share.expiry_token = expiry_token;
+        if let Some((_, old_timer)) = self.expiry_timers.remove(&share_id) {
+            old_timer.handle.abort();
+        }
         self.shared_folders.insert(share_id.clone(), share.clone());
         log::debug!("📁 添加共享: {} ({})", share.name, share_id);
-        
+
         // 如果设置了过期时间,创建定时器
         if let Some(expire_time) = share.expire_time {
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
-            
             if expire_time > now {
                 let delay_secs = expire_time - now;
-                log::info!("⏰ 为共享 {} 设置过期定时器: {}秒后过期", share_id, delay_secs);
-                
+                log::info!(
+                    "⏰ 为共享 {} 设置过期定时器: {}秒后过期",
+                    share_id,
+                    delay_secs
+                );
+
                 let shared_folders = self.shared_folders.clone();
                 let expiry_timers = self.expiry_timers.clone();
                 let share_id_clone = share_id.clone();
-                
+                let deadline = expire_time;
+                let token = expiry_token;
+
                 let timer_handle = tokio::spawn(async move {
                     tokio::time::sleep(tokio::time::Duration::from_secs(delay_secs)).await;
-                    
-                    // 删除过期共享
-                    if shared_folders.remove(&share_id_clone).is_some() {
+
+                    // Do not let a stale timer remove a replacement share, even
+                    // when it reuses the same ID and deadline.
+                    if shared_folders
+                        .remove_if(&share_id_clone, |_, current| {
+                            current.expiry_token == token && current.expire_time == Some(deadline)
+                        })
+                        .is_some()
+                    {
                         log::info!("⏰ 共享已过期并自动删除: {}", share_id_clone);
                     }
-                    
-                    // 清理定时器
-                    expiry_timers.remove(&share_id_clone);
+
+                    expiry_timers.remove_if(&share_id_clone, |_, timer| {
+                        timer.deadline == deadline && timer.token == token
+                    });
                 });
-                
-                self.expiry_timers.insert(share_id.clone(), timer_handle);
-            } else {
-                log::warn!("⚠️ 共享 {} 的过期时间已过,不添加", share_id);
-                return Err("共享已过期".to_string());
+
+                self.expiry_timers.insert(
+                    share_id.clone(),
+                    ExpiryTimer {
+                        deadline: expire_time,
+                        token: expiry_token,
+                        handle: timer_handle,
+                    },
+                );
             }
         }
-        
+
         Ok(())
     }
 
     /// 删除共享文件夹
     pub fn remove_share(&self, share_id: &str) -> Result<(), String> {
-        self.shared_folders
+        let (_, share) = self
+            .shared_folders
             .remove(share_id)
             .ok_or_else(|| "共享不存在".to_string())?;
-        
+
         // 取消过期定时器
-        if let Some((_, timer_handle)) = self.expiry_timers.remove(share_id) {
-            timer_handle.abort();
+        if let Some((_, timer)) = self
+            .expiry_timers
+            .remove_if(share_id, |_, timer| timer.token == share.expiry_token)
+        {
+            timer.handle.abort();
             log::debug!("⏰ 取消共享 {} 的过期定时器", share_id);
         }
-        
+
         log::debug!("🗑️ 删除共享: {}", share_id);
         Ok(())
     }
 
     /// 获取所有共享
     pub fn get_shares(&self) -> Vec<SharedFolder> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
         self.shared_folders
             .iter()
+            .filter(|entry| !is_expired(entry.value().expire_time, now))
             .map(|entry| entry.value().clone())
             .collect()
     }
@@ -387,24 +434,38 @@ impl FileTransferService {
     pub fn cleanup_expired_shares(&self) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_secs();
 
-        let expired: Vec<String> = self
+        let expired: Vec<(String, Uuid)> = self
             .shared_folders
             .iter()
             .filter(|entry| {
                 if let Some(expire_time) = entry.value().expire_time {
-                    expire_time < now
+                    expire_time <= now
                 } else {
                     false
                 }
             })
-            .map(|entry| entry.key().clone())
+            .map(|entry| (entry.key().clone(), entry.value().expiry_token))
             .collect();
 
-        for share_id in expired {
-            self.shared_folders.remove(&share_id);
+        for (share_id, token) in expired {
+            if self
+                .shared_folders
+                .remove_if(&share_id, |_, share| {
+                    share.expiry_token == token && is_expired(share.expire_time, now)
+                })
+                .is_none()
+            {
+                continue;
+            }
+            if let Some((_, timer)) = self
+                .expiry_timers
+                .remove_if(&share_id, |_, timer| timer.token == token)
+            {
+                timer.handle.abort();
+            }
             log::debug!("⏰ 清理过期共享: {}", share_id);
         }
     }
@@ -414,55 +475,95 @@ impl FileTransferService {
 #[derive(Clone)]
 struct AppState {
     shared_folders: Arc<DashMap<String, SharedFolder>>,
-    allowed_peers: Arc<RwLock<HashSet<String>>>,
+    batch_slots: Arc<Semaphore>,
+    password_failures: Arc<Mutex<HashMap<(String, IpAddr), VecDeque<Instant>>>>,
+    lobby_token: Arc<RwLock<Option<String>>>,
 }
 
-/// 判断调用方是否仍是本大厅成员。
-///
-/// 名册为空时放行：可能是尚未下发（刚进大厅）或对端为旧版本，
-/// 此时不能让文件共享直接不可用。名册非空则要求来源 IP 在册。
-fn is_lobby_member(allowed_peers: &HashSet<String>, peer_ip: IpAddr) -> bool {
-    if allowed_peers.is_empty() {
-        return true;
+fn authenticate_lobby(state: &AppState, headers: &HeaderMap) -> Result<(), StatusCode> {
+    let expected = state
+        .lobby_token
+        .read()
+        .clone()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let mut values = headers.get_all(LOBBY_TOKEN_HEADER).iter();
+    let supplied = values
+        .next()
+        .and_then(|value| value.to_str().ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+    if values.next().is_some() || !ct_eq(supplied.as_bytes(), expected.as_bytes()) {
+        return Err(StatusCode::UNAUTHORIZED);
     }
-    let peer = peer_ip.to_string();
-    allowed_peers.iter().any(|allowed| {
-        allowed
-            .parse::<IpAddr>()
-            .map(|ip| ip == peer_ip)
-            .unwrap_or_else(|_| allowed == &peer)
-    })
+    Ok(())
 }
 
-/// 统一的成员校验入口：非成员一律 403，并记录日志便于排查。
-fn reject_non_member(
+fn overlay_socket_addr(ip: &str, port: u16) -> Result<SocketAddr, Box<dyn std::error::Error>> {
+    let parsed: std::net::Ipv4Addr = ip
+        .trim()
+        .parse()
+        .map_err(|error| format!("无效的虚拟IP: {} ({})", ip, error))?;
+    let octets = parsed.octets();
+    if octets[..3] != [10, 126, 126] || octets[3] == 0 || octets[3] == 255 {
+        return Err(format!("文件服务器只能绑定具体的EasyTier虚拟IP: {}", ip).into());
+    }
+    Ok(SocketAddr::new(IpAddr::V4(parsed), port))
+}
+
+async fn is_share_access_allowed(
     state: &AppState,
-    peer_addr: &SocketAddr,
-    what: &str,
-) -> Result<(), StatusCode> {
-    let allowed = state.allowed_peers.read();
-    if is_lobby_member(&allowed, peer_addr.ip()) {
-        return Ok(());
+    share_id: &str,
+    share: &SharedFolder,
+    peer: SocketAddr,
+    provided_password: &str,
+) -> bool {
+    let Some(expected_password) = share
+        .password
+        .as_deref()
+        .filter(|password| !password.trim().is_empty())
+    else {
+        return true;
+    };
+
+    let key = (share_id.to_string(), peer.ip());
+    let now = Instant::now();
+    let mut failures = state.password_failures.lock().await;
+    failures.retain(|_, attempts| {
+        while attempts
+            .front()
+            .is_some_and(|attempt| now.duration_since(*attempt) > PASSWORD_FAILURE_WINDOW)
+        {
+            attempts.pop_front();
+        }
+        !attempts.is_empty()
+    });
+    if !failures.contains_key(&key) && failures.len() >= MAX_PASSWORD_FAILURE_KEYS {
+        return false;
     }
-    log::warn!(
-        "🚫 [FileShare] 拒绝非大厅成员访问 {}：来源 {}",
-        what,
-        peer_addr.ip()
-    );
-    Err(StatusCode::FORBIDDEN)
+    {
+        let attempts = failures.entry(key.clone()).or_default();
+        if attempts.len() >= MAX_PASSWORD_FAILURES {
+            return false;
+        }
+    }
+
+    let valid = ct_eq(provided_password.as_bytes(), expected_password.as_bytes());
+    if valid {
+        failures.remove(&key);
+    } else {
+        failures.entry(key).or_default().push_back(now);
+    }
+    valid
 }
 
-fn is_share_access_allowed(share: &SharedFolder, headers: &HeaderMap) -> bool {
-    if let Some(expected_password) = &share.password {
-        let provided_password = headers
-            .get("x-share-password")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
+fn share_password_header(headers: &HeaderMap) -> &str {
+    headers
+        .get("x-share-password")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+}
 
-        return ct_eq(provided_password.as_bytes(), expected_password.as_bytes());
-    }
-
-    true
+fn is_expired(expire_time: Option<u64>, now: u64) -> bool {
+    expire_time.is_some_and(|deadline| deadline <= now)
 }
 
 /// 常量时间字符串比较，避免密码校验的时间侧信道
@@ -481,36 +582,212 @@ fn ct_eq(a: &[u8], b: &[u8]) -> bool {
 ///
 /// 仅允许「正常」路径段，拒绝绝对路径、根、盘符前缀以及任何 `..` 父目录段，
 /// 从而保证最终路径一定位于共享目录内部。返回 `None` 表示路径非法。
-fn safe_join(base: &Path, rel: &str) -> Option<PathBuf> {
-    use std::path::Component;
+fn is_link_or_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::fs::MetadataExt;
+        metadata.file_type().is_symlink() || metadata.file_attributes() & 0x400 != 0
+    }
 
-    let rel_path = Path::new(rel);
-    if rel_path.is_absolute() {
+    #[cfg(not(target_os = "windows"))]
+    metadata.file_type().is_symlink()
+}
+
+fn is_windows_reserved_name(name: &str) -> bool {
+    let trimmed = name.trim_end_matches([' ', '.']);
+    let stem = trimmed.split('.').next().unwrap_or("").to_ascii_uppercase();
+    matches!(
+        stem.as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    )
+}
+
+/// Return a portable ZIP member name and a case-insensitive collision key.
+/// ZIPs can be created on Unix and extracted on Windows, so apply the
+/// stricter Windows filename rules on every platform.
+fn safe_zip_entry_name(name: &str) -> Option<(String, String)> {
+    if name.is_empty() || name.contains('\0') {
+        return None;
+    }
+
+    let normalized = name.replace('\\', "/");
+    if normalized.starts_with('/') {
+        return None;
+    }
+
+    let mut components = Vec::new();
+    for component in normalized.split('/') {
+        if component.is_empty()
+            || component == "."
+            || component == ".."
+            || component.chars().any(char::is_control)
+            || component.contains(':')
+            || component
+                .chars()
+                .any(|ch| matches!(ch, '<' | '>' | '"' | '|' | '?' | '*'))
+            || component != component.trim_end_matches([' ', '.'])
+            || is_windows_reserved_name(component)
+        {
+            return None;
+        }
+        components.push(component.to_string());
+    }
+
+    if components.is_empty() {
+        return None;
+    }
+
+    let entry_name = components.join("/");
+    let key = components
+        .iter()
+        .map(|component| component.to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join("/");
+    Some((entry_name, key))
+}
+
+fn safe_join(base: &Path, rel: &str) -> Option<PathBuf> {
+    if rel.contains('\0') {
+        return None;
+    }
+    let normalized = rel.replace('\\', "/");
+    if normalized.starts_with('/') {
         return None;
     }
 
     let mut result = base.to_path_buf();
-    for comp in rel_path.components() {
-        match comp {
-            Component::Normal(c) => result.push(c),
-            Component::CurDir => {} // 忽略 "."
-            // 拒绝 ".."、根目录、盘符前缀等可能逃出共享目录的段
-            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+    for component in normalized.split('/') {
+        if component.is_empty() || component == "." {
+            continue;
         }
+        if component == ".." || component.chars().any(char::is_control) {
+            return None;
+        }
+        #[cfg(windows)]
+        if component.contains(':')
+            || component != component.trim_end_matches([' ', '.'])
+            || is_windows_reserved_name(component)
+        {
+            return None;
+        }
+        result.push(component);
     }
     Some(result)
+}
+
+fn safe_existing_join(base: &Path, rel: &str) -> Option<PathBuf> {
+    let candidate = safe_join(base, rel)?;
+    let base_metadata = std::fs::symlink_metadata(base).ok()?;
+    if is_link_or_reparse_point(&base_metadata) {
+        return None;
+    }
+    let canonical_base = std::fs::canonicalize(base).ok()?;
+    let relative = candidate.strip_prefix(base).ok()?;
+    let mut current = base.to_path_buf();
+    for component in relative.components() {
+        let std::path::Component::Normal(name) = component else {
+            return None;
+        };
+        current.push(name);
+        let metadata = std::fs::symlink_metadata(&current).ok()?;
+        if is_link_or_reparse_point(&metadata) {
+            return None;
+        }
+        if !std::fs::canonicalize(&current)
+            .ok()?
+            .starts_with(&canonical_base)
+        {
+            return None;
+        }
+    }
+    Some(candidate)
+}
+
+fn open_readonly_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // Open the reparse point itself so a last-moment leaf swap cannot be
+        // followed outside the shared directory.
+        options.custom_flags(0x0020_0000);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = options.open(path)?;
+    if is_link_or_reparse_point(&file.metadata()?) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "refusing to follow a link or reparse point",
+        ));
+    }
+    Ok(file)
+}
+
+fn content_disposition(path: &Path) -> String {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "download".into());
+    let sanitized: String = name
+        .chars()
+        .map(|ch| {
+            if ch == '"' || ch == '\\' || ch.is_control() {
+                '_'
+            } else {
+                ch
+            }
+        })
+        .collect();
+    format!(
+        "attachment; filename=\"{}\"",
+        if sanitized.is_empty() {
+            "download"
+        } else {
+            &sanitized
+        }
+    )
 }
 
 /// 获取共享列表
 async fn list_shares(
     State(state): State<AppState>,
-    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
 ) -> Result<Json<ShareListResponse>, StatusCode> {
-    reject_non_member(&state, &peer_addr, "共享列表")?;
-
+    authenticate_lobby(&state, &headers)?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
     let shares: Vec<SharedFolderSummary> = state
         .shared_folders
         .iter()
+        .filter(|entry| !is_expired(entry.value().expire_time, now))
         .map(|entry| SharedFolderSummary::from(entry.value()))
         .collect();
 
@@ -522,6 +799,7 @@ async fn list_shares(
 #[cfg(test)]
 mod share_list_response_tests {
     use super::{ShareListResponse, SharedFolder, SharedFolderSummary};
+    use uuid::Uuid;
 
     fn protected_share() -> SharedFolder {
         SharedFolder {
@@ -533,6 +811,7 @@ mod share_list_response_tests {
             compress_before_send: Some(true),
             owner_id: "owner-1".to_string(),
             created_at: 1_800_000_000,
+            expiry_token: Uuid::nil(),
         }
     }
 
@@ -559,98 +838,48 @@ mod share_list_response_tests {
         assert!(!SharedFolderSummary::from(&share).has_password);
     }
 
-    /// 旧节点只返回明文 `password`、没有 `has_password`。若不做归一化，
-    /// `has_password` 会默认为 false，导致新客户端不显示锁图标、直接跳过密码校验。
     #[test]
-    fn legacy_node_password_is_inferred_as_protected() {
-        let legacy = serde_json::json!({
-            "id": "share-1",
-            "name": "Legacy share",
-            "path": r"C:\Users\test\private",
-            "password": "secret-password",
-            "owner_id": "owner-1",
-            "created_at": 1_800_000_000u64
-        });
+    fn whitespace_password_is_reported_as_unprotected() {
+        let mut share = protected_share();
+        share.password = Some("  \t".to_string());
 
-        let summary: SharedFolderSummary =
-            serde_json::from_value(legacy).expect("deserialize legacy share");
-        assert!(!summary.has_password, "旧节点响应本身没有 has_password 字段");
-
-        let summary = summary.normalized();
-        assert!(summary.has_password, "应据明文 password 推断出需要密码");
-        assert!(summary.legacy_password.is_none(), "归一化后不得残留密码");
-    }
-
-    #[test]
-    fn legacy_empty_password_stays_unprotected() {
-        let legacy = serde_json::json!({
-            "id": "share-1",
-            "name": "Legacy share",
-            "password": "",
-            "owner_id": "owner-1",
-            "created_at": 1_800_000_000u64
-        });
-
-        let summary: SharedFolderSummary = serde_json::from_value::<SharedFolderSummary>(legacy)
-            .expect("deserialize legacy share")
-            .normalized();
-        assert!(!summary.has_password);
-    }
-
-    #[test]
-    fn new_node_has_password_is_preserved() {
-        let modern = serde_json::json!({
-            "id": "share-1",
-            "name": "Modern share",
-            "has_password": true,
-            "owner_id": "owner-1",
-            "created_at": 1_800_000_000u64
-        });
-
-        let summary: SharedFolderSummary = serde_json::from_value::<SharedFolderSummary>(modern)
-            .expect("deserialize modern share")
-            .normalized();
-        assert!(summary.has_password);
-    }
-
-    /// 归一化后的摘要即使来自旧节点，也不得把密码再序列化出去。
-    #[test]
-    fn normalized_summary_never_serializes_password() {
-        let legacy = serde_json::json!({
-            "id": "share-1",
-            "name": "Legacy share",
-            "password": "secret-password",
-            "owner_id": "owner-1",
-            "created_at": 1_800_000_000u64
-        });
-
-        let summary: SharedFolderSummary = serde_json::from_value::<SharedFolderSummary>(legacy)
-            .expect("deserialize legacy share")
-            .normalized();
-        let json = serde_json::to_value(&summary).expect("serialize summary");
-
-        assert!(json.get("password").is_none());
-        assert!(!json.to_string().contains("secret-password"));
+        assert!(!SharedFolderSummary::from(&share).has_password);
     }
 }
 
 /// 获取文件列表
 async fn list_files(
     State(state): State<AppState>,
-    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     AxumPath(share_id): AxumPath<String>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Result<Json<FileListResponse>, StatusCode> {
-    reject_non_member(&state, &peer_addr, "文件列表")?;
-
+    authenticate_lobby(&state, &headers)?;
     // 获取共享信息
     let share = state
         .shared_folders
         .get(&share_id)
+        .map(|share| share.clone())
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    if !is_share_access_allowed(&share, &headers) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    if is_expired(share.expire_time, now) {
+        return Err(StatusCode::GONE);
+    }
+
+    if !is_share_access_allowed(
+        &state,
+        &share_id,
+        &share,
+        peer,
+        share_password_header(&headers),
+    )
+    .await
+    {
         return Err(StatusCode::UNAUTHORIZED);
     }
 
@@ -658,10 +887,23 @@ async fn list_files(
     let sub_path = params.get("path").map(|s| s.as_str()).unwrap_or("");
 
     // 安全检查：使用 safe_join 防止路径穿越，确保路径在共享目录内
-    let full_path = match safe_join(&base_path, sub_path) {
+    let full_path = match safe_existing_join(&base_path, sub_path) {
         Some(p) => p,
         None => return Err(StatusCode::FORBIDDEN),
     };
+
+    let directory_metadata = tokio::fs::symlink_metadata(&full_path)
+        .await
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                StatusCode::NOT_FOUND
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        })?;
+    if is_link_or_reparse_point(&directory_metadata) || !directory_metadata.is_dir() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
 
     // 读取目录
     let mut files = Vec::new();
@@ -674,10 +916,12 @@ async fn list_files(
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     {
-        let metadata = entry
-            .metadata()
+        let metadata = tokio::fs::symlink_metadata(entry.path())
             .await
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        if is_link_or_reparse_point(&metadata) {
+            continue;
+        }
 
         let name = entry.file_name().to_string_lossy().to_string();
         let relative_path = if sub_path.is_empty() {
@@ -722,120 +966,134 @@ async fn list_files(
 /// 验证密码
 async fn verify_password(
     State(state): State<AppState>,
-    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     AxumPath(share_id): AxumPath<String>,
+    headers: HeaderMap,
     Json(req): Json<VerifyPasswordRequest>,
-) -> Json<VerifyPasswordResponse> {
-    // 非大厅成员不得试探密码（否则可绕过成员校验做离线爆破）
-    if reject_non_member(&state, &peer_addr, "密码校验").is_err() {
-        return Json(VerifyPasswordResponse {
-            success: false,
-            message: "共享不存在".to_string(),
-        });
+) -> Result<Json<VerifyPasswordResponse>, StatusCode> {
+    authenticate_lobby(&state, &headers)?;
+    let share = state
+        .shared_folders
+        .get(&share_id)
+        .map(|share| share.clone())
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    if is_expired(share.expire_time, now) {
+        return Err(StatusCode::GONE);
     }
 
-    let share = match state.shared_folders.get(&share_id) {
-        Some(s) => s,
-        None => {
-            return Json(VerifyPasswordResponse {
-                success: false,
-                message: "共享不存在".to_string(),
-            });
-        }
-    };
+    let success = is_share_access_allowed(&state, &share_id, &share, peer, &req.password).await;
 
-    let success = match &share.password {
-        Some(pwd) => ct_eq(pwd.as_bytes(), req.password.as_bytes()),
-        None => true, // 无密码保护
-    };
-
-    Json(VerifyPasswordResponse {
+    Ok(Json(VerifyPasswordResponse {
         success,
         message: if success {
             "验证成功".to_string()
         } else {
             "密码错误".to_string()
         },
-    })
+    }))
 }
 
 /// 下载文件（支持Range请求）
 async fn download_file(
     State(state): State<AppState>,
-    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     AxumPath((share_id, file_path)): AxumPath<(String, String)>,
     headers: HeaderMap,
 ) -> Result<Response, StatusCode> {
-    reject_non_member(&state, &peer_addr, "文件下载")?;
-
+    authenticate_lobby(&state, &headers)?;
     // 获取共享信息
     let share = state
         .shared_folders
         .get(&share_id)
+        .map(|share| share.clone())
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    if !is_share_access_allowed(&share, &headers) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    if is_expired(share.expire_time, now) {
+        return Err(StatusCode::GONE);
+    }
+
+    if !is_share_access_allowed(
+        &state,
+        &share_id,
+        &share,
+        peer,
+        share_password_header(&headers),
+    )
+    .await
+    {
         return Err(StatusCode::UNAUTHORIZED);
     }
 
     let base_path = PathBuf::from(&share.path);
 
     // 安全检查：使用 safe_join 防止路径穿越
-    let full_path = match safe_join(&base_path, &file_path) {
+    let full_path = match safe_existing_join(&base_path, &file_path) {
         Some(p) => p,
         None => return Err(StatusCode::FORBIDDEN),
     };
 
-    if !full_path.exists() {
-        return Err(StatusCode::NOT_FOUND);
-    }
-
-    // 获取文件元数据
-    let metadata = tokio::fs::metadata(&full_path)
+    // Re-check the leaf without following links immediately before opening it.
+    // The path was validated earlier, but a file can be replaced while a
+    // request is in flight.
+    let metadata = tokio::fs::symlink_metadata(&full_path)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                StatusCode::NOT_FOUND
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        })?;
 
-    if metadata.is_dir() {
+    if is_link_or_reparse_point(&metadata) {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    if !metadata.is_file() {
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    let file_size = metadata.len();
+    let opened_file = open_readonly_no_follow(&full_path).map_err(|_| StatusCode::FORBIDDEN)?;
+    let opened_metadata = opened_file
+        .metadata()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    if !opened_metadata.is_file() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let file_size = opened_metadata.len();
+    let mut file = File::from_std(opened_file);
 
     // 解析Range头
-    let range = headers
-        .get(header::RANGE)
-        .and_then(|v| v.to_str().ok())
-        .and_then(parse_range);
+    let range = match headers.get(header::RANGE) {
+        Some(value) => {
+            let value = value
+                .to_str()
+                .map_err(|_| StatusCode::RANGE_NOT_SATISFIABLE)?;
+            Some(parse_range(value).ok_or(StatusCode::RANGE_NOT_SATISFIABLE)?)
+        }
+        None => None,
+    };
 
     match range {
-        Some(_) if file_size == 0 => {
-            // 空文件：Range 无意义，直接返回 200 + 空体，避免 file_size - 1 下溢 panic
-            Response::builder()
-                .status(StatusCode::OK)
-                .header(header::CONTENT_TYPE, "application/octet-stream")
-                .header(header::CONTENT_LENGTH, 0u64)
-                .header(
-                    header::CONTENT_DISPOSITION,
-                    format!(
-                        "attachment; filename=\"{}\"",
-                        full_path.file_name().unwrap().to_string_lossy()
-                    ),
-                )
-                .body(Body::empty())
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
-        }
-        Some((start, _)) if start >= file_size => {
-            // 起始位置超出文件范围：按 HTTP 语义返回 416
-            Err(StatusCode::RANGE_NOT_SATISFIABLE)
-        }
-        Some((start, end)) => {
+        Some(range) => {
+            let Some((start, end)) = resolve_range(range, file_size) else {
+                return Response::builder()
+                    .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                    .header(header::CONTENT_RANGE, format!("bytes */{}", file_size))
+                    .header(header::ACCEPT_RANGES, "bytes")
+                    .body(Body::empty())
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
+            };
             // 范围请求
-            let end = end.min(file_size - 1);
             let length = end - start + 1;
-
-            let mut file = File::open(&full_path)
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
             file.seek(std::io::SeekFrom::Start(start))
                 .await
@@ -847,39 +1105,25 @@ async fn download_file(
                 .status(StatusCode::PARTIAL_CONTENT)
                 .header(header::CONTENT_TYPE, "application/octet-stream")
                 .header(header::CONTENT_LENGTH, length)
+                .header(header::ACCEPT_RANGES, "bytes")
                 .header(
                     header::CONTENT_RANGE,
                     format!("bytes {}-{}/{}", start, end, file_size),
                 )
-                .header(
-                    header::CONTENT_DISPOSITION,
-                    format!(
-                        "attachment; filename=\"{}\"",
-                        full_path.file_name().unwrap().to_string_lossy()
-                    ),
-                )
+                .header(header::CONTENT_DISPOSITION, content_disposition(&full_path))
                 .body(Body::from_stream(stream))
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
         }
         None => {
             // 完整文件请求
-            let file = File::open(&full_path)
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
             let stream = create_file_stream(file, file_size);
 
             Response::builder()
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, "application/octet-stream")
                 .header(header::CONTENT_LENGTH, file_size)
-                .header(
-                    header::CONTENT_DISPOSITION,
-                    format!(
-                        "attachment; filename=\"{}\"",
-                        full_path.file_name().unwrap().to_string_lossy()
-                    ),
-                )
+                .header(header::ACCEPT_RANGES, "bytes")
+                .header(header::CONTENT_DISPOSITION, content_disposition(&full_path))
                 .body(Body::from_stream(stream))
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
         }
@@ -887,23 +1131,97 @@ async fn download_file(
 }
 
 /// 解析Range头
-fn parse_range(range_str: &str) -> Option<(u64, u64)> {
-    // 格式: "bytes=start-end"
-    let range_str = range_str.strip_prefix("bytes=")?;
-    let parts: Vec<&str> = range_str.split('-').collect();
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ByteRange {
+    From { start: u64, end: Option<u64> },
+    Suffix(u64),
+}
 
-    if parts.len() != 2 {
+fn parse_range(range_str: &str) -> Option<ByteRange> {
+    let (unit, value) = range_str.split_once('=')?;
+    if !unit.eq_ignore_ascii_case("bytes") || value.contains(',') {
         return None;
     }
-
-    let start = parts[0].parse::<u64>().ok()?;
-    let end = if parts[1].is_empty() {
-        u64::MAX
+    let (start, end) = value.split_once('-')?;
+    if end.contains('-') {
+        return None;
+    }
+    if start.is_empty() {
+        let length = end.parse::<u64>().ok()?;
+        return (length > 0).then_some(ByteRange::Suffix(length));
+    }
+    let start = start.parse::<u64>().ok()?;
+    let end = if end.is_empty() {
+        None
     } else {
-        parts[1].parse::<u64>().ok()?
+        Some(end.parse::<u64>().ok()?)
     };
+    Some(ByteRange::From { start, end })
+}
 
-    Some((start, end))
+fn resolve_range(range: ByteRange, file_size: u64) -> Option<(u64, u64)> {
+    if file_size == 0 {
+        return None;
+    }
+    match range {
+        ByteRange::From { start, end } => {
+            if start >= file_size {
+                return None;
+            }
+            let end = end.unwrap_or(file_size - 1).min(file_size - 1);
+            (end >= start).then_some((start, end))
+        }
+        ByteRange::Suffix(length) => {
+            let length = length.min(file_size);
+            Some((file_size - length, file_size - 1))
+        }
+    }
+}
+
+#[cfg(test)]
+mod range_tests {
+    use super::{parse_range, resolve_range, ByteRange};
+
+    #[test]
+    fn parses_open_ended_and_suffix_ranges() {
+        assert_eq!(
+            parse_range("bytes=4-"),
+            Some(ByteRange::From {
+                start: 4,
+                end: None
+            })
+        );
+        assert_eq!(parse_range("BYTES=-8"), Some(ByteRange::Suffix(8)));
+        assert_eq!(parse_range("bytes=0-3,5-7"), None);
+        assert_eq!(parse_range("bytes=-0"), None);
+    }
+
+    #[test]
+    fn resolves_ranges_without_rejecting_a_large_end() {
+        assert_eq!(
+            resolve_range(
+                ByteRange::From {
+                    start: 2,
+                    end: Some(999)
+                },
+                10
+            ),
+            Some((2, 9))
+        );
+        assert_eq!(resolve_range(ByteRange::Suffix(4), 10), Some((6, 9)));
+        assert_eq!(resolve_range(ByteRange::Suffix(40), 10), Some((0, 9)));
+        assert_eq!(
+            resolve_range(
+                ByteRange::From {
+                    start: 10,
+                    end: None
+                },
+                10
+            ),
+            None
+        );
+        assert_eq!(resolve_range(ByteRange::Suffix(1), 0), None);
+    }
 }
 
 /// 创建文件流
@@ -932,28 +1250,349 @@ fn create_file_stream(
     }
 }
 
+struct TempFileStreamGuard {
+    file: Option<File>,
+    path: PathBuf,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl Drop for TempFileStreamGuard {
+    fn drop(&mut self) {
+        self.file.take();
+        if let Err(error) = std::fs::remove_file(&self.path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                log::warn!("清理临时ZIP失败 {:?}: {}", self.path, error);
+            }
+        }
+    }
+}
+
+fn create_temp_file_stream(
+    file: File,
+    path: PathBuf,
+    length: u64,
+    permit: OwnedSemaphorePermit,
+) -> impl futures_util::Stream<Item = Result<bytes::Bytes, std::io::Error>> {
+    let guard = TempFileStreamGuard {
+        file: Some(file),
+        path,
+        _permit: permit,
+    };
+    async_stream::stream! {
+        let mut guard = guard;
+        let mut remaining = length;
+        let mut buffer = vec![0u8; CHUNK_SIZE];
+        while remaining > 0 {
+            let to_read = std::cmp::min(CHUNK_SIZE as u64, remaining) as usize;
+            let result = match guard.file.as_mut() {
+                Some(file) => file.read(&mut buffer[..to_read]).await,
+                None => break,
+            };
+            match result {
+                Ok(0) => break,
+                Ok(read) => {
+                    remaining -= read as u64;
+                    yield Ok(bytes::Bytes::copy_from_slice(&buffer[..read]));
+                }
+                Err(error) => {
+                    yield Err(error);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+struct TempPathCleanup {
+    path: PathBuf,
+    armed: bool,
+}
+
+struct PreparedBatchZip {
+    file: Option<std::fs::File>,
+    path: PathBuf,
+    filename: String,
+    size: u64,
+    permit: Option<OwnedSemaphorePermit>,
+    armed: bool,
+}
+
+impl PreparedBatchZip {
+    fn into_stream_parts(mut self) -> (File, PathBuf, String, u64, OwnedSemaphorePermit) {
+        self.armed = false;
+        (
+            File::from_std(self.file.take().expect("prepared ZIP file missing")),
+            self.path.clone(),
+            self.filename.clone(),
+            self.size,
+            self.permit.take().expect("prepared ZIP permit missing"),
+        )
+    }
+}
+
+impl Drop for PreparedBatchZip {
+    fn drop(&mut self) {
+        self.file.take();
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+fn ensure_share_current(
+    shared_folders: &DashMap<String, SharedFolder>,
+    share_id: &str,
+    share_token: Uuid,
+) -> Result<(), StatusCode> {
+    let share = shared_folders.get(share_id).ok_or(StatusCode::GONE)?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    if share.expiry_token != share_token || is_expired(share.expire_time, now) {
+        return Err(StatusCode::GONE);
+    }
+    Ok(())
+}
+
+struct ShareValidityReader<R> {
+    inner: R,
+    shared_folders: Arc<DashMap<String, SharedFolder>>,
+    share_id: String,
+    share_token: Uuid,
+}
+
+impl<R: std::io::Read> std::io::Read for ShareValidityReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        ensure_share_current(&self.shared_folders, &self.share_id, self.share_token).map_err(
+            |_| std::io::Error::new(std::io::ErrorKind::Interrupted, SHARE_INVALID_ERROR),
+        )?;
+        self.inner.read(buffer)
+    }
+}
+
+struct SizeLimitedWriter<W> {
+    inner: W,
+    position: u64,
+    written: u64,
+    limit: u64,
+}
+
+impl<W: std::io::Write> std::io::Write for SizeLimitedWriter<W> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        let available = self.limit.saturating_sub(self.position);
+        if buffer.len() as u64 > available {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                ZIP_OUTPUT_LIMIT_ERROR,
+            ));
+        }
+
+        let written = self.inner.write(buffer)?;
+        self.position = self.position.saturating_add(written as u64);
+        self.written = self.written.max(self.position);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl<W: std::io::Seek> std::io::Seek for SizeLimitedWriter<W> {
+    fn seek(&mut self, position: std::io::SeekFrom) -> std::io::Result<u64> {
+        let position = self.inner.seek(position)?;
+        if position > self.limit {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                ZIP_OUTPUT_LIMIT_ERROR,
+            ));
+        }
+        self.position = position;
+        Ok(position)
+    }
+}
+
+impl Drop for TempPathCleanup {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+fn build_batch_zip(
+    base_path: PathBuf,
+    file_paths: Vec<String>,
+    shared_folders: Arc<DashMap<String, SharedFolder>>,
+    share_id: String,
+    share_token: Uuid,
+    permit: OwnedSemaphorePermit,
+) -> Result<PreparedBatchZip, StatusCode> {
+    use std::io::{Read, Seek};
+
+    if file_paths.is_empty() || file_paths.len() > MAX_BATCH_FILES {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    ensure_share_current(&shared_folders, &share_id, share_token)?;
+
+    let zip_filename = format!("mctier_batch_{}.zip", Uuid::new_v4());
+    let zip_path = std::env::temp_dir().join(&zip_filename);
+    let mut cleanup = TempPathCleanup {
+        path: zip_path.clone(),
+        armed: true,
+    };
+    let zip_file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&zip_path)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut zip = zip::ZipWriter::new(SizeLimitedWriter {
+        inner: zip_file,
+        position: 0,
+        written: 0,
+        limit: MAX_BATCH_ZIP_BYTES,
+    });
+    let options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .compression_level(Some(6));
+    let mut seen = HashSet::new();
+    let mut total_source_bytes = 0u64;
+
+    for requested_path in file_paths {
+        ensure_share_current(&shared_folders, &share_id, share_token)?;
+        let (entry_name, entry_key) =
+            safe_zip_entry_name(&requested_path).ok_or(StatusCode::BAD_REQUEST)?;
+        let full_path =
+            safe_existing_join(&base_path, &requested_path).ok_or(StatusCode::BAD_REQUEST)?;
+        let metadata = std::fs::symlink_metadata(&full_path).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                StatusCode::NOT_FOUND
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        })?;
+        if is_link_or_reparse_point(&metadata) || !metadata.is_file() {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+        if !seen.insert(entry_key) {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+        let file = open_readonly_no_follow(&full_path).map_err(|_| StatusCode::FORBIDDEN)?;
+        let opened_metadata = file
+            .metadata()
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        if !opened_metadata.is_file() {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+        if total_source_bytes
+            .checked_add(opened_metadata.len())
+            .is_none_or(|total| total > MAX_BATCH_SOURCE_BYTES)
+        {
+            return Err(StatusCode::PAYLOAD_TOO_LARGE);
+        }
+
+        zip.start_file(entry_name, options).map_err(|error| {
+            if error.to_string().contains(ZIP_OUTPUT_LIMIT_ERROR) {
+                StatusCode::PAYLOAD_TOO_LARGE
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        })?;
+        let remaining = MAX_BATCH_SOURCE_BYTES - total_source_bytes;
+        let mut reader = ShareValidityReader {
+            inner: file.take(remaining + 1),
+            shared_folders: shared_folders.clone(),
+            share_id: share_id.clone(),
+            share_token,
+        };
+        let copied = std::io::copy(&mut reader, &mut zip).map_err(|error| {
+            if error.to_string() == SHARE_INVALID_ERROR {
+                StatusCode::GONE
+            } else if error.kind() == std::io::ErrorKind::Other
+                && error.to_string() == ZIP_OUTPUT_LIMIT_ERROR
+            {
+                StatusCode::PAYLOAD_TOO_LARGE
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        })?;
+        if copied > remaining {
+            return Err(StatusCode::PAYLOAD_TOO_LARGE);
+        }
+        total_source_bytes += copied;
+    }
+
+    let mut zip_file = zip.finish().map_err(|error| {
+        if error.to_string().contains(ZIP_OUTPUT_LIMIT_ERROR) {
+            StatusCode::PAYLOAD_TOO_LARGE
+        } else {
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    })?;
+    let zip_size = zip_file.written;
+    zip_file
+        .inner
+        .sync_all()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    ensure_share_current(&shared_folders, &share_id, share_token)?;
+    zip_file
+        .inner
+        .seek(std::io::SeekFrom::Start(0))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    cleanup.armed = false;
+    Ok(PreparedBatchZip {
+        file: Some(zip_file.inner),
+        path: zip_path,
+        filename: zip_filename,
+        size: zip_size,
+        permit: Some(permit),
+        armed: true,
+    })
+}
+
 /// 批量打包下载（先压后发）
 async fn batch_download(
     State(state): State<AppState>,
-    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     AxumPath(share_id): AxumPath<String>,
     headers: HeaderMap,
     Json(req): Json<BatchDownloadRequest>,
 ) -> Result<Response, StatusCode> {
-    reject_non_member(&state, &peer_addr, "批量下载")?;
+    authenticate_lobby(&state, &headers)?;
+    log::info!(
+        "📦 收到批量打包下载请求: share_id={}, files={}",
+        share_id,
+        req.file_paths.len()
+    );
 
-    log::info!("📦 收到批量打包下载请求: share_id={}, files={}", share_id, req.file_paths.len());
-    
     // 获取共享信息
     let share = state
         .shared_folders
         .get(&share_id)
+        .map(|share| share.clone())
         .ok_or_else(|| {
             log::error!("❌ 共享不存在: {}", share_id);
             StatusCode::NOT_FOUND
         })?;
 
-    if !is_share_access_allowed(&share, &headers) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    if is_expired(share.expire_time, now) {
+        return Err(StatusCode::GONE);
+    }
+
+    if !is_share_access_allowed(
+        &state,
+        &share_id,
+        &share,
+        peer,
+        share_password_header(&headers),
+    )
+    .await
+    {
         return Err(StatusCode::UNAUTHORIZED);
     }
 
@@ -964,99 +1603,69 @@ async fn batch_download(
     }
 
     let base_path = PathBuf::from(&share.path);
-    
-    // 创建临时ZIP文件
-    let temp_dir = std::env::temp_dir();
-    let zip_filename = format!("mctier_batch_{}_{}.zip", share_id, SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs());
-    let zip_path = temp_dir.join(&zip_filename);
-    
-    log::info!("📦 创建临时ZIP文件: {:?}", zip_path);
-    
-    // 创建ZIP文件
-    let zip_file = std::fs::File::create(&zip_path)
-        .map_err(|e| {
-            log::error!("❌ 创建ZIP文件失败: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-    
-    let mut zip = zip::ZipWriter::new(zip_file);
-    let options = SimpleFileOptions::default()
-        .compression_method(zip::CompressionMethod::Deflated)
-        .compression_level(Some(6));
-    
-    // 添加文件到ZIP
-    for file_path in &req.file_paths {
-        // 安全检查：使用 safe_join 防止路径穿越
-        let full_path = match safe_join(&base_path, file_path) {
-            Some(p) => p,
-            None => {
-                log::warn!("⚠️ 路径安全检查失败（疑似路径穿越）: {}", file_path);
-                continue;
-            }
-        };
-        
-        if !full_path.exists() {
-            log::warn!("⚠️ 文件不存在: {:?}", full_path);
-            continue;
-        }
-        
-        let metadata = std::fs::metadata(&full_path)
-            .map_err(|e| {
-                log::error!("❌ 获取文件元数据失败: {}", e);
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?;
-        
-        if metadata.is_file() {
-            log::info!("📄 添加文件到ZIP: {}", file_path);
-            
-            zip.start_file(file_path, options)
-                .map_err(|e| {
-                    log::error!("❌ 开始写入ZIP文件失败: {}", e);
-                    StatusCode::INTERNAL_SERVER_ERROR
-                })?;
-            
-            let mut file = std::fs::File::open(&full_path)
-                .map_err(|e| {
-                    log::error!("❌ 打开文件失败: {}", e);
-                    StatusCode::INTERNAL_SERVER_ERROR
-                })?;
-            
-            std::io::copy(&mut file, &mut zip)
-                .map_err(|e| {
-                    log::error!("❌ 复制文件到ZIP失败: {}", e);
-                    StatusCode::INTERNAL_SERVER_ERROR
-                })?;
-        }
-    }
-    
-    zip.finish()
-        .map_err(|e| {
-            log::error!("❌ 完成ZIP文件失败: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-    
-    log::info!("✅ ZIP文件创建成功: {:?}", zip_path);
-    
-    // 读取ZIP文件
-    let zip_data = tokio::fs::read(&zip_path)
+    let share_token = share.expiry_token;
+    let file_paths = req.file_paths;
+    // Keep one slot occupied from compression start until the response body
+    // is dropped. This bounds both CPU and temporary-disk pressure.
+    let permit = state
+        .batch_slots
+        .clone()
+        .acquire_owned()
         .await
-        .map_err(|e| {
-            log::error!("❌ 读取ZIP文件失败: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-    
-    let zip_size = zip_data.len();
-    log::info!("📦 ZIP文件大小: {} bytes", zip_size);
-    
-    // 【修复】立即删除临时文件（在发送响应前）
-    // 因为zip_data已经读取到内存中了，可以安全删除文件
-    if let Err(e) = tokio::fs::remove_file(&zip_path).await {
-        log::warn!("⚠️ 删除临时ZIP文件失败: {}", e);
-    } else {
-        log::info!("🗑️ 临时ZIP文件已删除: {:?}", zip_path);
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let current = state
+        .shared_folders
+        .get(&share_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+    if current.expiry_token != share_token
+        || is_expired(
+            current.expire_time,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        )
+    {
+        return Err(StatusCode::GONE);
     }
-    
-    // 返回ZIP文件
+    drop(current);
+
+    let shared_folders = state.shared_folders.clone();
+    let build_share_id = share_id.clone();
+    let prepared = tokio::task::spawn_blocking(move || {
+        build_batch_zip(
+            base_path,
+            file_paths,
+            shared_folders,
+            build_share_id,
+            share_token,
+            permit,
+        )
+    })
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)??;
+
+    let current = state
+        .shared_folders
+        .get(&share_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let still_allowed = current.expiry_token == share_token
+        && !is_expired(
+            current.expire_time,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        );
+    drop(current);
+    if !still_allowed {
+        return Err(StatusCode::GONE);
+    }
+
+    let (zip_file, zip_path, zip_filename, zip_size, permit) = prepared.into_stream_parts();
+    let stream = create_temp_file_stream(zip_file, zip_path, zip_size, permit);
+
     Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, "application/zip")
@@ -1065,73 +1674,6 @@ async fn batch_download(
             header::CONTENT_DISPOSITION,
             format!("attachment; filename=\"{}\"", zip_filename),
         )
-        .body(Body::from(zip_data))
-        .map_err(|e| {
-            log::error!("❌ 构建响应失败: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
-}
-
-
-
-#[cfg(test)]
-mod lobby_member_tests {
-    use super::{is_lobby_member, FileTransferService};
-    use std::collections::HashSet;
-    use std::net::IpAddr;
-
-    fn peers(list: &[&str]) -> HashSet<String> {
-        list.iter().map(|s| s.to_string()).collect()
-    }
-
-    fn ip(value: &str) -> IpAddr {
-        value.parse().expect("测试用 IP 应可解析")
-    }
-
-    #[test]
-    fn rejects_a_peer_that_left_the_lobby() {
-        // 被移出大厅的玩家仍在 EasyTier 虚拟网内，但不应再能访问共享
-        let allowed = peers(&["10.126.126.1", "10.126.126.2"]);
-        assert!(
-            !is_lobby_member(&allowed, ip("10.126.126.9")),
-            "非大厅成员必须被拒绝，否则被踢玩家仍能下载文件"
-        );
-    }
-
-    #[test]
-    fn allows_current_lobby_members() {
-        let allowed = peers(&["10.126.126.1", "10.126.126.2"]);
-        assert!(is_lobby_member(&allowed, ip("10.126.126.1")));
-        assert!(is_lobby_member(&allowed, ip("10.126.126.2")));
-    }
-
-    #[test]
-    fn allows_everything_before_the_roster_is_pushed() {
-        // 刚进大厅或对端为旧版本时，不能让文件共享直接不可用
-        assert!(is_lobby_member(&HashSet::new(), ip("10.126.126.9")));
-    }
-
-    #[test]
-    fn set_allowed_peers_drops_blank_entries() {
-        let service = FileTransferService::new();
-        service.set_allowed_peers(vec![
-            "10.126.126.1".to_string(),
-            String::new(),
-            "   ".to_string(),
-        ]);
-        let allowed = service.allowed_peers.read().clone();
-        assert_eq!(allowed.len(), 1, "空白地址不得进入名单：{:?}", allowed);
-        assert!(allowed.contains("10.126.126.1"));
-    }
-
-    #[test]
-    fn clear_allowed_peers_resets_the_check() {
-        let service = FileTransferService::new();
-        service.set_allowed_peers(vec!["10.126.126.1".to_string()]);
-        service.clear_allowed_peers();
-        assert!(
-            service.allowed_peers.read().is_empty(),
-            "退出大厅后必须清空名单，否则会影响下一个大厅"
-        );
-    }
+        .body(Body::from_stream(stream))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
 }

--- a/src-tauri/src/modules/hosts_manager.rs
+++ b/src-tauri/src/modules/hosts_manager.rs
@@ -1,11 +1,68 @@
 // Hosts文件管理模块
 // 用于实现MCTier专属的Magic DNS功能
 
+use crate::modules::error::AppError;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
-use crate::modules::error::AppError;
+
+fn validate_host_domain(domain: &str) -> Result<(), AppError> {
+    if domain.is_empty() || domain.len() > 253 || domain != domain.trim() {
+        return Err(AppError::ValidationError(
+            "域名为空、过长或包含首尾空白".to_string(),
+        ));
+    }
+    if domain
+        .chars()
+        .any(|ch| ch.is_control() || ch == '#' || ch == '/' || ch == '\\' || ch == ':')
+    {
+        return Err(AppError::ValidationError("域名包含非法字符".to_string()));
+    }
+
+    for label in domain.split('.') {
+        if label.is_empty() || label.len() > 63 {
+            return Err(AppError::ValidationError("域名标签长度无效".to_string()));
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(AppError::ValidationError(
+                "域名标签不能以连字符开头或结尾".to_string(),
+            ));
+        }
+        if !label.chars().all(|ch| ch.is_alphanumeric() || ch == '-') {
+            return Err(AppError::ValidationError("域名包含非法字符".to_string()));
+        }
+    }
+    Ok(())
+}
+
+fn validate_host_ip(ip: &str) -> Result<(), AppError> {
+    let address = ip
+        .parse::<std::net::IpAddr>()
+        .map_err(|_| AppError::ValidationError("IP 地址格式无效".to_string()))?;
+    if address.is_unspecified() || address.is_loopback() || address.is_multicast() {
+        return Err(AppError::ValidationError(
+            "不允许使用未指定、回环或组播地址".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn sanitize_marker_component(value: &str) -> String {
+    let mut sanitized = String::new();
+    for ch in value.chars().take(64) {
+        if ch.is_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+            sanitized.push(ch);
+        } else {
+            sanitized.push('_');
+        }
+    }
+    if sanitized.is_empty() {
+        "lobby".to_string()
+    } else {
+        sanitized
+    }
+}
 
 /// 进程级 hosts 文件操作锁：串行化所有「读-改-写」，防止并发交错导致 hosts 文件损坏
 fn hosts_lock() -> &'static Mutex<()> {
@@ -25,22 +82,25 @@ impl HostsManager {
     pub fn new(lobby_name: &str) -> Self {
         #[cfg(windows)]
         let hosts_path = PathBuf::from(r"C:\Windows\System32\drivers\etc\hosts");
-        
+
         #[cfg(not(windows))]
         let hosts_path = PathBuf::from("/etc/hosts");
-        
+
         Self {
             hosts_path,
-            marker_start: format!("# MCTier Magic DNS - {}", lobby_name),
+            marker_start: format!(
+                "# MCTier Magic DNS - {}",
+                sanitize_marker_component(lobby_name)
+            ),
             marker_end: "# MCTier Magic DNS End".to_string(),
         }
     }
-    
+
     /// 清理所有MCTier相关的hosts记录（静态方法）
-    /// 
+    ///
     /// 此方法会清理所有以"# MCTier Magic DNS"开头的记录块，
     /// 无论大厅名称是什么，确保彻底清理
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 清理成功
     /// * `Err(AppError)` - 清理失败
@@ -48,27 +108,27 @@ impl HostsManager {
         log::info!("🧹 开始清理所有MCTier hosts记录...");
         // 串行化 hosts 读-改-写
         let _guard = hosts_lock().lock().unwrap_or_else(|e| e.into_inner());
-        
+
         #[cfg(windows)]
         let hosts_path = PathBuf::from(r"C:\Windows\System32\drivers\etc\hosts");
-        
+
         #[cfg(not(windows))]
         let hosts_path = PathBuf::from("/etc/hosts");
-        
+
         // 读取hosts文件
         let mut file = File::open(&hosts_path)
             .map_err(|e| AppError::FileError(format!("无法打开hosts文件: {}", e)))?;
-        
+
         let mut content = String::new();
         file.read_to_string(&mut content)
             .map_err(|e| AppError::FileError(format!("无法读取hosts文件: {}", e)))?;
-        
+
         // 分析并移除所有MCTier相关的记录块
         let lines: Vec<&str> = content.lines().collect();
         let mut new_lines = Vec::new();
         let mut in_mctier_section = false;
         let mut removed_count = 0;
-        
+
         for line in lines {
             if line.starts_with("# MCTier Magic DNS") {
                 in_mctier_section = true;
@@ -84,20 +144,25 @@ impl HostsManager {
                 new_lines.push(line);
             }
         }
-        
+
         // 重新组合内容
         let new_content = new_lines.join("\n");
         if !new_content.is_empty() && !new_content.ends_with('\n') {
             // 确保文件以换行符结尾
             let new_content = format!("{}\n", new_content);
-            
+
             // 写回hosts文件
             let mut file = OpenOptions::new()
                 .write(true)
                 .truncate(true)
                 .open(&hosts_path)
-                .map_err(|e| AppError::FileError(format!("无法打开hosts文件进行写入: {}. 请确保以管理员权限运行", e)))?;
-            
+                .map_err(|e| {
+                    AppError::FileError(format!(
+                        "无法打开hosts文件进行写入: {}. 请确保以管理员权限运行",
+                        e
+                    ))
+                })?;
+
             file.write_all(new_content.as_bytes())
                 .map_err(|e| AppError::FileError(format!("无法写入hosts文件: {}", e)))?;
         } else {
@@ -106,36 +171,41 @@ impl HostsManager {
                 .write(true)
                 .truncate(true)
                 .open(&hosts_path)
-                .map_err(|e| AppError::FileError(format!("无法打开hosts文件进行写入: {}. 请确保以管理员权限运行", e)))?;
-            
+                .map_err(|e| {
+                    AppError::FileError(format!(
+                        "无法打开hosts文件进行写入: {}. 请确保以管理员权限运行",
+                        e
+                    ))
+                })?;
+
             file.write_all(new_content.as_bytes())
                 .map_err(|e| AppError::FileError(format!("无法写入hosts文件: {}", e)))?;
         }
-        
+
         // 刷新DNS缓存
         Self::flush_dns_cache_static()?;
-        
+
         if removed_count > 0 {
             log::info!("✅ 已清理 {} 个MCTier hosts记录块", removed_count);
         } else {
             log::info!("✅ 没有发现MCTier hosts记录，无需清理");
         }
-        
+
         Ok(())
     }
-    
+
     /// 刷新DNS缓存（静态方法）
     fn flush_dns_cache_static() -> Result<(), AppError> {
         #[cfg(windows)]
         {
-            use std::process::Command;
             use std::os::windows::process::CommandExt;
-            
+            use std::process::Command;
+
             // Windows 常量：CREATE_NO_WINDOW = 0x08000000
             const CREATE_NO_WINDOW: u32 = 0x08000000;
-            
+
             log::info!("🔄 [HostsManager] 正在刷新DNS缓存...");
-            
+
             // 使用 ipconfig /flushdns
             match Command::new("ipconfig")
                 .arg("/flushdns")
@@ -154,194 +224,204 @@ impl HostsManager {
                 }
             }
         }
-        
+
         #[cfg(not(windows))]
         {
             log::info!("✅ [HostsManager] 非Windows平台，跳过DNS缓存刷新");
         }
-        
+
         Ok(())
     }
-    
+
     /// 添加域名映射
-    /// 
+    ///
     /// # 参数
     /// * `domain` - 域名（如：qyzz.mct.net）
     /// * `ip` - 虚拟IP地址
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 添加成功
     /// * `Err(AppError)` - 添加失败
     pub fn add_entry(&self, domain: &str, ip: &str) -> Result<(), AppError> {
+        validate_host_domain(domain)?;
+        validate_host_ip(ip)?;
+
         // 串行化 hosts 读-改-写，防止与其它 hosts 操作交错
         let _guard = hosts_lock().lock().unwrap_or_else(|e| e.into_inner());
         log::info!("📝 [HostsManager] 开始添加hosts记录");
         log::info!("📝 [HostsManager] 域名: {}", domain);
         log::info!("📝 [HostsManager] IP: {}", ip);
         log::info!("📝 [HostsManager] Hosts文件路径: {:?}", self.hosts_path);
-        
+
         // 读取现有hosts文件内容
         log::info!("📝 [HostsManager] 正在读取hosts文件...");
         let mut content = self.read_hosts()?;
-        log::info!("📝 [HostsManager] Hosts文件读取成功，大小: {} 字节", content.len());
-        
+        log::info!(
+            "📝 [HostsManager] Hosts文件读取成功，大小: {} 字节",
+            content.len()
+        );
+
         // 查找MCTier标记区域
         log::info!("📝 [HostsManager] 正在查找MCTier标记区域...");
         let (before_marker, mut mctier_section, after_marker) = self.split_content(&content);
         log::info!("📝 [HostsManager] 标记前内容: {} 字节", before_marker.len());
-        log::info!("📝 [HostsManager] MCTier区域: {} 字节", mctier_section.len());
+        log::info!(
+            "📝 [HostsManager] MCTier区域: {} 字节",
+            mctier_section.len()
+        );
         log::info!("📝 [HostsManager] 标记后内容: {} 字节", after_marker.len());
-        
+
         // 检查是否已存在该域名
         let entry = format!("{} {}", ip, domain);
         log::info!("📝 [HostsManager] 要添加的记录: {}", entry);
-        
+
         if !mctier_section.contains(&entry) {
             log::info!("📝 [HostsManager] 记录不存在，准备添加");
             // 如果MCTier区域不存在，创建它
             if mctier_section.is_empty() {
                 log::info!("📝 [HostsManager] MCTier区域不存在，创建新区域");
-                mctier_section = format!("{}\n{}\n{}\n", 
-                    self.marker_start, 
-                    entry, 
-                    self.marker_end
-                );
+                mctier_section = format!("{}\n{}\n{}\n", self.marker_start, entry, self.marker_end);
             } else {
                 log::info!("📝 [HostsManager] MCTier区域已存在，在结束标记前添加记录");
                 // 在结束标记前添加新记录
-                mctier_section = mctier_section.replace(
-                    &self.marker_end,
-                    &format!("{}\n{}", entry, self.marker_end)
-                );
+                mctier_section = mctier_section
+                    .replace(&self.marker_end, &format!("{}\n{}", entry, self.marker_end));
             }
         } else {
             log::info!("📝 [HostsManager] 记录已存在，跳过添加");
         }
-        
+
         // 重新组合内容
         log::info!("📝 [HostsManager] 正在重新组合内容...");
         content = format!("{}{}{}", before_marker, mctier_section, after_marker);
         log::info!("📝 [HostsManager] 新内容大小: {} 字节", content.len());
-        
+
         // 写回hosts文件
         log::info!("📝 [HostsManager] 正在写入hosts文件...");
         self.write_hosts(&content)?;
-        
+
         log::info!("✅ [HostsManager] hosts记录添加成功");
         Ok(())
     }
-    
+
     /// 删除域名映射
-    /// 
+    ///
     /// # 参数
     /// * `domain` - 要删除的域名
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 删除成功
     /// * `Err(AppError)` - 删除失败
     pub fn remove_entry(&self, domain: &str) -> Result<(), AppError> {
+        validate_host_domain(domain)?;
         log::info!("删除hosts记录: {}", domain);
         let _guard = hosts_lock().lock().unwrap_or_else(|e| e.into_inner());
-        
+
         // 读取现有hosts文件内容
         let content = self.read_hosts()?;
-        
+
         // 查找MCTier标记区域
         let (before_marker, mctier_section, after_marker) = self.split_content(&content);
-        
+
         // 从MCTier区域删除指定域名的记录
         let lines: Vec<&str> = mctier_section.lines().collect();
         let mut new_section = String::new();
-        
+
         for line in lines {
-            if !line.contains(domain) {
+            let matches_domain = line.split_whitespace().skip(1).any(|host| host == domain);
+            if !matches_domain {
                 new_section.push_str(line);
                 new_section.push('\n');
             }
         }
-        
+
         // 重新组合内容
         let new_content = format!("{}{}{}", before_marker, new_section, after_marker);
-        
+
         // 写回hosts文件
         self.write_hosts(&new_content)?;
-        
+
         log::info!("✅ hosts记录删除成功");
         Ok(())
     }
-    
+
     /// 清理所有MCTier相关的hosts记录
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 清理成功
     /// * `Err(AppError)` - 清理失败
     pub fn clear_all(&self) -> Result<(), AppError> {
         log::info!("清理所有MCTier hosts记录");
         let _guard = hosts_lock().lock().unwrap_or_else(|e| e.into_inner());
-        
+
         // 读取现有hosts文件内容
         let content = self.read_hosts()?;
-        
+
         // 查找MCTier标记区域
         let (before_marker, _, after_marker) = self.split_content(&content);
-        
+
         // 移除MCTier区域
         let new_content = format!("{}{}", before_marker, after_marker);
-        
+
         // 写回hosts文件
         self.write_hosts(&new_content)?;
-        
+
         log::info!("✅ 所有MCTier hosts记录已清理");
         Ok(())
     }
-    
+
     /// 批量添加域名映射
-    /// 
+    ///
     /// # 参数
     /// * `entries` - 域名和IP的映射列表 [(domain, ip), ...]
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 添加成功
     /// * `Err(AppError)` - 添加失败
     pub fn add_entries(&self, entries: &[(String, String)]) -> Result<(), AppError> {
         log::info!("批量添加{}条hosts记录", entries.len());
-        
+
         for (domain, ip) in entries {
             self.add_entry(domain, ip)?;
         }
-        
+
         Ok(())
     }
-    
+
     /// 读取hosts文件内容
     fn read_hosts(&self) -> Result<String, AppError> {
         let mut file = File::open(&self.hosts_path)
             .map_err(|e| AppError::FileError(format!("无法打开hosts文件: {}", e)))?;
-        
+
         let mut content = String::new();
         file.read_to_string(&mut content)
             .map_err(|e| AppError::FileError(format!("无法读取hosts文件: {}", e)))?;
-        
+
         Ok(content)
     }
-    
+
     /// 写入hosts文件内容
     fn write_hosts(&self, content: &str) -> Result<(), AppError> {
         let mut file = OpenOptions::new()
             .write(true)
             .truncate(true)
             .open(&self.hosts_path)
-            .map_err(|e| AppError::FileError(format!("无法打开hosts文件进行写入: {}. 请确保以管理员权限运行", e)))?;
-        
+            .map_err(|e| {
+                AppError::FileError(format!(
+                    "无法打开hosts文件进行写入: {}. 请确保以管理员权限运行",
+                    e
+                ))
+            })?;
+
         file.write_all(content.as_bytes())
             .map_err(|e| AppError::FileError(format!("无法写入hosts文件: {}", e)))?;
-        
+
         // 刷新DNS缓存
         self.flush_dns_cache()?;
-        
+
         Ok(())
     }
-    
+
     /// 分割hosts文件内容
     /// 返回：(MCTier标记之前的内容, MCTier区域内容, MCTier标记之后的内容)
     fn split_content(&self, content: &str) -> (String, String, String) {
@@ -349,9 +429,9 @@ impl HostsManager {
         let mut before = Vec::new();
         let mut mctier = Vec::new();
         let mut after = Vec::new();
-        
+
         let mut in_mctier_section = false;
-        
+
         for line in lines {
             if line.starts_with(&self.marker_start) {
                 in_mctier_section = true;
@@ -367,40 +447,40 @@ impl HostsManager {
                 after.push(line);
             }
         }
-        
+
         let before_str = if before.is_empty() {
             String::new()
         } else {
             format!("{}\n", before.join("\n"))
         };
-        
+
         let mctier_str = if mctier.is_empty() {
             String::new()
         } else {
             format!("{}\n", mctier.join("\n"))
         };
-        
+
         let after_str = if after.is_empty() {
             String::new()
         } else {
             format!("{}\n", after.join("\n"))
         };
-        
+
         (before_str, mctier_str, after_str)
     }
-    
+
     /// 刷新DNS缓存
     fn flush_dns_cache(&self) -> Result<(), AppError> {
         #[cfg(windows)]
         {
-            use std::process::Command;
             use std::os::windows::process::CommandExt;
-            
+            use std::process::Command;
+
             // Windows 常量：CREATE_NO_WINDOW = 0x08000000
             const CREATE_NO_WINDOW: u32 = 0x08000000;
-            
+
             log::info!("🔄 [HostsManager] 正在刷新DNS缓存...");
-            
+
             // 方法1: 使用 ipconfig /flushdns（隐藏窗口）
             match Command::new("ipconfig")
                 .arg("/flushdns")
@@ -421,7 +501,7 @@ impl HostsManager {
                     log::warn!("⚠️ [HostsManager] 执行ipconfig失败: {}", e);
                 }
             }
-            
+
             // 方法2: 使用 netsh 清除DNS缓存（更彻底，隐藏窗口）
             match Command::new("netsh")
                 .args(&["interface", "ip", "delete", "arpcache"])
@@ -439,7 +519,7 @@ impl HostsManager {
                     log::debug!("执行netsh失败: {}（可能不影响DNS解析）", e);
                 }
             }
-            
+
             // 方法3: 使用 netsh 重置DNS客户端（隐藏窗口）
             match Command::new("netsh")
                 .args(&["interface", "ip", "delete", "destinationcache"])
@@ -457,15 +537,15 @@ impl HostsManager {
                     log::debug!("执行netsh失败: {}（可能不影响DNS解析）", e);
                 }
             }
-            
+
             log::info!("✅ [HostsManager] DNS缓存刷新完成");
         }
-        
+
         #[cfg(not(windows))]
         {
             log::info!("✅ [HostsManager] 非Windows平台，跳过DNS缓存刷新");
         }
-        
+
         Ok(())
     }
 }
@@ -473,22 +553,60 @@ impl HostsManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_split_content() {
         let manager = HostsManager::new("测试大厅");
-        
+
         let content = r#"127.0.0.1 localhost
 # MCTier Magic DNS - 测试大厅
 10.126.126.1 test.mct.net
 # MCTier Magic DNS End
 192.168.1.1 router
 "#;
-        
+
         let (before, mctier, after) = manager.split_content(content);
-        
+
         assert!(before.contains("127.0.0.1 localhost"));
         assert!(mctier.contains("10.126.126.1 test.mct.net"));
         assert!(after.contains("192.168.1.1 router"));
+    }
+
+    #[test]
+    fn rejects_hosts_line_injection_and_dangerous_addresses() {
+        assert!(validate_host_domain("player.mct.net\n127.0.0.1 evil").is_err());
+        assert!(validate_host_domain("player # comment").is_err());
+        assert!(validate_host_domain("player..mct.net").is_err());
+        assert!(validate_host_ip("10.126.126.8\n127.0.0.1").is_err());
+        assert!(validate_host_ip("127.0.0.1").is_err());
+        assert!(validate_host_ip("0.0.0.0").is_err());
+    }
+
+    #[test]
+    fn sanitizes_lobby_name_before_using_it_in_hosts_marker() {
+        let manager = HostsManager::new("room\n# injected");
+        assert!(!manager.marker_start.contains('\n'));
+        assert_eq!(manager.marker_start, "# MCTier Magic DNS - room___injected");
+    }
+
+    #[test]
+    fn domain_removal_matches_a_host_token_not_a_substring() {
+        let manager = HostsManager::new("test");
+        let content = "127.0.0.1 localhost\n# MCTier Magic DNS - test\n10.0.0.1 player.mct.net\n10.0.0.2 not-player.mct.net\n# MCTier Magic DNS End\n";
+        let (before, section, after) = manager.split_content(content);
+        let mut kept = String::new();
+        for line in section.lines() {
+            if !line
+                .split_whitespace()
+                .skip(1)
+                .any(|host| host == "player.mct.net")
+            {
+                kept.push_str(line);
+                kept.push('\n');
+            }
+        }
+        let rebuilt = format!("{}{}{}", before, kept, after);
+        assert!(!rebuilt.contains("10.0.0.1 player.mct.net"));
+        assert!(rebuilt.contains("10.0.0.2 not-player.mct.net"));
     }
 }

--- a/src-tauri/src/modules/http_cors.rs
+++ b/src-tauri/src/modules/http_cors.rs
@@ -39,6 +39,7 @@ pub fn lan_cors_layer() -> CorsLayer {
             header::CONTENT_TYPE,
             header::RANGE,
             header::HeaderName::from_static("x-share-password"),
+            header::HeaderName::from_static("x-mctier-chat-token"),
         ])
         .expose_headers([
             header::CONTENT_LENGTH,

--- a/src-tauri/src/modules/lobby_manager.rs
+++ b/src-tauri/src/modules/lobby_manager.rs
@@ -34,7 +34,7 @@ pub struct Lobby {
 
 impl Lobby {
     /// 创建新的大厅实例
-    /// 
+    ///
     /// # 参数
     /// * `name` - 大厅名称
     /// * `password` - 大厅密码（可选）
@@ -43,13 +43,13 @@ impl Lobby {
     /// * `virtual_domain` - 虚拟域名（可选）
     /// * `use_domain` - 是否使用域名访问（可选）
     /// * `signaling_server` - 信令服务器地址（可选）
-    /// 
+    ///
     /// # 返回
     /// 新的大厅实例
     pub fn new(
-        name: String, 
-        password: Option<String>, 
-        virtual_ip: String, 
+        name: String,
+        password: Option<String>,
+        virtual_ip: String,
         creator_virtual_ip: String,
         virtual_domain: Option<String>,
         use_domain: Option<bool>,
@@ -89,11 +89,11 @@ pub struct Player {
 
 impl Player {
     /// 创建新的玩家实例
-    /// 
+    ///
     /// # 参数
     /// * `name` - 玩家名称
     /// * `virtual_ip` - 虚拟IP地址
-    /// 
+    ///
     /// # 返回
     /// 新的玩家实例
     pub fn new(name: String, virtual_ip: String) -> Self {
@@ -114,19 +114,19 @@ pub enum LobbyError {
     /// 输入验证错误
     #[error("输入验证失败: {0}")]
     InvalidInput(String),
-    
+
     /// 网络错误
     #[error("网络错误: {0}")]
     NetworkError(String),
-    
+
     /// 已经在大厅中
     #[error("已经在大厅中")]
     AlreadyInLobby,
-    
+
     /// 不在大厅中
     #[error("不在大厅中")]
     NotInLobby,
-    
+
     /// 玩家不存在
     #[error("玩家不存在: {0}")]
     PlayerNotFound(String),
@@ -138,12 +138,8 @@ impl From<LobbyError> for AppError {
         match err {
             LobbyError::InvalidInput(msg) => AppError::ValidationError(msg),
             LobbyError::NetworkError(msg) => AppError::NetworkError(msg),
-            LobbyError::AlreadyInLobby => {
-                AppError::ValidationError("已经在大厅中".to_string())
-            }
-            LobbyError::NotInLobby => {
-                AppError::ValidationError("不在大厅中".to_string())
-            }
+            LobbyError::AlreadyInLobby => AppError::ValidationError("已经在大厅中".to_string()),
+            LobbyError::NotInLobby => AppError::ValidationError("不在大厅中".to_string()),
             LobbyError::PlayerNotFound(id) => {
                 AppError::ValidationError(format!("玩家不存在: {}", id))
             }
@@ -152,7 +148,7 @@ impl From<LobbyError> for AppError {
 }
 
 /// 大厅管理器
-/// 
+///
 /// 负责管理大厅的创建、加入、退出以及玩家管理
 pub struct LobbyManager {
     /// 当前大厅（如果已加入）
@@ -165,7 +161,7 @@ pub struct LobbyManager {
 
 impl LobbyManager {
     /// 创建新的大厅管理器实例
-    /// 
+    ///
     /// # 返回
     /// 新的大厅管理器实例
     pub fn new() -> Self {
@@ -177,15 +173,15 @@ impl LobbyManager {
     }
 
     /// 验证输入字符串
-    /// 
+    ///
     /// # 参数
     /// * `input` - 要验证的输入字符串
     /// * `field_name` - 字段名称（用于错误消息）
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 验证通过
     /// * `Err(LobbyError)` - 验证失败
-    /// 
+    ///
     /// # 验证规则
     /// - 不能为空字符串
     /// - 不能仅包含空白字符（空格、制表符、换行符等）
@@ -228,14 +224,14 @@ impl LobbyManager {
         trimmed.to_string()
     }
     /// 验证大厅名称
-    /// 
+    ///
     /// # 参数
     /// * `name` - 大厅名称
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 验证通过
     /// * `Err(LobbyError)` - 验证失败
-    /// 
+    ///
     /// # 验证规则
     /// - 长度：4-32 个字符
     /// - 必须包含字母或数字
@@ -243,17 +239,17 @@ impl LobbyManager {
     /// - 不能仅包含空白字符
     pub fn validate_lobby_name(name: &str) -> Result<(), LobbyError> {
         let trimmed = name.trim();
-        
+
         // 检查长度
         let char_count = trimmed.chars().count();
         if char_count < 4 {
             return Err(LobbyError::InvalidInput(
-                "大厅名称至少需要 4 个字符".to_string()
+                "大厅名称至少需要 4 个字符".to_string(),
             ));
         }
         if char_count > 32 {
             return Err(LobbyError::InvalidInput(
-                "大厅名称最多 32 个字符".to_string()
+                "大厅名称最多 32 个字符".to_string(),
             ));
         }
 
@@ -261,18 +257,18 @@ impl LobbyManager {
         let has_alphanumeric = trimmed.chars().any(|c| c.is_alphanumeric());
         if !has_alphanumeric {
             return Err(LobbyError::InvalidInput(
-                "大厅名称必须包含至少一个字母或数字".to_string()
+                "大厅名称必须包含至少一个字母或数字".to_string(),
             ));
         }
 
         // 检查字符是否合法（中文、字母、数字、下划线、连字符、空格）
-        let is_valid = trimmed.chars().all(|c| {
-            c.is_alphanumeric() || c == '_' || c == '-' || c == ' ' || c.is_whitespace()
-        });
-        
+        let is_valid = trimmed
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == ' ' || c.is_whitespace());
+
         if !is_valid {
             return Err(LobbyError::InvalidInput(
-                "大厅名称只能包含中文、字母、数字、下划线、连字符和空格".to_string()
+                "大厅名称只能包含中文、字母、数字、下划线、连字符和空格".to_string(),
             ));
         }
 
@@ -280,38 +276,36 @@ impl LobbyManager {
     }
 
     /// 验证密码
-    /// 
+    ///
     /// # 参数
     /// * `password` - 密码
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 验证通过
     /// * `Err(LobbyError)` - 验证失败
-    /// 
+    ///
     /// # 规则
     /// - 长度：8-32 个字符
     /// - 必须包含字母和数字
     /// - 不能仅包含空白字符
     pub fn validate_password(password: &str) -> Result<(), LobbyError> {
         let trimmed = password.trim();
-        
+
         // 检查长度
         if trimmed.len() < 8 {
             return Err(LobbyError::InvalidInput(
-                "密码至少需要 8 个字符".to_string()
+                "密码至少需要 8 个字符".to_string(),
             ));
         }
         if trimmed.len() > 32 {
-            return Err(LobbyError::InvalidInput(
-                "密码最多 32 个字符".to_string()
-            ));
+            return Err(LobbyError::InvalidInput("密码最多 32 个字符".to_string()));
         }
 
         // 检查是否包含字母
         let has_letter = trimmed.chars().any(|c| c.is_alphabetic());
         if !has_letter {
             return Err(LobbyError::InvalidInput(
-                "密码必须包含至少一个字母".to_string()
+                "密码必须包含至少一个字母".to_string(),
             ));
         }
 
@@ -319,7 +313,7 @@ impl LobbyManager {
         let has_digit = trimmed.chars().any(|c| c.is_numeric());
         if !has_digit {
             return Err(LobbyError::InvalidInput(
-                "密码必须包含至少一个数字".to_string()
+                "密码必须包含至少一个数字".to_string(),
             ));
         }
 
@@ -327,7 +321,7 @@ impl LobbyManager {
     }
 
     /// 创建大厅
-    /// 
+    ///
     /// # 参数
     /// * `name` - 大厅名称
     /// * `password` - 大厅密码
@@ -336,12 +330,12 @@ impl LobbyManager {
     /// * `signaling_server` - 信令服务器地址
     /// * `use_domain` - 是否使用域名访问
     /// * `network_service` - 网络服务引用（用于启动 EasyTier）
-    /// 
+    ///
     /// # 返回
     /// * `Ok(Lobby)` - 成功创建的大厅信息
     /// * `Err(LobbyError)` - 创建失败
     /// 创建大厅（带配置参数，避免死锁）
-    /// 
+    ///
     /// # 参数
     /// * `name` - 大厅名称
     /// * `password` - 大厅密码
@@ -354,7 +348,7 @@ impl LobbyManager {
     /// * `app_handle` - Tauri 应用句柄
     /// * `global_config` - 全局 EasyTier 高级配置
     /// * `lobby_config` - 大厅 EasyTier 高级配置
-    /// 
+    ///
     /// # 返回
     /// * `Ok(Lobby)` - 成功创建的大厅信息
     /// * `Err(LobbyError)` - 创建失败
@@ -383,7 +377,12 @@ impl LobbyManager {
         Self::validate_input(&player_name, "玩家名称")?;
         Self::validate_input(&server_node, "服务器节点")?;
 
-        log::info!("正在创建大厅: {}, 使用域名: {}, 虚拟域名: {:?}", name, use_domain, virtual_domain);
+        log::info!(
+            "正在创建大厅: {}, 使用域名: {}, 虚拟域名: {:?}",
+            name,
+            use_domain,
+            virtual_domain
+        );
 
         // 构建 EasyTier 网络凭证
         // 使用 "MCTier-" + 大厅名称作为网络号，实现大厅隔离
@@ -398,10 +397,10 @@ impl LobbyManager {
         // 启动 EasyTier 服务（统一启用魔法DNS），传递配置参数
         let virtual_ip = network_service
             .start_easytier_with_config(
-                network_name, 
-                network_key, 
-                normalized_server_node, 
-                player_name.clone(), 
+                network_name,
+                network_key,
+                normalized_server_node,
+                player_name.clone(),
                 app_handle,
                 Some(global_config),
                 Some(lobby_config),
@@ -425,7 +424,7 @@ impl LobbyManager {
         if use_domain {
             log::info!("启用域名访问，创建HostsManager...");
             let hosts_manager = HostsManager::new(&name);
-            
+
             // 添加当前玩家的域名映射
             if let Some(ref domain) = final_virtual_domain {
                 log::info!("添加当前玩家的域名映射: {} -> {}", domain, virtual_ip);
@@ -436,7 +435,7 @@ impl LobbyManager {
                     log::info!("✅ 当前玩家的域名映射已添加");
                 }
             }
-            
+
             // 保存HostsManager实例
             self.hosts_manager = Some(hosts_manager);
         }
@@ -447,9 +446,9 @@ impl LobbyManager {
         let creator_virtual_ip = "10.126.126.1".to_string();
         log::info!("约定的信令服务器地址: {}:8445", creator_virtual_ip);
         let lobby = Lobby::new(
-            name, 
-            Some(password), 
-            virtual_ip.clone(), 
+            name,
+            Some(password),
+            virtual_ip.clone(),
             creator_virtual_ip,
             final_virtual_domain,
             Some(use_domain),
@@ -469,7 +468,7 @@ impl LobbyManager {
     }
 
     /// 创建大厅
-    /// 
+    ///
     /// # 参数
     /// * `name` - 大厅名称
     /// * `password` - 大厅密码
@@ -480,7 +479,7 @@ impl LobbyManager {
     /// * `virtual_domain` - 虚拟域名
     /// * `network_service` - 网络服务引用（用于连接 EasyTier）
     /// * `app_handle` - Tauri 应用句柄
-    /// 
+    ///
     /// # 返回
     /// * `Ok(Lobby)` - 成功创建的大厅信息
     /// * `Err(LobbyError)` - 创建失败
@@ -507,7 +506,12 @@ impl LobbyManager {
         Self::validate_input(&player_name, "玩家名称")?;
         Self::validate_input(&server_node, "服务器节点")?;
 
-        log::info!("正在创建大厅: {}, 使用域名: {}, 虚拟域名: {:?}", name, use_domain, virtual_domain);
+        log::info!(
+            "正在创建大厅: {}, 使用域名: {}, 虚拟域名: {:?}",
+            name,
+            use_domain,
+            virtual_domain
+        );
 
         // 构建 EasyTier 网络凭证
         // 使用 "MCTier-" + 大厅名称作为网络号，实现大厅隔离
@@ -521,7 +525,13 @@ impl LobbyManager {
 
         // 启动 EasyTier 服务（统一启用魔法DNS）
         let virtual_ip = network_service
-            .start_easytier(network_name, network_key, normalized_server_node, player_name.clone(), app_handle)
+            .start_easytier(
+                network_name,
+                network_key,
+                normalized_server_node,
+                player_name.clone(),
+                app_handle,
+            )
             .await
             .map_err(|e| LobbyError::NetworkError(e.inner_message()))?;
 
@@ -541,7 +551,7 @@ impl LobbyManager {
         if use_domain {
             log::info!("启用域名访问，创建HostsManager...");
             let hosts_manager = HostsManager::new(&name);
-            
+
             // 添加当前玩家的域名映射
             if let Some(ref domain) = final_virtual_domain {
                 log::info!("添加当前玩家的域名映射: {} -> {}", domain, virtual_ip);
@@ -552,7 +562,7 @@ impl LobbyManager {
                     log::info!("✅ 当前玩家的域名映射已添加");
                 }
             }
-            
+
             // 保存HostsManager实例
             self.hosts_manager = Some(hosts_manager);
         }
@@ -563,9 +573,9 @@ impl LobbyManager {
         let creator_virtual_ip = "10.126.126.1".to_string();
         log::info!("约定的信令服务器地址: {}:8445", creator_virtual_ip);
         let lobby = Lobby::new(
-            name, 
-            Some(password), 
-            virtual_ip.clone(), 
+            name,
+            Some(password),
+            virtual_ip.clone(),
             creator_virtual_ip,
             final_virtual_domain,
             Some(use_domain),
@@ -585,7 +595,7 @@ impl LobbyManager {
     }
 
     /// 加入大厅
-    /// 
+    ///
     /// # 参数
     /// * `name` - 大厅名称
     /// * `password` - 大厅密码
@@ -594,12 +604,12 @@ impl LobbyManager {
     /// * `signaling_server` - 信令服务器地址
     /// * `use_domain` - 是否使用域名访问
     /// * `network_service` - 网络服务引用（用于连接 EasyTier）
-    /// 
+    ///
     /// # 返回
     /// * `Ok(Lobby)` - 成功加入的大厅信息
     /// * `Err(LobbyError)` - 加入失败
     /// 加入大厅（带配置参数，避免死锁）
-    /// 
+    ///
     /// # 参数
     /// * `name` - 大厅名称
     /// * `password` - 大厅密码
@@ -612,7 +622,7 @@ impl LobbyManager {
     /// * `app_handle` - Tauri 应用句柄
     /// * `global_config` - 全局 EasyTier 高级配置
     /// * `lobby_config` - 大厅 EasyTier 高级配置
-    /// 
+    ///
     /// # 返回
     /// * `Ok(Lobby)` - 成功加入的大厅信息
     /// * `Err(LobbyError)` - 加入失败
@@ -641,7 +651,12 @@ impl LobbyManager {
         Self::validate_input(&player_name, "玩家名称")?;
         Self::validate_input(&server_node, "服务器节点")?;
 
-        log::info!("正在加入大厅: {}, 使用域名: {}, 虚拟域名: {:?}", name, use_domain, virtual_domain);
+        log::info!(
+            "正在加入大厅: {}, 使用域名: {}, 虚拟域名: {:?}",
+            name,
+            use_domain,
+            virtual_domain
+        );
 
         // 构建 EasyTier 网络凭证
         let network_name = format!("MCTier-{}", name);
@@ -655,10 +670,10 @@ impl LobbyManager {
         // 启动 EasyTier 服务（统一启用魔法DNS），传递配置参数
         let virtual_ip = network_service
             .start_easytier_with_config(
-                network_name, 
-                network_key, 
-                normalized_server_node, 
-                player_name.clone(), 
+                network_name,
+                network_key,
+                normalized_server_node,
+                player_name.clone(),
                 app_handle,
                 Some(global_config),
                 Some(lobby_config),
@@ -682,7 +697,7 @@ impl LobbyManager {
         if use_domain {
             log::info!("启用域名访问，创建HostsManager...");
             let hosts_manager = HostsManager::new(&name);
-            
+
             // 添加当前玩家的域名映射
             if let Some(ref domain) = final_virtual_domain {
                 log::info!("添加当前玩家的域名映射: {} -> {}", domain, virtual_ip);
@@ -693,7 +708,7 @@ impl LobbyManager {
                     log::info!("✅ 当前玩家的域名映射已添加");
                 }
             }
-            
+
             // 保存HostsManager实例
             self.hosts_manager = Some(hosts_manager);
         }
@@ -702,9 +717,9 @@ impl LobbyManager {
         let creator_virtual_ip = "10.126.126.1".to_string();
         log::info!("约定的信令服务器地址: {}:8445", creator_virtual_ip);
         let lobby = Lobby::new(
-            name, 
-            Some(password), 
-            virtual_ip.clone(), 
+            name,
+            Some(password),
+            virtual_ip.clone(),
             creator_virtual_ip,
             final_virtual_domain,
             Some(use_domain),
@@ -724,7 +739,7 @@ impl LobbyManager {
     }
 
     /// 加入大厅
-    /// 
+    ///
     /// # 参数
     /// * `name` - 大厅名称
     /// * `password` - 大厅密码
@@ -733,7 +748,7 @@ impl LobbyManager {
     /// * `signaling_server` - 信令服务器地址
     /// * `use_domain` - 是否使用域名访问
     /// * `network_service` - 网络服务引用（用于连接 EasyTier）
-    /// 
+    ///
     /// # 返回
     /// * `Ok(Lobby)` - 成功加入的大厅信息
     /// * `Err(LobbyError)` - 加入失败
@@ -760,7 +775,12 @@ impl LobbyManager {
         Self::validate_input(&player_name, "玩家名称")?;
         Self::validate_input(&server_node, "服务器节点")?;
 
-        log::info!("正在加入大厅: {}, 使用域名: {}, 虚拟域名: {:?}", name, use_domain, virtual_domain);
+        log::info!(
+            "正在加入大厅: {}, 使用域名: {}, 虚拟域名: {:?}",
+            name,
+            use_domain,
+            virtual_domain
+        );
 
         // 构建 EasyTier 网络凭证
         // 使用 "MCTier-" + 大厅名称作为网络号，实现大厅隔离
@@ -774,7 +794,13 @@ impl LobbyManager {
 
         // 连接到 EasyTier 网络（统一启用魔法DNS）
         let virtual_ip = network_service
-            .start_easytier(network_name, network_key, normalized_server_node, player_name.clone(), app_handle)
+            .start_easytier(
+                network_name,
+                network_key,
+                normalized_server_node,
+                player_name.clone(),
+                app_handle,
+            )
             .await
             .map_err(|e| LobbyError::NetworkError(e.inner_message()))?;
 
@@ -796,7 +822,7 @@ impl LobbyManager {
         if use_domain {
             log::info!("启用域名访问，创建HostsManager...");
             let hosts_manager = HostsManager::new(&name);
-            
+
             // 添加当前玩家的域名映射
             if let Some(ref domain) = final_virtual_domain {
                 log::info!("添加当前玩家的域名映射: {} -> {}", domain, virtual_ip);
@@ -807,7 +833,7 @@ impl LobbyManager {
                     log::info!("✅ 当前玩家的域名映射已添加");
                 }
             }
-            
+
             // 保存HostsManager实例
             self.hosts_manager = Some(hosts_manager);
         }
@@ -816,14 +842,14 @@ impl LobbyManager {
         // 在 EasyTier DHCP 模式下，第一个加入网络的节点通常会获得 10.126.126.1
         // 如果第一个节点离开，需要有重新选举机制（TODO）
         let creator_virtual_ip = "10.126.126.1".to_string();
-        
+
         log::info!("将连接到信令服务器: {}:8445", creator_virtual_ip);
 
         // 创建大厅实例
         let lobby = Lobby::new(
-            name, 
-            Some(password), 
-            virtual_ip.clone(),  // clone一份，因为后面还要用
+            name,
+            Some(password),
+            virtual_ip.clone(), // clone一份，因为后面还要用
             creator_virtual_ip,
             final_virtual_domain,
             Some(use_domain),
@@ -843,10 +869,10 @@ impl LobbyManager {
     }
 
     /// 退出大厅
-    /// 
+    ///
     /// # 参数
     /// * `network_service` - 网络服务引用（用于断开 EasyTier）
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 成功退出
     /// * `Err(LobbyError)` - 退出失败
@@ -871,7 +897,7 @@ impl LobbyManager {
                 log::info!("✅ hosts记录已清理");
             }
         }
-        
+
         // 释放HostsManager实例
         self.hosts_manager = None;
 
@@ -891,10 +917,10 @@ impl LobbyManager {
     }
 
     /// 添加玩家
-    /// 
+    ///
     /// # 参数
     /// * `player` - 要添加的玩家
-    /// 
+    ///
     /// # 说明
     /// 此方法用于添加其他玩家到玩家列表（通过网络同步）
     pub fn add_player(&mut self, player: Player) {
@@ -903,10 +929,10 @@ impl LobbyManager {
     }
 
     /// 移除玩家
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 要移除的玩家 ID
-    /// 
+    ///
     /// # 返回
     /// * `Some(Player)` - 被移除的玩家信息
     /// * `None` - 玩家不存在
@@ -916,20 +942,20 @@ impl LobbyManager {
     }
 
     /// 获取玩家列表
-    /// 
+    ///
     /// # 返回
     /// 所有玩家的列表（按加入时间排序）
     pub fn get_players(&self) -> Vec<Player> {
         let mut players: Vec<Player> = self.players.values().cloned().collect();
-        
+
         // 按加入时间排序
         players.sort_by(|a, b| a.joined_at.cmp(&b.joined_at));
-        
+
         players
     }
 
     /// 获取玩家数量
-    /// 
+    ///
     /// # 返回
     /// 当前大厅中的玩家数量
     pub fn get_player_count(&self) -> usize {
@@ -937,10 +963,10 @@ impl LobbyManager {
     }
 
     /// 根据 ID 获取玩家
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 玩家 ID
-    /// 
+    ///
     /// # 返回
     /// * `Some(&Player)` - 玩家信息引用
     /// * `None` - 玩家不存在
@@ -949,10 +975,10 @@ impl LobbyManager {
     }
 
     /// 根据 ID 获取玩家（可变引用）
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 玩家 ID
-    /// 
+    ///
     /// # 返回
     /// * `Some(&mut Player)` - 玩家信息可变引用
     /// * `None` - 玩家不存在
@@ -961,11 +987,11 @@ impl LobbyManager {
     }
 
     /// 更新玩家麦克风状态
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 玩家 ID
     /// * `mic_enabled` - 麦克风是否开启
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 更新成功
     /// * `Err(LobbyError)` - 玩家不存在
@@ -980,21 +1006,17 @@ impl LobbyManager {
 
         player.mic_enabled = mic_enabled;
 
-        log::debug!(
-            "更新玩家 {} 麦克风状态: {}",
-            player_id,
-            mic_enabled
-        );
+        log::debug!("更新玩家 {} 麦克风状态: {}", player_id, mic_enabled);
 
         Ok(())
     }
 
     /// 更新玩家静音状态
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 玩家 ID
     /// * `is_muted` - 是否被静音
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 更新成功
     /// * `Err(LobbyError)` - 玩家不存在
@@ -1009,17 +1031,13 @@ impl LobbyManager {
 
         player.is_muted = is_muted;
 
-        log::debug!(
-            "更新玩家 {} 静音状态: {}",
-            player_id,
-            is_muted
-        );
+        log::debug!("更新玩家 {} 静音状态: {}", player_id, is_muted);
 
         Ok(())
     }
 
     /// 获取当前大厅信息
-    /// 
+    ///
     /// # 返回
     /// * `Some(&Lobby)` - 当前大厅信息引用
     /// * `None` - 未加入大厅
@@ -1028,7 +1046,7 @@ impl LobbyManager {
     }
 
     /// 检查是否在大厅中
-    /// 
+    ///
     /// # 返回
     /// * `true` - 在大厅中
     /// * `false` - 不在大厅中
@@ -1037,25 +1055,25 @@ impl LobbyManager {
     }
 
     /// 清空所有玩家（保留当前大厅）
-    /// 
+    ///
     /// # 说明
     /// 此方法用于重新同步玩家列表
     pub fn clear_players(&mut self) {
         log::info!("清空玩家列表");
         self.players.clear();
     }
-    
+
     /// 获取HostsManager引用
-    /// 
+    ///
     /// # 返回
     /// * `Some(&HostsManager)` - HostsManager引用
     /// * `None` - HostsManager不存在
     pub fn get_hosts_manager(&self) -> Option<&HostsManager> {
         self.hosts_manager.as_ref()
     }
-    
+
     /// 设置HostsManager
-    /// 
+    ///
     /// # 参数
     /// * `hosts_manager` - HostsManager实例
     pub fn set_hosts_manager(&mut self, hosts_manager: Option<HostsManager>) {
@@ -1069,15 +1087,22 @@ impl Default for LobbyManager {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_lobby_creation() {
-        let lobby = Lobby::new("测试大厅".to_string(), Some("test1234".to_string()), "10.144.144.1".to_string(), "10.144.144.1".to_string(), Some("testplayer.mct.net".to_string()), Some(true), Some("wss://mctier.pmhs.top/signaling".to_string()));
-        
+        let lobby = Lobby::new(
+            "测试大厅".to_string(),
+            Some("test1234".to_string()),
+            "10.144.144.1".to_string(),
+            "10.144.144.1".to_string(),
+            Some("testplayer.mct.net".to_string()),
+            Some(true),
+            Some("wss://mctier.pmhs.top/signaling".to_string()),
+        );
+
         assert_eq!(lobby.name, "测试大厅");
         assert_eq!(lobby.password, Some("test1234".to_string()));
         assert_eq!(lobby.virtual_ip, "10.144.144.1");
@@ -1088,7 +1113,7 @@ mod tests {
     #[test]
     fn test_player_creation() {
         let player = Player::new("测试玩家".to_string(), "10.126.126.1".to_string());
-        
+
         assert_eq!(player.name, "测试玩家");
         assert!(!player.mic_enabled);
         assert!(!player.is_muted);
@@ -1099,7 +1124,7 @@ mod tests {
     fn test_validate_input_empty_string() {
         let result = LobbyManager::validate_input("", "测试字段");
         assert!(result.is_err());
-        
+
         if let Err(LobbyError::InvalidInput(msg)) = result {
             assert!(msg.contains("测试字段"));
             assert!(msg.contains("不能为空"));
@@ -1120,11 +1145,7 @@ mod tests {
 
         for input in test_cases {
             let result = LobbyManager::validate_input(input, "测试字段");
-            assert!(
-                result.is_err(),
-                "应该拒绝空白字符串: {:?}",
-                input
-            );
+            assert!(result.is_err(), "应该拒绝空白字符串: {:?}", input);
         }
     }
 
@@ -1139,18 +1160,14 @@ mod tests {
 
         for input in test_cases {
             let result = LobbyManager::validate_input(input, "测试字段");
-            assert!(
-                result.is_ok(),
-                "应该接受有效输入: {:?}",
-                input
-            );
+            assert!(result.is_ok(), "应该接受有效输入: {:?}", input);
         }
     }
 
     #[test]
     fn test_lobby_manager_creation() {
         let manager = LobbyManager::new();
-        
+
         assert!(!manager.is_in_lobby());
         assert_eq!(manager.get_player_count(), 0);
         assert!(manager.get_current_lobby().is_none());
@@ -1159,28 +1176,28 @@ mod tests {
     #[test]
     fn test_add_and_remove_player() {
         let mut manager = LobbyManager::new();
-        
+
         let player1 = Player::new("玩家1".to_string(), "10.126.126.1".to_string());
         let player2 = Player::new("玩家2".to_string(), "10.126.126.2".to_string());
-        
+
         let player1_id = player1.id.clone();
         let player2_id = player2.id.clone();
-        
+
         // 添加玩家
         manager.add_player(player1);
         manager.add_player(player2);
-        
+
         assert_eq!(manager.get_player_count(), 2);
-        
+
         // 获取玩家
         assert!(manager.get_player(&player1_id).is_some());
         assert!(manager.get_player(&player2_id).is_some());
-        
+
         // 移除玩家
         let removed = manager.remove_player(&player1_id);
         assert!(removed.is_some());
         assert_eq!(removed.unwrap().id, player1_id);
-        
+
         assert_eq!(manager.get_player_count(), 1);
         assert!(manager.get_player(&player1_id).is_none());
         assert!(manager.get_player(&player2_id).is_some());
@@ -1189,20 +1206,20 @@ mod tests {
     #[test]
     fn test_get_players_sorted() {
         let mut manager = LobbyManager::new();
-        
+
         // 添加多个玩家（会按加入时间排序）
         let player1 = Player::new("玩家1".to_string(), "10.126.126.1".to_string());
         std::thread::sleep(std::time::Duration::from_millis(10));
         let player2 = Player::new("玩家2".to_string(), "10.126.126.2".to_string());
         std::thread::sleep(std::time::Duration::from_millis(10));
         let player3 = Player::new("玩家3".to_string(), "10.126.126.3".to_string());
-        
+
         manager.add_player(player1.clone());
         manager.add_player(player2.clone());
         manager.add_player(player3.clone());
-        
+
         let players = manager.get_players();
-        
+
         assert_eq!(players.len(), 3);
         // 验证按加入时间排序
         assert_eq!(players[0].id, player1.id);
@@ -1213,20 +1230,20 @@ mod tests {
     #[test]
     fn test_update_player_mic_status() {
         let mut manager = LobbyManager::new();
-        
+
         let player = Player::new("测试玩家".to_string(), "10.126.126.1".to_string());
         let player_id = player.id.clone();
-        
+
         manager.add_player(player);
-        
+
         // 初始状态应该是关闭
         assert!(!manager.get_player(&player_id).unwrap().mic_enabled);
-        
+
         // 更新为开启
         let result = manager.update_player_mic_status(&player_id, true);
         assert!(result.is_ok());
         assert!(manager.get_player(&player_id).unwrap().mic_enabled);
-        
+
         // 更新为关闭
         let result = manager.update_player_mic_status(&player_id, false);
         assert!(result.is_ok());
@@ -1236,20 +1253,20 @@ mod tests {
     #[test]
     fn test_update_player_mute_status() {
         let mut manager = LobbyManager::new();
-        
+
         let player = Player::new("测试玩家".to_string(), "10.126.126.1".to_string());
         let player_id = player.id.clone();
-        
+
         manager.add_player(player);
-        
+
         // 初始状态应该是未静音
         assert!(!manager.get_player(&player_id).unwrap().is_muted);
-        
+
         // 更新为静音
         let result = manager.update_player_mute_status(&player_id, true);
         assert!(result.is_ok());
         assert!(manager.get_player(&player_id).unwrap().is_muted);
-        
+
         // 更新为取消静音
         let result = manager.update_player_mute_status(&player_id, false);
         assert!(result.is_ok());
@@ -1259,10 +1276,10 @@ mod tests {
     #[test]
     fn test_update_nonexistent_player() {
         let mut manager = LobbyManager::new();
-        
+
         let result = manager.update_player_mic_status("nonexistent_id", true);
         assert!(result.is_err());
-        
+
         if let Err(LobbyError::PlayerNotFound(id)) = result {
             assert_eq!(id, "nonexistent_id");
         } else {
@@ -1273,14 +1290,14 @@ mod tests {
     #[test]
     fn test_clear_players() {
         let mut manager = LobbyManager::new();
-        
+
         manager.add_player(Player::new("玩家1".to_string(), "10.126.126.1".to_string()));
         manager.add_player(Player::new("玩家2".to_string(), "10.126.126.2".to_string()));
-        
+
         assert_eq!(manager.get_player_count(), 2);
-        
+
         manager.clear_players();
-        
+
         assert_eq!(manager.get_player_count(), 0);
     }
 
@@ -1288,7 +1305,7 @@ mod tests {
     fn test_lobby_error_conversion() {
         let error = LobbyError::InvalidInput("测试错误".to_string());
         let app_error: AppError = error.into();
-        
+
         match app_error {
             AppError::ValidationError(msg) => {
                 assert_eq!(msg, "测试错误");
@@ -1299,14 +1316,22 @@ mod tests {
 
     #[test]
     fn test_lobby_serialization() {
-        let lobby = Lobby::new("测试大厅".to_string(), Some("test1234".to_string()), "10.144.144.1".to_string(), "10.144.144.1".to_string(), Some("testplayer.mct.net".to_string()), Some(true), Some("wss://mctier.pmhs.top/signaling".to_string()));
-        
+        let lobby = Lobby::new(
+            "测试大厅".to_string(),
+            Some("test1234".to_string()),
+            "10.144.144.1".to_string(),
+            "10.144.144.1".to_string(),
+            Some("testplayer.mct.net".to_string()),
+            Some(true),
+            Some("wss://mctier.pmhs.top/signaling".to_string()),
+        );
+
         // 序列化
         let json = serde_json::to_string(&lobby).unwrap();
-        
+
         // 反序列化
         let deserialized: Lobby = serde_json::from_str(&json).unwrap();
-        
+
         // 验证往返一致性
         assert_eq!(lobby.id, deserialized.id);
         assert_eq!(lobby.name, deserialized.name);
@@ -1318,13 +1343,13 @@ mod tests {
     #[test]
     fn test_player_serialization() {
         let player = Player::new("测试玩家".to_string(), "10.126.126.1".to_string());
-        
+
         // 序列化
         let json = serde_json::to_string(&player).unwrap();
-        
+
         // 反序列化
         let deserialized: Player = serde_json::from_str(&json).unwrap();
-        
+
         // 验证往返一致性
         assert_eq!(player.id, deserialized.id);
         assert_eq!(player.name, deserialized.name);
@@ -1481,33 +1506,54 @@ mod tests {
 
     #[test]
     fn test_lobby_struct_fields() {
-        let lobby = Lobby::new("测试大厅".to_string(), Some("test1234".to_string()), "10.144.144.1".to_string(), "10.144.144.1".to_string(), Some("testplayer.mct.net".to_string()), Some(true), Some("wss://mctier.pmhs.top/signaling".to_string()));
-        
+        let lobby = Lobby::new(
+            "测试大厅".to_string(),
+            Some("test1234".to_string()),
+            "10.144.144.1".to_string(),
+            "10.144.144.1".to_string(),
+            Some("testplayer.mct.net".to_string()),
+            Some(true),
+            Some("wss://mctier.pmhs.top/signaling".to_string()),
+        );
+
         // 验证所有字段都已正确设置
         assert!(!lobby.id.is_empty(), "大厅 ID 不应为空");
         assert_eq!(lobby.name, "测试大厅", "大厅名称应该匹配");
-        assert_eq!(lobby.password, Some("test1234".to_string()), "大厅密码应该匹配");
+        assert_eq!(
+            lobby.password,
+            Some("test1234".to_string()),
+            "大厅密码应该匹配"
+        );
         assert_eq!(lobby.virtual_ip, "10.144.144.1", "虚拟 IP 应该匹配");
-        assert_eq!(lobby.creator_virtual_ip, "10.144.144.1", "创建者虚拟 IP 应该匹配");
-        assert!(lobby.created_at <= chrono::Utc::now(), "创建时间应该在当前时间之前或等于");
+        assert_eq!(
+            lobby.creator_virtual_ip, "10.144.144.1",
+            "创建者虚拟 IP 应该匹配"
+        );
+        assert!(
+            lobby.created_at <= chrono::Utc::now(),
+            "创建时间应该在当前时间之前或等于"
+        );
     }
 
     #[test]
     fn test_player_struct_fields() {
         let player = Player::new("测试玩家".to_string(), "10.126.126.1".to_string());
-        
+
         // 验证所有字段都已正确设置
         assert!(!player.id.is_empty(), "玩家 ID 不应为空");
         assert_eq!(player.name, "测试玩家", "玩家名称应该匹配");
         assert!(!player.mic_enabled, "麦克风默认应该关闭");
         assert!(!player.is_muted, "默认不应该被静音");
-        assert!(player.joined_at <= chrono::Utc::now(), "加入时间应该在当前时间之前或等于");
+        assert!(
+            player.joined_at <= chrono::Utc::now(),
+            "加入时间应该在当前时间之前或等于"
+        );
     }
 
     #[test]
     fn test_lobby_manager_initial_state() {
         let manager = LobbyManager::new();
-        
+
         // 验证初始状态
         assert!(!manager.is_in_lobby(), "初始状态不应该在大厅中");
         assert_eq!(manager.get_player_count(), 0, "初始玩家数量应该为 0");
@@ -1518,18 +1564,18 @@ mod tests {
     #[test]
     fn test_multiple_players_management() {
         let mut manager = LobbyManager::new();
-        
+
         // 添加多个玩家
         for i in 1..=5 {
             let player = Player::new(format!("玩家{}", i), format!("10.126.126.{}", i));
             manager.add_player(player);
         }
-        
+
         assert_eq!(manager.get_player_count(), 5, "应该有 5 个玩家");
-        
+
         let players = manager.get_players();
         assert_eq!(players.len(), 5, "玩家列表长度应该为 5");
-        
+
         // 验证玩家名称
         for (i, player) in players.iter().enumerate() {
             assert_eq!(player.name, format!("玩家{}", i + 1));
@@ -1540,25 +1586,49 @@ mod tests {
     fn test_player_id_uniqueness() {
         let player1 = Player::new("玩家1".to_string(), "10.126.126.1".to_string());
         let player2 = Player::new("玩家2".to_string(), "10.126.126.2".to_string());
-        
+
         // 验证每个玩家都有唯一的 ID
         assert_ne!(player1.id, player2.id, "玩家 ID 应该是唯一的");
     }
 
     #[test]
     fn test_lobby_id_uniqueness() {
-        let lobby1 = Lobby::new("大厅1".to_string(), Some("test1234".to_string()), "10.144.144.1".to_string(), "10.144.144.1".to_string(), Some("player1.mct.net".to_string()), Some(true), Some("wss://mctier.pmhs.top/signaling".to_string()));
-        let lobby2 = Lobby::new("大厅2".to_string(), Some("test5678".to_string()), "10.144.144.2".to_string(), "10.144.144.2".to_string(), Some("player2.mct.net".to_string()), Some(true), Some("wss://mctier.pmhs.top/signaling".to_string()));
-        
+        let lobby1 = Lobby::new(
+            "大厅1".to_string(),
+            Some("test1234".to_string()),
+            "10.144.144.1".to_string(),
+            "10.144.144.1".to_string(),
+            Some("player1.mct.net".to_string()),
+            Some(true),
+            Some("wss://mctier.pmhs.top/signaling".to_string()),
+        );
+        let lobby2 = Lobby::new(
+            "大厅2".to_string(),
+            Some("test5678".to_string()),
+            "10.144.144.2".to_string(),
+            "10.144.144.2".to_string(),
+            Some("player2.mct.net".to_string()),
+            Some(true),
+            Some("wss://mctier.pmhs.top/signaling".to_string()),
+        );
+
         // 验证每个大厅都有唯一的 ID
         assert_ne!(lobby1.id, lobby2.id, "大厅 ID 应该是唯一的");
     }
 
     #[test]
     fn test_lobby_equality() {
-        let lobby1 = Lobby::new("测试大厅".to_string(), Some("test1234".to_string()), "10.144.144.1".to_string(), "10.144.144.1".to_string(), Some("testplayer.mct.net".to_string()), Some(true), Some("wss://mctier.pmhs.top/signaling".to_string()));
+        let lobby1 = Lobby::new(
+            "测试大厅".to_string(),
+            Some("test1234".to_string()),
+            "10.144.144.1".to_string(),
+            "10.144.144.1".to_string(),
+            Some("testplayer.mct.net".to_string()),
+            Some(true),
+            Some("wss://mctier.pmhs.top/signaling".to_string()),
+        );
         let lobby2 = lobby1.clone();
-        
+
         // 验证克隆的大厅相等
         assert_eq!(lobby1, lobby2, "克隆的大厅应该相等");
     }
@@ -1567,7 +1637,7 @@ mod tests {
     fn test_player_equality() {
         let player1 = Player::new("测试玩家".to_string(), "10.126.126.1".to_string());
         let player2 = player1.clone();
-        
+
         // 验证克隆的玩家相等
         assert_eq!(player1, player2, "克隆的玩家应该相等");
     }
@@ -1577,14 +1647,14 @@ mod tests {
         let mut manager = LobbyManager::new();
         let player = Player::new("测试玩家".to_string(), "10.126.126.1".to_string());
         let player_id = player.id.clone();
-        
+
         manager.add_player(player);
-        
+
         // 测试获取存在的玩家
         let retrieved = manager.get_player(&player_id);
         assert!(retrieved.is_some(), "应该能获取到玩家");
         assert_eq!(retrieved.unwrap().id, player_id, "玩家 ID 应该匹配");
-        
+
         // 测试获取不存在的玩家
         let not_found = manager.get_player("nonexistent_id");
         assert!(not_found.is_none(), "不存在的玩家应该返回 None");
@@ -1593,7 +1663,7 @@ mod tests {
     #[test]
     fn test_remove_nonexistent_player() {
         let mut manager = LobbyManager::new();
-        
+
         // 尝试移除不存在的玩家
         let result = manager.remove_player("nonexistent_id");
         assert!(result.is_none(), "移除不存在的玩家应该返回 None");
@@ -1604,20 +1674,20 @@ mod tests {
         let mut manager = LobbyManager::new();
         let player = Player::new("测试玩家".to_string(), "10.126.126.1".to_string());
         let player_id = player.id.clone();
-        
+
         manager.add_player(player);
-        
+
         // 测试麦克风状态更新
         assert!(manager.update_player_mic_status(&player_id, true).is_ok());
         assert!(manager.get_player(&player_id).unwrap().mic_enabled);
-        
+
         assert!(manager.update_player_mic_status(&player_id, false).is_ok());
         assert!(!manager.get_player(&player_id).unwrap().mic_enabled);
-        
+
         // 测试静音状态更新
         assert!(manager.update_player_mute_status(&player_id, true).is_ok());
         assert!(manager.get_player(&player_id).unwrap().is_muted);
-        
+
         assert!(manager.update_player_mute_status(&player_id, false).is_ok());
         assert!(!manager.get_player(&player_id).unwrap().is_muted);
     }
@@ -1625,16 +1695,16 @@ mod tests {
     #[test]
     fn test_clear_players_preserves_lobby() {
         let mut manager = LobbyManager::new();
-        
+
         // 添加玩家
         manager.add_player(Player::new("玩家1".to_string(), "10.126.126.1".to_string()));
         manager.add_player(Player::new("玩家2".to_string(), "10.126.126.2".to_string()));
-        
+
         assert_eq!(manager.get_player_count(), 2);
-        
+
         // 清空玩家
         manager.clear_players();
-        
+
         // 验证玩家已清空
         assert_eq!(manager.get_player_count(), 0);
         assert_eq!(manager.get_players().len(), 0);
@@ -1644,10 +1714,9 @@ mod tests {
     fn test_default_trait() {
         let manager1 = LobbyManager::new();
         let manager2 = LobbyManager::default();
-        
+
         // 验证两种创建方式的结果一致
         assert_eq!(manager1.is_in_lobby(), manager2.is_in_lobby());
         assert_eq!(manager1.get_player_count(), manager2.get_player_count());
     }
 }
-

--- a/src-tauri/src/modules/mc_lan_bridge.rs
+++ b/src-tauri/src/modules/mc_lan_bridge.rs
@@ -150,7 +150,10 @@ fn ensure_emit_thread() {
                         if !b.running {
                             Vec::new()
                         } else {
-                            b.proxies.values().map(|p| (p.proxy_port, p.motd.clone())).collect()
+                            b.proxies
+                                .values()
+                                .map(|p| (p.proxy_port, p.motd.clone()))
+                                .collect()
                         }
                     }
                     Err(_) => Vec::new(), // 锁中毒时本轮跳过，不 panic

--- a/src-tauri/src/modules/minecraft_discovery.rs
+++ b/src-tauri/src/modules/minecraft_discovery.rs
@@ -5,9 +5,9 @@
 // 并解析出 MOTD、版本、在线人数等信息，供前端展示"可加入的世界"。
 
 use serde::Serialize;
+use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use std::time::Duration;
 
 /// 发现的 Minecraft 服务器信息
 #[derive(Debug, Clone, Serialize)]
@@ -133,7 +133,10 @@ async fn query_server(ip: &str, port: u16) -> Option<DiscoveredServer> {
         stream.write_all(&status_req).await?;
         stream.flush().await
     };
-    if tokio::time::timeout(Duration::from_millis(1500), send).await.is_err() {
+    if tokio::time::timeout(Duration::from_millis(1500), send)
+        .await
+        .is_err()
+    {
         return None;
     }
 
@@ -207,14 +210,18 @@ pub async fn scan_minecraft_servers(
     port: Option<u16>,
 ) -> Vec<DiscoveredServer> {
     let port = port.unwrap_or(25565);
-    log::info!("🔍 扫描 Minecraft 局域网世界: {} 个IP, 端口 {}", peer_ips.len(), port);
+    log::info!(
+        "🔍 扫描 Minecraft 局域网世界: {} 个IP, 端口 {}",
+        peer_ips.len(),
+        port
+    );
 
     let mut tasks = Vec::new();
     for ip in peer_ips {
         let ip_clone = ip.clone();
-        tasks.push(tokio::spawn(async move {
-            query_server(&ip_clone, port).await
-        }));
+        tasks.push(tokio::spawn(
+            async move { query_server(&ip_clone, port).await },
+        ));
     }
 
     let mut results = Vec::new();
@@ -275,9 +282,17 @@ pub async fn measure_peers_latency(peer_ips: Vec<String>) -> Vec<PeerLatency> {
                     oks.push(rtt);
                 }
             }
-            let latency = if oks.is_empty() { None } else { Some(oks.iter().sum::<u64>() / oks.len() as u64) };
+            let latency = if oks.is_empty() {
+                None
+            } else {
+                Some(oks.iter().sum::<u64>() / oks.len() as u64)
+            };
             let loss = (((probes as usize - oks.len()) * 100) / probes as usize) as u8;
-            PeerLatency { ip: ip_clone, latency_ms: latency, loss_rate: loss }
+            PeerLatency {
+                ip: ip_clone,
+                latency_ms: latency,
+                loss_rate: loss,
+            }
         }));
     }
     let mut results = Vec::new();

--- a/src-tauri/src/modules/network_service.rs
+++ b/src-tauri/src/modules/network_service.rs
@@ -21,12 +21,14 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 #[cfg(windows)]
 fn is_elevated() -> bool {
     use windows::Win32::Foundation::HANDLE;
-    use windows::Win32::Security::{GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY};
+    use windows::Win32::Security::{
+        GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+    };
     use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
     unsafe {
         let mut token: HANDLE = HANDLE::default();
-        
+
         // 打开当前进程的访问令牌
         if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_err() {
             return false;
@@ -87,7 +89,7 @@ impl Default for NetworkConfig {
 }
 
 /// 网络服务
-/// 
+///
 /// 负责管理 EasyTier 子进程，提供虚拟网络连接功能
 pub struct NetworkService {
     /// EasyTier 子进程
@@ -112,10 +114,10 @@ pub struct NetworkService {
 
 impl NetworkService {
     /// 创建新的网络服务实例
-    /// 
+    ///
     /// # 参数
     /// * `config` - 网络配置
-    /// 
+    ///
     /// # 返回
     /// 新的网络服务实例
     pub fn new(config: NetworkConfig) -> Self {
@@ -136,17 +138,17 @@ impl NetworkService {
     pub fn new_with_defaults() -> Self {
         Self::new(NetworkConfig::default())
     }
-    
+
     /// 设置 Tauri 应用句柄
-    /// 
+    ///
     /// # 参数
     /// * `app_handle` - Tauri 应用句柄
     pub fn set_app_handle(&mut self, app_handle: tauri::AppHandle) {
         self.app_handle = Some(app_handle);
     }
-    
+
     /// 获取 EasyTier 可执行文件路径
-    /// 
+    ///
     /// # 返回
     /// * `Ok(PathBuf)` - EasyTier 可执行文件路径
     /// * `Err(AppError)` - 获取路径失败
@@ -160,7 +162,7 @@ impl NetworkService {
     }
 
     /// 应用 EasyTier 高级配置到命令行
-    /// 
+    ///
     /// # 参数
     /// * `cmd` - 命令对象
     /// * `config` - EasyTier 高级配置
@@ -169,27 +171,27 @@ impl NetworkService {
         config: &crate::modules::config_manager::EasyTierAdvancedConfig,
     ) {
         log::info!("应用 EasyTier 高级配置");
-        
+
         // ========== 网络模式 ==========
         if config.no_tun {
             cmd.arg("--no-tun");
             log::info!("  ✅ 启用无 TUN 模式");
         }
-        
+
         if config.dhcp {
             cmd.arg("--dhcp").arg("true");
             log::info!("  ✅ 启用 DHCP");
         } else {
             cmd.arg("--dhcp").arg("false");
         }
-        
+
         if let Some(ref ipv4) = config.ipv4 {
             if !ipv4.is_empty() {
                 cmd.arg("--ipv4").arg(ipv4);
                 log::info!("  ✅ 手动指定 IPv4: {}", ipv4);
             }
         }
-        
+
         // ========== 代理和转发 ==========
         if config.enable_socks5 {
             if let Some(port) = config.socks5_port {
@@ -197,38 +199,38 @@ impl NetworkService {
                 log::info!("  ✅ 启用 SOCKS5 代理，端口: {}", port);
             }
         }
-        
+
         for rule in &config.port_forward_rules {
             let forward_rule = format!("{}://{}/{}", rule.protocol, rule.bind_addr, rule.dst_addr);
             cmd.arg("--port-forward").arg(&forward_rule);
             log::info!("  ✅ 添加端口转发规则: {}", forward_rule);
         }
-        
+
         if config.proxy_forward_by_system {
             cmd.arg("--proxy-forward-by-system");
             log::info!("  ✅ 启用系统转发");
         }
-        
+
         for network in &config.proxy_networks {
             if !network.trim().is_empty() {
                 cmd.arg("--proxy-networks").arg(network.trim());
                 log::info!("  ✅ 添加代理网络: {}", network.trim());
             }
         }
-        
+
         // ========== 出口节点 ==========
         if config.enable_as_exit_node {
             cmd.arg("--enable-exit-node");
             log::info!("  ✅ 启用作为出口节点");
         }
-        
+
         for node in &config.exit_nodes {
             if !node.trim().is_empty() {
                 cmd.arg("--exit-nodes").arg(node.trim());
                 log::info!("  ✅ 使用出口节点: {}", node.trim());
             }
         }
-        
+
         // ========== 性能优化 ==========
         if config.multi_thread {
             cmd.arg("--multi-thread").arg("true");
@@ -241,100 +243,100 @@ impl NetworkService {
                 log::info!("  ✅ 启用多线程（默认2线程）");
             }
         }
-        
+
         if config.latency_first {
             cmd.arg("--latency-first").arg("true");
             log::info!("  ✅ 启用延迟优先模式");
         }
-        
+
         if config.use_smoltcp {
             cmd.arg("--use-smoltcp");
             log::info!("  ✅ 启用 smoltcp");
         }
-        
+
         // ========== 协议优化 ==========
         if config.enable_kcp_proxy {
             cmd.arg("--enable-kcp-proxy");
             log::info!("  ✅ 启用 KCP 代理");
         }
-        
+
         if config.disable_kcp_input {
             cmd.arg("--disable-kcp-input");
             log::info!("  ✅ 禁用 KCP 输入");
         }
-        
+
         if config.enable_quic_proxy {
             cmd.arg("--enable-quic-proxy");
             log::info!("  ✅ 启用 QUIC 代理");
         }
-        
+
         if config.disable_quic_input {
             cmd.arg("--disable-quic-input");
             log::info!("  ✅ 禁用 QUIC 输入");
         }
-        
+
         if let Some(port) = config.quic_listen_port {
             cmd.arg("--quic-listen-port").arg(port.to_string());
             log::info!("  ✅ QUIC 监听端口: {}", port);
         }
-        
+
         // ========== 加密和安全 ==========
         if config.disable_encryption {
             cmd.arg("--disable-encryption");
             log::info!("  ✅ 禁用加密");
         }
-        
+
         if let Some(ref algo) = config.encryption_algorithm {
             if !algo.is_empty() {
                 cmd.arg("--encryption-algorithm").arg(algo);
                 log::info!("  ✅ 加密算法: {}", algo);
             }
         }
-        
+
         // ========== 网络设备 ==========
         if config.bind_device {
             cmd.arg("--bind-device").arg("true");
             log::info!("  ✅ 绑定到物理设备");
         }
-        
+
         if let Some(ref dev_name) = config.dev_name {
             if !dev_name.is_empty() {
                 cmd.arg("--dev-name").arg(dev_name);
                 log::info!("  ✅ TUN 设备名称: {}", dev_name);
             }
         }
-        
+
         if let Some(mtu) = config.mtu {
             cmd.arg("--mtu").arg(mtu.to_string());
             log::info!("  ✅ MTU: {}", mtu);
         }
-        
+
         // ========== P2P 配置 ==========
         if config.p2p_only {
             cmd.arg("--p2p-only");
             log::info!("  ✅ 仅使用 P2P");
         }
-        
+
         if config.disable_p2p {
             cmd.arg("--disable-p2p");
             log::info!("  ✅ 禁用 P2P");
         }
-        
+
         if config.disable_udp_hole_punching {
             cmd.arg("--disable-udp-hole-punching");
             log::info!("  ✅ 禁用 UDP 打洞");
         }
-        
+
         if config.disable_tcp_hole_punching {
             cmd.arg("--disable-tcp-hole-punching");
             log::info!("  ✅ 禁用 TCP 打洞");
         }
-        
+
         if config.disable_sym_hole_punching {
             cmd.arg("--disable-sym-hole-punching");
             log::info!("  ✅ 禁用对称 NAT 打洞");
         }
-        
+
         // ========== 中继配置 ==========
         for network in &config.relay_network_whitelist {
             if !network.trim().is_empty() {
@@ -342,27 +344,27 @@ impl NetworkService {
                 log::info!("  ✅ 中继网络白名单: {}", network.trim());
             }
         }
-        
+
         if config.relay_all_peer_rpc {
             cmd.arg("--relay-all-peer-rpc");
             log::info!("  ✅ 转发所有对等节点 RPC");
         }
-        
+
         if config.disable_relay_kcp {
             cmd.arg("--disable-relay-kcp");
             log::info!("  ✅ 禁用中继 KCP");
         }
-        
+
         if config.enable_relay_foreign_network_kcp {
             cmd.arg("--enable-relay-foreign-network-kcp");
             log::info!("  ✅ 启用中继外部网络 KCP");
         }
-        
+
         if let Some(limit) = config.foreign_relay_bps_limit {
             cmd.arg("--foreign-relay-bps-limit").arg(limit.to_string());
             log::info!("  ✅ 外部网络流量限制: {} BPS", limit);
         }
-        
+
         // ========== 路由配置 ==========
         for route in &config.manual_routes {
             if !route.trim().is_empty() {
@@ -370,7 +372,7 @@ impl NetworkService {
                 log::info!("  ✅ 手动路由: {}", route.trim());
             }
         }
-        
+
         // ========== 压缩 ==========
         if let Some(ref compression) = config.compression {
             if !compression.is_empty() {
@@ -378,7 +380,7 @@ impl NetworkService {
                 log::info!("  ✅ 压缩算法: {}", compression);
             }
         }
-        
+
         // ========== 监听器配置 ==========
         for listener in &config.listeners {
             if !listener.trim().is_empty() {
@@ -386,40 +388,40 @@ impl NetworkService {
                 log::info!("  ✅ 监听器: {}", listener.trim());
             }
         }
-        
+
         for mapped in &config.mapped_listeners {
             if !mapped.trim().is_empty() {
                 cmd.arg("--mapped-listeners").arg(mapped.trim());
                 log::info!("  ✅ 映射监听器: {}", mapped.trim());
             }
         }
-        
+
         if config.no_listener {
             cmd.arg("--no-listener");
             log::info!("  ✅ 不监听任何端口");
         }
-        
+
         if let Some(ref protocol) = config.default_protocol {
             if !protocol.is_empty() {
                 cmd.arg("--default-protocol").arg(protocol);
                 log::info!("  ✅ 默认协议: {}", protocol);
             }
         }
-        
+
         // ========== DNS 配置 ==========
         if config.accept_dns {
             // 当前 easytier-core 要求 --accept-dns 必须带布尔值
             cmd.arg("--accept-dns").arg("true");
             log::info!("  ✅ 启用魔法 DNS");
         }
-        
+
         if let Some(ref zone) = config.tld_dns_zone {
             if !zone.is_empty() {
                 cmd.arg("--tld-dns-zone").arg(zone);
                 log::info!("  ✅ 顶级域名区域: {}", zone);
             }
         }
-        
+
         // ========== 端口白名单 ==========
         for port in &config.tcp_whitelist {
             if !port.trim().is_empty() {
@@ -427,27 +429,27 @@ impl NetworkService {
                 log::info!("  ✅ TCP 端口白名单: {}", port.trim());
             }
         }
-        
+
         for port in &config.udp_whitelist {
             if !port.trim().is_empty() {
                 cmd.arg("--udp-whitelist").arg(port.trim());
                 log::info!("  ✅ UDP 端口白名单: {}", port.trim());
             }
         }
-        
+
         // ========== IPv6 ==========
         if config.disable_ipv6 {
             cmd.arg("--disable-ipv6");
             log::info!("  ✅ 禁用 IPv6");
         }
-        
+
         if let Some(ref ipv6) = config.ipv6 {
             if !ipv6.is_empty() {
                 cmd.arg("--ipv6").arg(ipv6);
                 log::info!("  ✅ IPv6 地址: {}", ipv6);
             }
         }
-        
+
         // ========== STUN 服务器 ==========
         for server in &config.stun_servers {
             if !server.trim().is_empty() {
@@ -455,32 +457,32 @@ impl NetworkService {
                 log::info!("  ✅ STUN 服务器: {}", server.trim());
             }
         }
-        
+
         for server in &config.stun_servers_v6 {
             if !server.trim().is_empty() {
                 cmd.arg("--stun-servers-v6").arg(server.trim());
                 log::info!("  ✅ IPv6 STUN 服务器: {}", server.trim());
             }
         }
-        
+
         // ========== 私有模式 ==========
         if config.private_mode {
             cmd.arg("--private-mode");
             log::info!("  ✅ 启用私有模式");
         }
-        
+
         log::info!("EasyTier 高级配置应用完成");
     }
 
     /// 启动 EasyTier 服务
-    /// 
+    ///
     /// # 参数
     /// * `network_name` - 网络名称（大厅名称）
     /// * `network_key` - 网络密钥（大厅密码）
     /// * `server_node` - 服务器节点地址
     /// * `player_name` - 玩家名称
     /// * `app_handle` - Tauri 应用句柄
-    /// 
+    ///
     /// # 返回
     /// * `Ok(String)` - 成功启动，返回虚拟 IP 地址
     /// * `Err(AppError)` - 启动失败
@@ -501,11 +503,12 @@ impl NetworkService {
             app_handle,
             None,
             None,
-        ).await
+        )
+        .await
     }
 
     /// 启动 EasyTier 服务（带配置参数，避免死锁）
-    /// 
+    ///
     /// # 参数
     /// * `network_name` - 网络名称（大厅名称）
     /// * `network_key` - 网络密钥（大厅密码）
@@ -514,7 +517,7 @@ impl NetworkService {
     /// * `app_handle` - Tauri 应用句柄
     /// * `global_config` - 全局 EasyTier 高级配置（可选，如果为 None 则从配置文件读取）
     /// * `lobby_config` - 大厅 EasyTier 高级配置（可选，如果为 None 则从配置文件读取）
-    /// 
+    ///
     /// # 返回
     /// * `Ok(String)` - 成功启动，返回虚拟 IP 地址
     /// * `Err(AppError)` - 启动失败
@@ -539,13 +542,11 @@ impl NetworkService {
             }
             log::info!("✅ 已确认管理员权限");
         }
-        
+
         // 检查是否已经在运行
         let is_running = *self.is_running.lock().await;
         if is_running {
-            return Err(AppError::NetworkError(
-                "EasyTier 服务已在运行".to_string(),
-            ));
+            return Err(AppError::NetworkError("EasyTier 服务已在运行".to_string()));
         }
 
         log::info!("========================================");
@@ -566,50 +567,68 @@ impl NetworkService {
 
         // 获取 EasyTier 可执行文件路径
         let easytier_path = self.get_easytier_path()?;
-        
+
         log::info!("使用 EasyTier 路径: {:?}", easytier_path);
 
         // 获取 EasyTier 所在目录作为工作目录
         let working_dir = easytier_path
             .parent()
             .ok_or_else(|| AppError::ProcessError("无法获取 EasyTier 所在目录".to_string()))?;
-        
+
         log::info!("设置工作目录: {:?}", working_dir);
 
         // 【优化】使用ResourceManager提取必需的DLL文件到easytier-core.exe所在目录
         // 这些DLL文件是easytier-core.exe运行所必需的
         log::info!("开始提取必需的DLL文件...");
-        
+
         // 提取Packet.dll
         let packet_dll_source = ResourceManager::get_packet_dll_path(app_handle)?;
         let packet_dll_target = working_dir.join("Packet.dll");
-        if !packet_dll_target.exists() || std::fs::metadata(&packet_dll_target).map(|m| m.len()).unwrap_or(0) 
-            != std::fs::metadata(&packet_dll_source).map(|m| m.len()).unwrap_or(1) {
+        if !packet_dll_target.exists()
+            || std::fs::metadata(&packet_dll_target)
+                .map(|m| m.len())
+                .unwrap_or(0)
+                != std::fs::metadata(&packet_dll_source)
+                    .map(|m| m.len())
+                    .unwrap_or(1)
+        {
             std::fs::copy(&packet_dll_source, &packet_dll_target)
                 .map_err(|e| AppError::ProcessError(format!("复制Packet.dll失败: {}", e)))?;
             log::info!("✅ 已复制 Packet.dll");
         }
-        
+
         // 提取wintun.dll
         let wintun_dll_source = ResourceManager::get_wintun_dll_path(app_handle)?;
         let wintun_dll_target = working_dir.join("wintun.dll");
-        if !wintun_dll_target.exists() || std::fs::metadata(&wintun_dll_target).map(|m| m.len()).unwrap_or(0) 
-            != std::fs::metadata(&wintun_dll_source).map(|m| m.len()).unwrap_or(1) {
+        if !wintun_dll_target.exists()
+            || std::fs::metadata(&wintun_dll_target)
+                .map(|m| m.len())
+                .unwrap_or(0)
+                != std::fs::metadata(&wintun_dll_source)
+                    .map(|m| m.len())
+                    .unwrap_or(1)
+        {
             std::fs::copy(&wintun_dll_source, &wintun_dll_target)
                 .map_err(|e| AppError::ProcessError(format!("复制wintun.dll失败: {}", e)))?;
             log::info!("✅ 已复制 wintun.dll");
         }
-        
+
         // 提取WinDivert64.sys
         let windivert_sys_source = ResourceManager::get_windivert_sys_path(app_handle)?;
         let windivert_sys_target = working_dir.join("WinDivert64.sys");
-        if !windivert_sys_target.exists() || std::fs::metadata(&windivert_sys_target).map(|m| m.len()).unwrap_or(0) 
-            != std::fs::metadata(&windivert_sys_source).map(|m| m.len()).unwrap_or(1) {
+        if !windivert_sys_target.exists()
+            || std::fs::metadata(&windivert_sys_target)
+                .map(|m| m.len())
+                .unwrap_or(0)
+                != std::fs::metadata(&windivert_sys_source)
+                    .map(|m| m.len())
+                    .unwrap_or(1)
+        {
             std::fs::copy(&windivert_sys_source, &windivert_sys_target)
                 .map_err(|e| AppError::ProcessError(format!("复制WinDivert64.sys失败: {}", e)))?;
             log::info!("✅ 已复制 WinDivert64.sys");
         }
-        
+
         log::info!("✅ 所有必需的DLL文件已准备就绪");
 
         // 生成唯一的实例名称（基于时间戳和随机数）
@@ -636,7 +655,11 @@ impl NetworkService {
                                 log::info!("已清理旧配置目录: {:?}", old_config_path);
                             }
                             Err(e) => {
-                                log::warn!("清理旧配置目录失败: {:?}, 错误: {}", old_config_path, e);
+                                log::warn!(
+                                    "清理旧配置目录失败: {:?}, 错误: {}",
+                                    old_config_path,
+                                    e
+                                );
                             }
                         }
                     }
@@ -647,16 +670,15 @@ impl NetworkService {
         // 创建独立的配置目录
         let config_dir = working_dir.join(format!("config_{}", instance_name));
         if !config_dir.exists() {
-            std::fs::create_dir_all(&config_dir).map_err(|e| {
-                AppError::ProcessError(format!("创建配置目录失败: {}", e))
-            })?;
+            std::fs::create_dir_all(&config_dir)
+                .map_err(|e| AppError::ProcessError(format!("创建配置目录失败: {}", e)))?;
         }
         log::info!("配置目录: {:?}", config_dir);
 
         // 查找可用的RPC端口（随机化起点，避免二次使用时端口粘连导致 os error 10013）
         let rpc_port = Self::find_available_rpc_port_randomized().await?;
         log::info!("✅ 将使用RPC端口: {}", rpc_port);
-        
+
         // 保存RPC端口
         *self.rpc_port.lock().await = Some(rpc_port);
 
@@ -666,15 +688,16 @@ impl NetworkService {
             .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
             .collect::<String>()
             .to_lowercase();
-        
+
         log::info!("使用主机名: {}", sanitized_hostname);
-        
+
         // 根据服务器节点协议自动选择监听器和默认协议
         let is_ws_peer = server_node.starts_with("ws://") || server_node.starts_with("wss://");
         // 【二次使用关键修复】不再使用端口 0（由系统自动分配），因为系统分配的
         // 临时端口可能落入 Windows(Hyper-V/Docker winnat) 保留端口段而触发 os error 10013。
         // 改为预先探测一个可用的显式端口给监听器使用，确保稳定。
-        let listener_port = Self::find_available_rpc_port_randomized().await
+        let listener_port = Self::find_available_rpc_port_randomized()
+            .await
             .unwrap_or(0); // 兜底：万一找不到则退回端口 0 让系统分配
         let listener = if is_ws_peer {
             format!("ws://0.0.0.0:{}/", listener_port)
@@ -685,38 +708,39 @@ impl NetworkService {
         let default_protocol = if is_ws_peer { "ws" } else { "udp" };
 
         // 读取高级功能配置
-        use tauri::Manager;
         use crate::modules::config_manager::EasyTierAdvancedConfig;
-        
+        use tauri::Manager;
+
         // 【关键修复】使用传入的配置参数，如果没有则从 ConfigManager 读取
-        let (global_config, lobby_config) = if global_config_param.is_some() || lobby_config_param.is_some() {
-            // 使用传入的配置参数
-            log::info!("使用传入的配置参数");
-            (
-                global_config_param.unwrap_or(None),
-                lobby_config_param.unwrap_or(None),
-            )
-        } else {
-            // 从 ConfigManager 读取配置
-            log::info!("从 ConfigManager 读取配置");
-            let state = app_handle.state::<crate::modules::tauri_commands::AppState>();
-            let core = state.core.lock().await;
-            let config_manager = core.get_config_manager();
-            let cfg_mgr = config_manager.lock().await;
-            let user_config = cfg_mgr.get_config();
-            
-            let global_cfg = user_config.global_easytier_advanced_config.clone();
-            let lobby_cfg = user_config.lobby_easytier_advanced_config.clone();
-            
-            drop(cfg_mgr);
-            drop(core);
-            
-            (global_cfg, lobby_cfg)
-        };
-        
+        let (global_config, lobby_config) =
+            if global_config_param.is_some() || lobby_config_param.is_some() {
+                // 使用传入的配置参数
+                log::info!("使用传入的配置参数");
+                (
+                    global_config_param.unwrap_or(None),
+                    lobby_config_param.unwrap_or(None),
+                )
+            } else {
+                // 从 ConfigManager 读取配置
+                log::info!("从 ConfigManager 读取配置");
+                let state = app_handle.state::<crate::modules::tauri_commands::AppState>();
+                let core = state.core.lock().await;
+                let config_manager = core.get_config_manager();
+                let cfg_mgr = config_manager.lock().await;
+                let user_config = cfg_mgr.get_config();
+
+                let global_cfg = user_config.global_easytier_advanced_config.clone();
+                let lobby_cfg = user_config.lobby_easytier_advanced_config.clone();
+
+                drop(cfg_mgr);
+                drop(core);
+
+                (global_cfg, lobby_cfg)
+            };
+
         log::info!("========================================");
         log::info!("📂 从 ConfigManager 读取配置");
-        
+
         if let Some(ref global_cfg) = global_config {
             log::info!("📋 发现全局配置:");
             log::info!("  - dev_name: {:?}", global_cfg.dev_name);
@@ -725,7 +749,7 @@ impl NetworkService {
         } else {
             log::warn!("⚠️ 未找到全局配置");
         }
-        
+
         if let Some(ref lobby_cfg) = lobby_config {
             log::info!("📋 发现大厅配置:");
             log::info!("  - use_global_config: {}", lobby_cfg.use_global_config);
@@ -735,7 +759,7 @@ impl NetworkService {
         } else {
             log::warn!("⚠️ 未找到大厅配置");
         }
-        
+
         // 合并配置：大厅配置优先，如果大厅配置设置了 use_global_config，则使用全局配置
         let final_config = if let Some(lobby_cfg) = lobby_config {
             log::info!("========================================");
@@ -744,7 +768,7 @@ impl NetworkService {
             log::info!("  - dev_name: {:?}", lobby_cfg.dev_name);
             log::info!("  - no_tun: {}", lobby_cfg.no_tun);
             log::info!("  - dhcp: {}", lobby_cfg.dhcp);
-            
+
             if lobby_cfg.use_global_config {
                 // 使用全局配置
                 log::info!("✅ 大厅配置设置了 use_global_config=true，将使用全局配置");
@@ -778,7 +802,7 @@ impl NetworkService {
                 EasyTierAdvancedConfig::default()
             }
         };
-        
+
         log::info!("========================================");
         log::info!("最终使用的高级配置:");
         log::info!("  - 使用全局配置标志: {}", final_config.use_global_config);
@@ -814,12 +838,13 @@ impl NetworkService {
             .arg(listener)
             .arg("--default-protocol")
             .arg(default_protocol);
-        
+
         // 应用高级配置
         Self::apply_advanced_config(&mut cmd, &final_config);
-        
+
         // 【重要】输出完整的 EasyTier 命令行，用于验证配置是否生效
-        let cmd_args: Vec<String> = cmd.as_std()
+        let cmd_args: Vec<String> = cmd
+            .as_std()
             .get_args()
             .map(|arg| arg.to_string_lossy().to_string())
             .collect();
@@ -840,15 +865,15 @@ impl NetworkService {
             }
         }
         log::info!("========================================");
-        
+
         cmd.current_dir(working_dir)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
-        
+
         // 设置环境变量，确保能找到 wintun.dll
         cmd.env("PATH", working_dir);
-        
+
         log::info!("使用 DHCP + TUN 模式，创建虚拟网卡以支持完整的网络功能");
         log::info!("虚拟IP由DHCP服务器自动分配");
         log::info!("虚拟网卡名称: MCTier_Net（固定名称，方便识别和管理）");
@@ -859,7 +884,10 @@ impl NetworkService {
         } else {
             log::info!("启用 UDP 监听器以支持 Minecraft 局域网发现功能");
         }
-        log::info!("使用动态检测的RPC端口 {}，避免与其他EasyTier实例冲突", rpc_port);
+        log::info!(
+            "使用动态检测的RPC端口 {}，避免与其他EasyTier实例冲突",
+            rpc_port
+        );
 
         // 在 Windows 上隐藏控制台窗口
         #[cfg(target_os = "windows")]
@@ -874,13 +902,15 @@ impl NetworkService {
         })?;
 
         // 获取标准输出和标准错误
-        let stdout = child.stdout.take().ok_or_else(|| {
-            AppError::ProcessError("无法获取 EasyTier 标准输出".to_string())
-        })?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| AppError::ProcessError("无法获取 EasyTier 标准输出".to_string()))?;
 
-        let stderr = child.stderr.take().ok_or_else(|| {
-            AppError::ProcessError("无法获取 EasyTier 标准错误".to_string())
-        })?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| AppError::ProcessError("无法获取 EasyTier 标准错误".to_string()))?;
 
         // 保存进程句柄和配置目录路径
         *self.easytier_process.lock().await = Some(child);
@@ -898,7 +928,14 @@ impl NetworkService {
         let stderr_buf_stdout = Arc::clone(&self.last_stderr);
 
         tokio::spawn(async move {
-            Self::monitor_stdout(stdout, virtual_ip_clone, status_clone, is_running_stdout, stderr_buf_stdout).await;
+            Self::monitor_stdout(
+                stdout,
+                virtual_ip_clone,
+                status_clone,
+                is_running_stdout,
+                stderr_buf_stdout,
+            )
+            .await;
         });
 
         let is_running_clone = Arc::clone(&self.is_running);
@@ -945,14 +982,14 @@ impl NetworkService {
                     "获取虚拟 IP 超时：请检查网络连接和 EasyTier 服务状态".to_string(),
                 ));
             }
-            
+
             // 每5秒输出一次等待日志
             if last_log_time.elapsed().as_secs() >= 5 {
                 let elapsed = start_time.elapsed().as_secs();
                 log::info!("⏳ 等待获取虚拟 IP... 已等待 {} 秒 / 60 秒", elapsed);
                 last_log_time = std::time::Instant::now();
             }
-            
+
             // 检查是否有错误状态
             let current_status = self.status.lock().await.clone();
             if let ConnectionStatus::Error(err_msg) = current_status {
@@ -968,7 +1005,7 @@ impl NetworkService {
                 *self.status.lock().await = ConnectionStatus::Connected(ip_addr.clone());
                 return Ok(ip_addr);
             }
-            
+
             // 【已废弃】不再使用 CLI 工具查询虚拟IP
             // easytier-cli已移除，完全依赖从标准输出解析虚拟IP
             // 如果超时仍未获取到IP，将在下面的超时检查中返回错误
@@ -983,8 +1020,7 @@ impl NetworkService {
                     return Err(AppError::NetworkError(err_msg));
                 }
                 // 否则根据最近的 stderr 输出生成可读的错误说明
-                let recent: Vec<String> =
-                    self.last_stderr.lock().await.iter().cloned().collect();
+                let recent: Vec<String> = self.last_stderr.lock().await.iter().cloned().collect();
                 let msg = Self::describe_exit_failure(None, &recent);
                 return Err(AppError::NetworkError(msg));
             }
@@ -995,10 +1031,10 @@ impl NetworkService {
     }
 
     /// 检测端口是否可用
-    /// 
+    ///
     /// # 参数
     /// * `port` - 要检测的端口号
-    /// 
+    ///
     /// # 返回
     /// * `true` - 端口可用
     /// * `false` - 端口被占用
@@ -1009,10 +1045,7 @@ impl NetworkService {
         // easytier 的 RPC portal 实际绑定在 0.0.0.0，若只测 127.0.0.1，
         // 当某端口被其他进程以独占方式占用 0.0.0.0 时，会误判为"可用"，
         // 随后交给 easytier 绑定就会触发 os error 10013（访问权限不允许）。
-        let addrs = [
-            format!("0.0.0.0:{}", port),
-            format!("127.0.0.1:{}", port),
-        ];
+        let addrs = [format!("0.0.0.0:{}", port), format!("127.0.0.1:{}", port)];
 
         for addr in &addrs {
             match TcpListener::bind(addr).await {
@@ -1030,19 +1063,19 @@ impl NetworkService {
         log::debug!("端口 {} 可用", port);
         true
     }
-    
+
     /// 查找可用的RPC端口
-    /// 
+    ///
     /// # 参数
     /// * `start_port` - 起始端口号
     /// * `max_attempts` - 最大尝试次数
-    /// 
+    ///
     /// # 返回
     /// * `Ok(u16)` - 可用的端口号
     /// * `Err(AppError)` - 未找到可用端口
     async fn find_available_rpc_port(start_port: u16, max_attempts: u16) -> Result<u16, AppError> {
         log::info!("开始查找可用的RPC端口，起始端口: {}", start_port);
-        
+
         for i in 0..max_attempts {
             let port = start_port + i;
             if Self::is_port_available(port).await {
@@ -1050,7 +1083,7 @@ impl NetworkService {
                 return Ok(port);
             }
         }
-        
+
         Err(AppError::NetworkError(format!(
             "未找到可用的RPC端口（尝试范围: {}-{}）",
             start_port,
@@ -1110,7 +1143,9 @@ impl NetworkService {
                 let stdout = String::from_utf8_lossy(&o.stdout);
                 // taskkill 在没有匹配进程时返回非 0，属正常情况，无需当作错误
                 if stdout.contains("SUCCESS") || stdout.contains("成功") {
-                    log::warn!("⚠️ [PreStart] 发现并清理了残留的 easytier-core.exe 进程，等待网卡释放...");
+                    log::warn!(
+                        "⚠️ [PreStart] 发现并清理了残留的 easytier-core.exe 进程，等待网卡释放..."
+                    );
                     // 给系统一点时间释放虚拟网卡和端口
                     sleep(Duration::from_millis(800)).await;
                 } else {
@@ -1142,17 +1177,19 @@ impl NetworkService {
         };
 
         // 先在最近日志里找"虚拟网卡创建失败"这类最关键的具体原因
-        if recent_stderr.iter().any(|l| {
-            l.contains("tun device error") || l.contains("Failed to create adapter")
-        }) {
+        if recent_stderr
+            .iter()
+            .any(|l| l.contains("tun device error") || l.contains("Failed to create adapter"))
+        {
             return "虚拟网卡创建失败：请右键以管理员身份运行 MCTier，并将本软件加入杀毒软件/防火墙白名单；若仍失败，请重启电脑后重试".to_string();
         }
 
         // 端口绑定被拒绝（os error 10013 / WSAEACCES）——常见于二次使用时上一个
         // 实例的端口尚未释放，或被防火墙/Hyper-V 保留端口段占用
-        if recent_stderr.iter().any(|l| {
-            l.contains("10013") || l.contains("os error 10013")
-        }) {
+        if recent_stderr
+            .iter()
+            .any(|l| l.contains("10013") || l.contains("os error 10013"))
+        {
             // 尝试从错误链里找出到底是哪个操作/端口绑定失败（含 bind/portal/listener 的行）
             let detail = recent_stderr
                 .iter()
@@ -1291,7 +1328,8 @@ impl NetworkService {
                 let message = if line.contains("DidNotSwitchProtocols(200)") {
                     "EasyTier WebSocket 反向代理配置错误：域名返回了普通 HTTP 页面。若由 Nginx 终止 TLS，请将 WSS 代理到 EasyTier 的 WS 端口 11011 并开启 WebSocket 升级；若直通 TLS，请使用 WSS 端口 11012".to_string()
                 } else if line.contains("DidNotSwitchProtocols(502)") {
-                    "EasyTier WebSocket 节点连接失败（HTTP 502）：请检查反向代理与 EasyTier WS 上游".to_string()
+                    "EasyTier WebSocket 节点连接失败（HTTP 502）：请检查反向代理与 EasyTier WS 上游"
+                        .to_string()
                 } else {
                     "EasyTier WebSocket 握手失败：请检查反向代理是否开启 WebSocket，并将上游指向 WS 端口 11011（TLS 直通则使用 WSS 端口 11012）".to_string()
                 };
@@ -1307,9 +1345,9 @@ impl NetworkService {
             // 解析虚拟 IP
             // 查找 DHCP 分配的 IP 或明确标记为虚拟IP的行
             let line_lower = line.to_lowercase();
-            
+
             // 检查是否包含虚拟IP相关的关键词
-            let _is_virtual_ip_line = line_lower.contains("virtual ip") 
+            let _is_virtual_ip_line = line_lower.contains("virtual ip")
                 || line_lower.contains("assigned ip")
                 || line_lower.contains("dhcp")
                 || line_lower.contains("got ip")
@@ -1317,14 +1355,14 @@ impl NetworkService {
                 || line_lower.contains("ip addr")
                 || line_lower.contains("my ipv4")
                 || (line_lower.contains("ipv4") && line_lower.contains("="));
-            
+
             // 排除包含 local_addr 和配置行的行
             let is_excluded = line.contains("local_addr") 
                 || line.contains("local:")
                 || line.contains("ipv4 = \"")  // 配置行
                 || line.contains("listeners")
                 || line.contains("rpc_portal =");
-            
+
             if !is_excluded {
                 if let Some(ip) = Self::extract_ip_from_line(&line) {
                     // 排除网络地址（最后一位是0）和广播地址（最后一位是255）
@@ -1337,7 +1375,11 @@ impl NetworkService {
                                 *virtual_ip.lock().await = Some(ip.clone());
                                 *status.lock().await = ConnectionStatus::Connected(ip);
                             } else {
-                                log::debug!("跳过无效的主机地址: {} (最后一位: {})", ip, last_octet);
+                                log::debug!(
+                                    "跳过无效的主机地址: {} (最后一位: {})",
+                                    ip,
+                                    last_octet
+                                );
                             }
                         }
                     }
@@ -1350,7 +1392,7 @@ impl NetworkService {
 
     /// 监控标准错误
     async fn monitor_stderr(
-        stderr: tokio::process::ChildStderr, 
+        stderr: tokio::process::ChildStderr,
         is_running: Arc<Mutex<bool>>,
         status: Arc<Mutex<ConnectionStatus>>,
         last_stderr: Arc<Mutex<std::collections::VecDeque<String>>>,
@@ -1373,7 +1415,7 @@ impl NetworkService {
             // 检查是否有致命错误
             if line.contains("error") || line.contains("Error") || line.contains("ERROR") {
                 log::error!("EasyTier 发生错误: {}", line);
-                
+
                 // 检查是否是 TUN 设备创建失败
                 if line.contains("tun device error") || line.contains("Failed to create adapter") {
                     log::error!("TUN 设备创建失败，可能是缺少 WinTun 驱动或权限不足");
@@ -1474,14 +1516,12 @@ impl NetworkService {
 
         None
     }
-    
+
     /// 检查是否为本地回环地址
-    /// 
+    ///
     /// 本地回环地址范围：127.0.0.0/8 (127.0.0.0 - 127.255.255.255)
     pub fn is_loopback(ip: &str) -> bool {
-        let parts: Vec<u8> = ip.split('.')
-            .filter_map(|p| p.parse::<u8>().ok())
-            .collect();
+        let parts: Vec<u8> = ip.split('.').filter_map(|p| p.parse::<u8>().ok()).collect();
 
         if parts.len() != 4 {
             return false;
@@ -1509,15 +1549,13 @@ impl NetworkService {
     }
 
     /// 检查是否为私有网络 IP
-    /// 
+    ///
     /// 私有网络 IP 范围：
     /// - 10.0.0.0/8 (10.0.0.0 - 10.255.255.255)
     /// - 172.16.0.0/12 (172.16.0.0 - 172.31.255.255)
     /// - 192.168.0.0/16 (192.168.0.0 - 192.168.255.255)
     pub fn is_private_ip(ip: &str) -> bool {
-        let parts: Vec<u8> = ip.split('.')
-            .filter_map(|p| p.parse::<u8>().ok())
-            .collect();
+        let parts: Vec<u8> = ip.split('.').filter_map(|p| p.parse::<u8>().ok()).collect();
 
         if parts.len() != 4 {
             return false;
@@ -1542,7 +1580,7 @@ impl NetworkService {
     }
 
     /// 停止 EasyTier 服务
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 成功停止
     /// * `Err(AppError)` - 停止失败
@@ -1556,7 +1594,7 @@ impl NetworkService {
 
         if let Some(mut child) = process_guard.take() {
             log::info!("🔄 [StopEasyTier] 正在优雅关闭 EasyTier 进程...");
-            
+
             // 尝试优雅地终止进程
             match child.kill().await {
                 Ok(_) => {
@@ -1571,7 +1609,10 @@ impl NetworkService {
             log::info!("⏳ [StopEasyTier] 等待进程自然退出（最多3秒）...");
             match tokio::time::timeout(Duration::from_secs(3), child.wait()).await {
                 Ok(Ok(status)) => {
-                    log::info!("✅ [StopEasyTier] EasyTier 进程已优雅退出，状态码: {:?}", status);
+                    log::info!(
+                        "✅ [StopEasyTier] EasyTier 进程已优雅退出，状态码: {:?}",
+                        status
+                    );
                     log::info!("💡 [StopEasyTier] 进程通过优雅关闭方式退出，未使用强制终止");
                     graceful_shutdown_success = true;
                 }
@@ -1597,7 +1638,7 @@ impl NetworkService {
             // 只有在优雅关闭失败时才使用强制终止
             log::warn!("⚠️ [StopEasyTier] 优雅关闭失败，现在尝试强制终止（taskkill /F）...");
             log::warn!("💡 [StopEasyTier] 这是最后的手段，仅在优雅关闭失败时使用");
-            
+
             #[cfg(target_os = "windows")]
             {
                 let _ = tokio::process::Command::new("taskkill")
@@ -1605,7 +1646,7 @@ impl NetworkService {
                     .creation_flags(CREATE_NO_WINDOW)
                     .output()
                     .await;
-                
+
                 log::info!("✅ [StopEasyTier] 已执行强制终止命令（taskkill /F）");
             }
         }
@@ -1625,15 +1666,15 @@ impl NetworkService {
             log::info!("========================================");
             log::info!("🧹 [StopEasyTier] 开始清理虚拟网卡...");
             log::info!("========================================");
-            
+
             // 等待一小段时间，确保进程已完全退出
             log::info!("⏳ [StopEasyTier] 等待进程完全退出（500ms）...");
             sleep(Duration::from_millis(500)).await;
             log::info!("✅ [StopEasyTier] 等待完成，开始清理网卡");
-            
+
             // 方法1: 使用 devcon 或 pnputil 强制删除 MCTier_Net 网卡
             log::info!("🔧 [StopEasyTier] 方法1: 使用pnputil强制删除MCTier_Net网卡...");
-            
+
             // 首先列出所有网络设备
             match tokio::process::Command::new("pnputil")
                 .args(&["/enum-devices", "/class", "Net"])
@@ -1644,43 +1685,47 @@ impl NetworkService {
                 Ok(output) => {
                     let output_str = String::from_utf8_lossy(&output.stdout);
                     log::info!("📋 [StopEasyTier] 网络设备列表:\n{}", output_str);
-                    
+
                     // 查找 MCTier_Net 或 WinTun 相关的设备实例ID
                     let mut device_ids_to_remove = Vec::new();
                     let mut current_instance_id = String::new();
                     let mut is_target_device = false;
-                    
+
                     for line in output_str.lines() {
                         // 检查实例ID行
                         if line.contains("Instance ID:") || line.contains("实例 ID:") {
-                            current_instance_id = line.split(':').nth(1)
+                            current_instance_id = line
+                                .split(':')
+                                .nth(1)
                                 .map(|s| s.trim().to_string())
                                 .unwrap_or_default();
                             is_target_device = false;
                         }
-                        
+
                         // 检查设备描述或友好名称（仅匹配 MCTier_ 开头的本应用网卡，
                         // 避免误伤 Tailscale / WireGuard 等其它基于 WinTun 的网卡）
-                        if line.contains("MCTier_") &&
-                           !current_instance_id.is_empty() {
+                        if line.contains("MCTier_") && !current_instance_id.is_empty() {
                             is_target_device = true;
                         }
-                        
+
                         // 如果找到目标设备，添加到删除列表
                         if is_target_device && !current_instance_id.is_empty() {
                             if !device_ids_to_remove.contains(&current_instance_id) {
-                                log::info!("🎯 [StopEasyTier] 发现需要删除的设备: {}", current_instance_id);
+                                log::info!(
+                                    "🎯 [StopEasyTier] 发现需要删除的设备: {}",
+                                    current_instance_id
+                                );
                                 device_ids_to_remove.push(current_instance_id.clone());
                             }
                             current_instance_id.clear();
                             is_target_device = false;
                         }
                     }
-                    
+
                     // 删除找到的所有目标设备
                     for device_id in &device_ids_to_remove {
                         log::info!("🗑️ [StopEasyTier] 正在删除设备: {}", device_id);
-                        
+
                         // 尝试删除设备
                         match tokio::process::Command::new("pnputil")
                             .args(&["/remove-device", device_id])
@@ -1691,7 +1736,7 @@ impl NetworkService {
                             Ok(remove_output) => {
                                 let remove_result = String::from_utf8_lossy(&remove_output.stdout);
                                 log::info!("📄 [StopEasyTier] 删除设备结果: {}", remove_result);
-                                
+
                                 if remove_output.status.success() {
                                     log::info!("✅ [StopEasyTier] 成功删除设备: {}", device_id);
                                 } else {
@@ -1702,21 +1747,24 @@ impl NetworkService {
                                 log::warn!("⚠️ [StopEasyTier] 执行删除命令失败: {}", e);
                             }
                         }
-                        
+
                         sleep(Duration::from_millis(200)).await;
                     }
-                    
+
                     if device_ids_to_remove.is_empty() {
                         log::info!("ℹ️ [StopEasyTier] 未发现需要删除的虚拟网卡设备");
                     } else {
-                        log::info!("✅ [StopEasyTier] pnputil清理完成，共删除 {} 个设备", device_ids_to_remove.len());
+                        log::info!(
+                            "✅ [StopEasyTier] pnputil清理完成，共删除 {} 个设备",
+                            device_ids_to_remove.len()
+                        );
                     }
                 }
                 Err(e) => {
                     log::warn!("⚠️ [StopEasyTier] 使用pnputil查询设备失败: {}", e);
                 }
             }
-            
+
             // 方法2: 使用netsh禁用和删除网卡
             log::info!("🔧 [StopEasyTier] 方法2: 使用netsh禁用和删除MCTier_Net网卡...");
             match tokio::process::Command::new("netsh")
@@ -1728,53 +1776,72 @@ impl NetworkService {
                 Ok(output) => {
                     let output_str = String::from_utf8_lossy(&output.stdout);
                     log::info!("📋 [StopEasyTier] 网卡列表:\n{}", output_str);
-                    
+
                     let mut disabled_count = 0;
-                    
+
                     // 仅查找 MCTier_ 开头的本应用网卡（避免误伤其它 WinTun VPN）
                     for line in output_str.lines() {
                         if line.contains("MCTier_") {
                             log::info!("🎯 [StopEasyTier] 发现虚拟网卡: {}", line);
-                            
+
                             // 尝试提取网卡名称（通常是最后一列）
                             let parts: Vec<&str> = line.split_whitespace().collect();
                             if parts.len() >= 3 {
                                 let interface_name = parts[parts.len() - 1];
-                                
-                                if !interface_name.is_empty() && 
-                                   interface_name != "Type" && 
-                                   interface_name != "Interface" &&
-                                   interface_name != "State" {
-                                    log::info!("🔧 [StopEasyTier] 尝试禁用网卡: {}", interface_name);
-                                    
+
+                                if !interface_name.is_empty()
+                                    && interface_name != "Type"
+                                    && interface_name != "Interface"
+                                    && interface_name != "State"
+                                {
+                                    log::info!(
+                                        "🔧 [StopEasyTier] 尝试禁用网卡: {}",
+                                        interface_name
+                                    );
+
                                     // 先禁用网卡
                                     match tokio::process::Command::new("netsh")
-                                        .args(&["interface", "set", "interface", interface_name, "admin=disable"])
+                                        .args(&[
+                                            "interface",
+                                            "set",
+                                            "interface",
+                                            interface_name,
+                                            "admin=disable",
+                                        ])
                                         .creation_flags(CREATE_NO_WINDOW)
                                         .output()
                                         .await
                                     {
                                         Ok(disable_output) => {
                                             if disable_output.status.success() {
-                                                log::info!("✅ [StopEasyTier] 成功禁用网卡: {}", interface_name);
+                                                log::info!(
+                                                    "✅ [StopEasyTier] 成功禁用网卡: {}",
+                                                    interface_name
+                                                );
                                                 disabled_count += 1;
                                             } else {
-                                                log::warn!("⚠️ [StopEasyTier] 禁用网卡失败: {}", interface_name);
+                                                log::warn!(
+                                                    "⚠️ [StopEasyTier] 禁用网卡失败: {}",
+                                                    interface_name
+                                                );
                                             }
                                         }
                                         Err(e) => {
                                             log::warn!("⚠️ [StopEasyTier] 执行禁用命令失败: {}", e);
                                         }
                                     }
-                                    
+
                                     sleep(Duration::from_millis(200)).await;
                                 }
                             }
                         }
                     }
-                    
+
                     if disabled_count > 0 {
-                        log::info!("✅ [StopEasyTier] netsh清理完成，共禁用 {} 个网卡", disabled_count);
+                        log::info!(
+                            "✅ [StopEasyTier] netsh清理完成，共禁用 {} 个网卡",
+                            disabled_count
+                        );
                     } else {
                         log::info!("ℹ️ [StopEasyTier] 未发现需要禁用的网卡");
                     }
@@ -1783,7 +1850,7 @@ impl NetworkService {
                     log::warn!("⚠️ [StopEasyTier] 查询网卡列表失败: {}", e);
                 }
             }
-            
+
             // 方法3: 使用 PowerShell 强制删除网卡
             log::info!("🔧 [StopEasyTier] 方法3: 使用PowerShell强制删除MCTier相关网卡...");
             let ps_script = r#"
@@ -1799,7 +1866,7 @@ impl NetworkService {
                     }
                 }
             "#;
-            
+
             match tokio::process::Command::new("powershell")
                 .args(&["-NoProfile", "-NonInteractive", "-Command", ps_script])
                 .creation_flags(CREATE_NO_WINDOW)
@@ -1809,7 +1876,7 @@ impl NetworkService {
                 Ok(ps_output) => {
                     let ps_result = String::from_utf8_lossy(&ps_output.stdout);
                     log::info!("📄 [StopEasyTier] PowerShell执行结果:\n{}", ps_result);
-                    
+
                     if !ps_result.is_empty() {
                         log::info!("✅ [StopEasyTier] PowerShell清理完成");
                     } else {
@@ -1820,11 +1887,11 @@ impl NetworkService {
                     log::warn!("⚠️ [StopEasyTier] 执行PowerShell脚本失败: {}", e);
                 }
             }
-            
+
             // 最终等待，确保所有清理操作完成
             log::info!("⏳ [StopEasyTier] 等待所有清理操作完成（500ms）...");
             sleep(Duration::from_millis(500)).await;
-            
+
             log::info!("========================================");
             log::info!("✅ [StopEasyTier] 虚拟网卡清理流程完成");
             log::info!("========================================");
@@ -1843,7 +1910,7 @@ impl NetworkService {
             log::info!("========================================");
             log::info!("🗑️ [StopEasyTier] 开始清理配置目录: {:?}", dir);
             log::info!("========================================");
-            
+
             // 增加重试次数和等待时间，提高清理成功率
             for attempt in 1..=5 {
                 match std::fs::remove_dir_all(&dir) {
@@ -1856,14 +1923,17 @@ impl NetworkService {
                             log::warn!("⚠️ [StopEasyTier] 清理配置目录失败（尝试 {}/5）: {}，等待后重试...", attempt, e);
                             sleep(Duration::from_millis(500)).await;
                         } else {
-                            log::warn!("⚠️ [StopEasyTier] 清理配置目录失败: {}，将在下次启动时自动清理", e);
+                            log::warn!(
+                                "⚠️ [StopEasyTier] 清理配置目录失败: {}，将在下次启动时自动清理",
+                                e
+                            );
                             // 最后一次尝试：标记目录以便下次启动时清理
                             // 配置目录名称格式为 config_mctier-xxx，下次启动时会自动清理
                         }
                     }
                 }
             }
-            
+
             log::info!("========================================");
             log::info!("✅ [StopEasyTier] 配置目录清理流程完成");
             log::info!("========================================");
@@ -1879,7 +1949,7 @@ impl NetworkService {
     }
 
     /// 检查连接状态
-    /// 
+    ///
     /// # 返回
     /// 当前连接状态
     pub async fn check_connection(&self) -> ConnectionStatus {
@@ -1887,7 +1957,7 @@ impl NetworkService {
     }
 
     /// 获取虚拟 IP 地址
-    /// 
+    ///
     /// # 返回
     /// * `Some(String)` - 虚拟 IP 地址
     /// * `None` - 未连接或未获取到 IP
@@ -1901,7 +1971,7 @@ impl NetworkService {
     }
 
     /// 检查服务是否正在运行
-    /// 
+    ///
     /// # 返回
     /// * `true` - 正在运行
     /// * `false` - 未运行
@@ -1910,14 +1980,14 @@ impl NetworkService {
     }
 
     /// 重启服务
-    /// 
+    ///
     /// # 参数
     /// * `network_name` - 网络名称
     /// * `network_key` - 网络密钥
     /// * `server_node` - 服务器节点地址
     /// * `player_name` - 玩家名称（用于设置hostname）
     /// * `app_handle` - Tauri应用句柄
-    /// 
+    ///
     /// # 返回
     /// * `Ok(String)` - 成功重启，返回虚拟 IP
     /// * `Err(AppError)` - 重启失败
@@ -1938,8 +2008,14 @@ impl NetworkService {
         sleep(Duration::from_secs(1)).await;
 
         // 重新启动服务
-        self.start_easytier(network_name, network_key, server_node, player_name, app_handle)
-            .await
+        self.start_easytier(
+            network_name,
+            network_key,
+            server_node,
+            player_name,
+            app_handle,
+        )
+        .await
     }
 }
 
@@ -2043,13 +2119,19 @@ mod tests {
             .iter()
             .position(|arg| arg == "--bind-device")
             .expect("bind-device argument should be present");
-        assert_eq!(args.get(bind_device_index + 1).map(String::as_str), Some("true"));
+        assert_eq!(
+            args.get(bind_device_index + 1).map(String::as_str),
+            Some("true")
+        );
 
         let dev_name_index = args
             .iter()
             .position(|arg| arg == "--dev-name")
             .expect("dev-name argument should be present");
-        assert_eq!(args.get(dev_name_index + 1).map(String::as_str), Some("MCTier_Net"));
+        assert_eq!(
+            args.get(dev_name_index + 1).map(String::as_str),
+            Some("MCTier_Net")
+        );
     }
 
     // ========== 创建大厅流程 - EasyTier 启动测试 ==========
@@ -2064,13 +2146,12 @@ mod tests {
             ("IP address is 10.0.0.1", Some("10.0.0.1")),
             ("Your IP: 192.168.0.1", Some("192.168.0.1")),
             ("Connected with IP 10.10.10.10", Some("10.10.10.10")),
-            
             // 无效的情况
             ("No IP here", None),
             ("Invalid IP: 999.999.999.999", None),
             ("Localhost: 127.0.0.1", None), // 本地回环应该被排除
-            ("Zero IP: 0.0.0.0", None), // 0.0.0.0 应该被排除
-            ("", None), // 空字符串
+            ("Zero IP: 0.0.0.0", None),     // 0.0.0.0 应该被排除
+            ("", None),                     // 空字符串
             ("Just some text", None),
         ];
 
@@ -2101,31 +2182,27 @@ mod tests {
         ];
 
         for ip in valid_ips {
-            assert!(
-                NetworkService::is_valid_ip(ip),
-                "应该接受有效的 IP: {}",
-                ip
-            );
+            assert!(NetworkService::is_valid_ip(ip), "应该接受有效的 IP: {}", ip);
         }
 
         // 无效的 IP 地址
         let invalid_ips = vec![
-            "256.1.1.1",      // 超出范围
-            "1.256.1.1",      // 超出范围
-            "1.1.256.1",      // 超出范围
-            "1.1.1.256",      // 超出范围
-            "1.1.1",          // 缺少段
-            "1.1",            // 缺少段
-            "1",              // 缺少段
-            "1.1.1.1.1",      // 多余段
+            "256.1.1.1",       // 超出范围
+            "1.256.1.1",       // 超出范围
+            "1.1.256.1",       // 超出范围
+            "1.1.1.256",       // 超出范围
+            "1.1.1",           // 缺少段
+            "1.1",             // 缺少段
+            "1",               // 缺少段
+            "1.1.1.1.1",       // 多余段
             "abc.def.ghi.jkl", // 非数字
-            "",               // 空字符串
-            "...",            // 只有点
-            "1..1.1",         // 连续的点
-            "1.1.1.",         // 末尾有点
-            ".1.1.1",         // 开头有点
-            "-1.1.1.1",       // 负数
-            "1.1.1.1a",       // 包含字母
+            "",                // 空字符串
+            "...",             // 只有点
+            "1..1.1",          // 连续的点
+            "1.1.1.",          // 末尾有点
+            ".1.1.1",          // 开头有点
+            "-1.1.1.1",        // 负数
+            "1.1.1.1a",        // 包含字母
         ];
 
         for ip in invalid_ips {
@@ -2150,7 +2227,7 @@ mod tests {
             // 测试序列化
             let json = serde_json::to_string(&status).unwrap();
             assert!(!json.is_empty(), "序列化结果不应为空");
-            
+
             // 测试反序列化
             let deserialized: ConnectionStatus = serde_json::from_str(&json).unwrap();
             assert_eq!(status, deserialized, "往返序列化应该保持一致");
@@ -2160,7 +2237,7 @@ mod tests {
     #[tokio::test]
     async fn test_network_service_initial_state() {
         let service = NetworkService::new_with_defaults();
-        
+
         // 验证初始状态
         assert!(!service.is_running().await, "初始状态不应该在运行");
         assert_eq!(
@@ -2178,14 +2255,17 @@ mod tests {
     #[tokio::test]
     async fn test_stop_easytier_when_not_running() {
         let service = NetworkService::new_with_defaults();
-        
+
         // 停止未运行的服务应该成功
         let result = service.stop_easytier().await;
         assert!(result.is_ok(), "停止未运行的服务应该成功");
-        
+
         // 验证状态仍然是断开
         assert!(!service.is_running().await);
-        assert_eq!(service.check_connection().await, ConnectionStatus::Disconnected);
+        assert_eq!(
+            service.check_connection().await,
+            ConnectionStatus::Disconnected
+        );
     }
 
     #[test]
@@ -2194,8 +2274,11 @@ mod tests {
             easytier_path: PathBuf::from("custom/path/easytier.exe"),
             config_dir: PathBuf::from("custom/config"),
         };
-        
-        assert_eq!(config.easytier_path, PathBuf::from("custom/path/easytier.exe"));
+
+        assert_eq!(
+            config.easytier_path,
+            PathBuf::from("custom/path/easytier.exe")
+        );
         assert_eq!(config.config_dir, PathBuf::from("custom/config"));
     }
 
@@ -2205,7 +2288,7 @@ mod tests {
             easytier_path: PathBuf::from("test/easytier.exe"),
             config_dir: PathBuf::from("test/config"),
         };
-        
+
         let _service = NetworkService::new(config);
         // 服务应该能够使用自定义配置创建
     }
@@ -2228,7 +2311,6 @@ mod tests {
             ("IP: 255.255.255.254", None),
             ("IP: 127.0.0.1", None),
             ("IP: 8.8.8.8", None),
-
             // 私有网段的边界值应当被接受
             ("IP: 10.0.0.1", Some("10.0.0.1")),
             ("IP: 172.16.0.1", Some("172.16.0.1")),
@@ -2237,25 +2319,21 @@ mod tests {
             // 172.15/172.32 不属于 172.16.0.0/12，必须落在私有网段之外
             ("IP: 172.15.0.1", None),
             ("IP: 172.32.0.1", None),
-
             // 特殊格式
             ("IP:10.144.144.1", Some("10.144.144.1")), // 没有空格
             ("IP: 10.144.144.1 ", Some("10.144.144.1")), // 末尾有空格
             (" IP: 10.144.144.1", Some("10.144.144.1")), // 开头有空格
-            
             // 包含其他文本
-            ("The virtual IP is 10.144.144.1 and ready", Some("10.144.144.1")),
+            (
+                "The virtual IP is 10.144.144.1 and ready",
+                Some("10.144.144.1"),
+            ),
             ("Network: 10.144.144.1/24", Some("10.144.144.1")),
         ];
 
         for (input, expected) in test_cases {
             let result = NetworkService::extract_ip_from_line(input);
-            assert_eq!(
-                result,
-                expected.map(|s| s.to_string()),
-                "输入: {}",
-                input
-            );
+            assert_eq!(result, expected.map(|s| s.to_string()), "输入: {}", input);
         }
     }
 
@@ -2264,10 +2342,10 @@ mod tests {
         let status1 = ConnectionStatus::Connected("10.144.144.1".to_string());
         let status2 = ConnectionStatus::Connected("10.144.144.1".to_string());
         let status3 = ConnectionStatus::Connected("10.144.144.2".to_string());
-        
+
         assert_eq!(status1, status2, "相同的连接状态应该相等");
         assert_ne!(status1, status3, "不同的连接状态不应该相等");
-        
+
         let status4 = ConnectionStatus::Disconnected;
         let status5 = ConnectionStatus::Disconnected;
         assert_eq!(status4, status5, "断开状态应该相等");
@@ -2277,7 +2355,7 @@ mod tests {
     fn test_connection_status_clone() {
         let status = ConnectionStatus::Connected("10.144.144.1".to_string());
         let cloned = status.clone();
-        
+
         assert_eq!(status, cloned, "克隆的状态应该相等");
     }
 
@@ -2288,7 +2366,7 @@ mod tests {
         assert!(NetworkService::is_valid_ip("255.255.255.255"));
         assert!(NetworkService::is_valid_ip("0.0.0.1"));
         assert!(NetworkService::is_valid_ip("255.255.255.254"));
-        
+
         // 测试超出边界
         assert!(!NetworkService::is_valid_ip("256.0.0.0"));
         assert!(!NetworkService::is_valid_ip("0.256.0.0"));
@@ -2312,7 +2390,11 @@ mod tests {
             // 或者如果提取了，应该是无效的
             if let Some(ip) = result {
                 // 如果提取了 IP，验证它确实是有效的 IP 格式
-                assert!(NetworkService::is_valid_ip(&ip), "提取的应该是有效 IP: {}", ip);
+                assert!(
+                    NetworkService::is_valid_ip(&ip),
+                    "提取的应该是有效 IP: {}",
+                    ip
+                );
             }
         }
     }
@@ -2320,11 +2402,14 @@ mod tests {
     #[tokio::test]
     async fn test_network_service_state_consistency() {
         let service = NetworkService::new_with_defaults();
-        
+
         // 多次检查状态应该保持一致
         for _ in 0..5 {
             assert!(!service.is_running().await);
-            assert_eq!(service.check_connection().await, ConnectionStatus::Disconnected);
+            assert_eq!(
+                service.check_connection().await,
+                ConnectionStatus::Disconnected
+            );
             assert_eq!(service.get_virtual_ip().await, None);
         }
     }

--- a/src-tauri/src/modules/p2p_signaling.rs
+++ b/src-tauri/src/modules/p2p_signaling.rs
@@ -1,11 +1,11 @@
-use std::net::{UdpSocket, SocketAddr};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::sync::RwLock;
+use crate::modules::error::AppError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::{SocketAddr, UdpSocket};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use tauri::Emitter;
-use crate::modules::error::AppError;
+use tokio::sync::RwLock;
 
 /// P2P 信令消息
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,20 +28,11 @@ pub enum P2PMessage {
         port: u16,
     },
     /// WebRTC Offer
-    Offer {
-        from: String,
-        sdp: String,
-    },
+    Offer { from: String, sdp: String },
     /// WebRTC Answer
-    Answer {
-        from: String,
-        sdp: String,
-    },
+    Answer { from: String, sdp: String },
     /// ICE Candidate
-    IceCandidate {
-        from: String,
-        candidate: String,
-    },
+    IceCandidate { from: String, candidate: String },
     /// 状态更新
     StatusUpdate {
         #[serde(rename = "playerId")]
@@ -72,28 +63,28 @@ pub struct PeerInfo {
 }
 
 /// P2P 信令服务
-/// 
+///
 /// 使用UDP在局域网中进行P2P通信，不需要中心化服务器
 pub struct P2PSignalingService {
     /// UDP套接字
     socket: Arc<RwLock<Option<UdpSocket>>>,
-    
+
     /// 已发现的对等节点
     peers: Arc<RwLock<HashMap<String, PeerInfo>>>,
-    
+
     /// 本地玩家信息
     local_player_id: Arc<RwLock<Option<String>>>,
     local_player_name: Arc<RwLock<Option<String>>>,
-    
+
     /// 虚拟IP地址
     virtual_ip: Arc<RwLock<Option<String>>>,
-    
+
     /// 监听端口（初始端口，实际可能不同）
     listen_port: u16,
-    
+
     /// 实际使用的端口
     actual_port: Arc<RwLock<u16>>,
-    
+
     /// Tauri 应用句柄
     app_handle: Arc<RwLock<Option<tauri::AppHandle>>>,
 
@@ -108,7 +99,7 @@ impl P2PSignalingService {
     /// 创建新的P2P信令服务
     pub fn new(listen_port: u16) -> Self {
         log::info!("创建P2P信令服务，初始监听端口: {}", listen_port);
-        
+
         Self {
             socket: Arc::new(RwLock::new(None)),
             peers: Arc::new(RwLock::new(HashMap::new())),
@@ -122,23 +113,32 @@ impl P2PSignalingService {
             task_handles: Arc::new(RwLock::new(Vec::new())),
         }
     }
-    
+
     /// 设置 Tauri 应用句柄
     pub async fn set_app_handle(&self, app_handle: tauri::AppHandle) {
         let mut handle = self.app_handle.write().await;
         *handle = Some(app_handle);
         log::info!("P2P信令服务已设置应用句柄");
     }
-    
+
     /// 启动P2P信令服务
-    pub async fn start(&self, player_id: String, player_name: String, virtual_ip: String) -> Result<(), AppError> {
-        log::info!("启动P2P信令服务: player={}, virtual_ip={}", player_name, virtual_ip);
-        
+    pub async fn start(
+        &self,
+        player_id: String,
+        player_name: String,
+        virtual_ip: String,
+    ) -> Result<(), AppError> {
+        log::info!(
+            "启动P2P信令服务: player={}, virtual_ip={}",
+            player_name,
+            virtual_ip
+        );
+
         // 保存本地玩家信息
         *self.local_player_id.write().await = Some(player_id.clone());
         *self.local_player_name.write().await = Some(player_name.clone());
         *self.virtual_ip.write().await = Some(virtual_ip.clone());
-        
+
         // 在 no-tun 模式下，虚拟IP不存在于系统网卡中
         // 我们需要使用真实的本地IP进行UDP通信
         // 绑定到 0.0.0.0 监听所有接口
@@ -146,7 +146,7 @@ impl P2PSignalingService {
         let socket = loop {
             let bind_addr = format!("0.0.0.0:{}", actual_port);
             log::info!("尝试绑定UDP套接字到: {}", bind_addr);
-            
+
             match UdpSocket::bind(&bind_addr) {
                 Ok(sock) => {
                     log::info!("✅ UDP套接字成功绑定到: {}", bind_addr);
@@ -161,84 +161,91 @@ impl P2PSignalingService {
                         // 尝试了100个端口都失败，返回错误
                         return Err(AppError::NetworkError(format!(
                             "无法绑定UDP套接字（尝试了端口 {} 到 {}）: {}",
-                            self.listen_port,
-                            actual_port,
-                            e
+                            self.listen_port, actual_port, e
                         )));
                     }
                 }
             }
         };
-        
+
         // 设置为非阻塞模式
-        socket.set_nonblocking(true)
+        socket
+            .set_nonblocking(true)
             .map_err(|e| AppError::NetworkError(format!("设置非阻塞模式失败: {}", e)))?;
-        
+
         // 启用广播
-        socket.set_broadcast(true)
+        socket
+            .set_broadcast(true)
             .map_err(|e| AppError::NetworkError(format!("启用广播失败: {}", e)))?;
-        
+
         log::info!("UDP套接字配置完成，实际端口: {}", actual_port);
-        
+
         // 保存实际使用的端口
         *self.actual_port.write().await = actual_port;
-        
+
         *self.socket.write().await = Some(socket);
-        
+
         // 标记为运行中，并清空可能残留的旧任务句柄
         self.running.store(true, Ordering::SeqCst);
         self.task_handles.write().await.clear();
-        
+
         // 启动接收线程
         self.start_receiver().await?;
-        
+
         // 启动持续的玩家发现广播任务（前10秒每秒发送一次，之后每5秒发送一次）
         self.start_discovery_broadcast().await;
-        
+
         // 启动心跳任务
         self.start_heartbeat().await;
-        
+
         Ok(())
     }
-    
+
     /// 启动接收线程
     async fn start_receiver(&self) -> Result<(), AppError> {
         let socket = self.socket.read().await;
-        let socket_clone = socket.as_ref()
+        let socket_clone = socket
+            .as_ref()
             .ok_or_else(|| AppError::NetworkError("套接字未初始化".to_string()))?
             .try_clone()
             .map_err(|e| AppError::NetworkError(format!("克隆套接字失败: {}", e)))?;
-        
+
         // 再克隆一个用于发送响应
-        let socket_for_response = socket.as_ref()
+        let socket_for_response = socket
+            .as_ref()
             .ok_or_else(|| AppError::NetworkError("套接字未初始化".to_string()))?
             .try_clone()
             .map_err(|e| AppError::NetworkError(format!("克隆套接字失败: {}", e)))?;
         drop(socket);
-        
+
         let peers = Arc::clone(&self.peers);
         let app_handle = Arc::clone(&self.app_handle);
         let local_player_id = Arc::clone(&self.local_player_id);
         let local_player_name = Arc::clone(&self.local_player_name);
         let actual_port = Arc::clone(&self.actual_port);
         let running = Arc::clone(&self.running);
-        
+
         let handle = tokio::spawn(async move {
             let mut buf = [0u8; 65536];
-            
+
             while running.load(Ordering::Relaxed) {
                 match socket_clone.recv_from(&mut buf) {
                     Ok((len, src_addr)) => {
                         if let Ok(msg_str) = std::str::from_utf8(&buf[..len]) {
                             if let Ok(message) = serde_json::from_str::<P2PMessage>(msg_str) {
                                 // 如果是PlayerDiscovery消息，立即发送响应
-                                if let P2PMessage::PlayerDiscovery { ref player_id, ref player_name, port } = message {
+                                if let P2PMessage::PlayerDiscovery {
+                                    ref player_id,
+                                    ref player_name,
+                                    port,
+                                } = message
+                                {
                                     // 检查是否是自己的广播
                                     let is_self = {
                                         let local_id = local_player_id.read().await;
                                         local_id.as_ref() == Some(player_id)
                                     };
-                                    
+
                                     if !is_self {
                                         // 立即发送响应
                                         if let (Some(my_id), Some(my_name)) = (
@@ -250,28 +257,38 @@ impl P2PSignalingService {
                                                 player_name: my_name.clone(),
                                                 port: *actual_port.read().await,
                                             };
-                                            
-                                            if let Ok(response_json) = serde_json::to_string(&response) {
+
+                                            if let Ok(response_json) =
+                                                serde_json::to_string(&response)
+                                            {
                                                 let mut response_addr = src_addr;
                                                 response_addr.set_port(port);
-                                                
-                                                if let Err(e) = socket_for_response.send_to(response_json.as_bytes(), response_addr) {
+
+                                                if let Err(e) = socket_for_response.send_to(
+                                                    response_json.as_bytes(),
+                                                    response_addr,
+                                                ) {
                                                     log::warn!("发送发现响应失败: {}", e);
                                                 } else {
-                                                    log::info!("✅ 已发送发现响应给 {} ({})", player_name, player_id);
+                                                    log::info!(
+                                                        "✅ 已发送发现响应给 {} ({})",
+                                                        player_name,
+                                                        player_id
+                                                    );
                                                 }
                                             }
                                         }
                                     }
                                 }
-                                
+
                                 Self::handle_message_static(
                                     message,
                                     src_addr,
                                     &peers,
                                     &app_handle,
                                     &local_player_id,
-                                ).await;
+                                )
+                                .await;
                             }
                         }
                     }
@@ -287,12 +304,12 @@ impl P2PSignalingService {
             }
             log::info!("UDP接收线程已退出");
         });
-        
+
         self.task_handles.write().await.push(handle);
         log::info!("UDP接收线程已启动");
         Ok(())
     }
-    
+
     /// 处理接收到的消息（静态方法）
     async fn handle_message_static(
         message: P2PMessage,
@@ -302,9 +319,13 @@ impl P2PSignalingService {
         local_player_id: &Arc<RwLock<Option<String>>>,
     ) {
         match message {
-            P2PMessage::PlayerDiscovery { player_id, player_name, port } => {
+            P2PMessage::PlayerDiscovery {
+                player_id,
+                player_name,
+                port,
+            } => {
                 log::info!("📡 收到玩家发现广播: {} ({})", player_name, player_id);
-                
+
                 // 忽略自己的广播
                 let local_id = local_player_id.read().await;
                 if local_id.as_ref() == Some(&player_id) {
@@ -312,52 +333,59 @@ impl P2PSignalingService {
                     return;
                 }
                 drop(local_id);
-                
+
                 // 检查是否已经存在
                 let already_exists = {
                     let peers_read = peers.read().await;
                     peers_read.contains_key(&player_id)
                 };
-                
+
                 // 添加到对等节点列表（必须在发送事件之前完成）
                 let mut addr = src_addr;
                 addr.set_port(port);
-                
+
                 let peer_info = PeerInfo {
                     player_id: player_id.clone(),
                     player_name: player_name.clone(),
                     addr,
                     last_seen: std::time::Instant::now(),
                 };
-                
+
                 {
                     let mut peers_write = peers.write().await;
                     peers_write.insert(player_id.clone(), peer_info);
                 }
-                
+
                 // 只有新玩家才发送 player-joined 事件
                 if !already_exists {
                     log::info!("✅ 新玩家加入: {} ({})", player_name, player_id);
                     log::info!("   玩家地址: {}", addr);
-                    
+
                     // 等待200ms确保peers列表已完全更新
                     tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-                    
+
                     // 发送事件到前端
                     if let Some(app) = app_handle.read().await.as_ref() {
-                        let _ = app.emit("player-joined", serde_json::json!({
-                            "playerId": player_id,
-                            "playerName": player_name,
-                        }));
+                        let _ = app.emit(
+                            "player-joined",
+                            serde_json::json!({
+                                "playerId": player_id,
+                                "playerName": player_name,
+                            }),
+                        );
                         log::info!("   已发送 player-joined 事件到前端");
                     }
                 } else {
                     log::debug!("更新已存在玩家的心跳: {}", player_id);
                 }
             }
-            P2PMessage::PlayerDiscoveryResponse { player_id, player_name, port } => {
+            P2PMessage::PlayerDiscoveryResponse {
+                player_id,
+                player_name,
+                port,
+            } => {
                 log::info!("📡 收到玩家发现响应: {} ({})", player_name, player_id);
-                
+
                 // 忽略自己的响应
                 let local_id = local_player_id.read().await;
                 if local_id.as_ref() == Some(&player_id) {
@@ -365,43 +393,46 @@ impl P2PSignalingService {
                     return;
                 }
                 drop(local_id);
-                
+
                 // 检查是否已经存在
                 let already_exists = {
                     let peers_read = peers.read().await;
                     peers_read.contains_key(&player_id)
                 };
-                
+
                 // 添加到对等节点列表（必须在发送事件之前完成）
                 let mut addr = src_addr;
                 addr.set_port(port);
-                
+
                 let peer_info = PeerInfo {
                     player_id: player_id.clone(),
                     player_name: player_name.clone(),
                     addr,
                     last_seen: std::time::Instant::now(),
                 };
-                
+
                 {
                     let mut peers_write = peers.write().await;
                     peers_write.insert(player_id.clone(), peer_info);
                 }
-                
+
                 // 只有新玩家才发送 player-joined 事件
                 if !already_exists {
                     log::info!("✅ 新玩家加入（通过响应）: {} ({})", player_name, player_id);
                     log::info!("   玩家地址: {}", addr);
-                    
+
                     // 等待200ms确保peers列表已更新
                     tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-                    
+
                     // 发送事件到前端
                     if let Some(app) = app_handle.read().await.as_ref() {
-                        let _ = app.emit("player-joined", serde_json::json!({
-                            "playerId": player_id,
-                            "playerName": player_name,
-                        }));
+                        let _ = app.emit(
+                            "player-joined",
+                            serde_json::json!({
+                                "playerId": player_id,
+                                "playerName": player_name,
+                            }),
+                        );
                         log::info!("   已发送 player-joined 事件到前端");
                     }
                 } else {
@@ -411,40 +442,55 @@ impl P2PSignalingService {
             P2PMessage::Offer { from, sdp } => {
                 log::info!("收到Offer from {}", from);
                 if let Some(app) = app_handle.read().await.as_ref() {
-                    let _ = app.emit("webrtc-signaling", serde_json::json!({
-                        "type": "offer",
-                        "from": from,
-                        "sdp": sdp,
-                    }));
+                    let _ = app.emit(
+                        "webrtc-signaling",
+                        serde_json::json!({
+                            "type": "offer",
+                            "from": from,
+                            "sdp": sdp,
+                        }),
+                    );
                 }
             }
             P2PMessage::Answer { from, sdp } => {
                 log::info!("收到Answer from {}", from);
                 if let Some(app) = app_handle.read().await.as_ref() {
-                    let _ = app.emit("webrtc-signaling", serde_json::json!({
-                        "type": "answer",
-                        "from": from,
-                        "sdp": sdp,
-                    }));
+                    let _ = app.emit(
+                        "webrtc-signaling",
+                        serde_json::json!({
+                            "type": "answer",
+                            "from": from,
+                            "sdp": sdp,
+                        }),
+                    );
                 }
             }
             P2PMessage::IceCandidate { from, candidate } => {
                 log::debug!("收到ICE Candidate from {}", from);
                 if let Some(app) = app_handle.read().await.as_ref() {
-                    let _ = app.emit("webrtc-signaling", serde_json::json!({
-                        "type": "ice-candidate",
-                        "from": from,
-                        "candidate": candidate,
-                    }));
+                    let _ = app.emit(
+                        "webrtc-signaling",
+                        serde_json::json!({
+                            "type": "ice-candidate",
+                            "from": from,
+                            "candidate": candidate,
+                        }),
+                    );
                 }
             }
-            P2PMessage::StatusUpdate { player_id, mic_enabled } => {
+            P2PMessage::StatusUpdate {
+                player_id,
+                mic_enabled,
+            } => {
                 log::info!("收到状态更新: {} mic={}", player_id, mic_enabled);
                 if let Some(app) = app_handle.read().await.as_ref() {
-                    let _ = app.emit("player-status-update", serde_json::json!({
-                        "playerId": player_id,
-                        "micEnabled": mic_enabled,
-                    }));
+                    let _ = app.emit(
+                        "player-status-update",
+                        serde_json::json!({
+                            "playerId": player_id,
+                            "micEnabled": mic_enabled,
+                        }),
+                    );
                 }
             }
             P2PMessage::Heartbeat { player_id, .. } => {
@@ -456,16 +502,19 @@ impl P2PSignalingService {
             P2PMessage::PlayerLeft { player_id } => {
                 log::info!("玩家离开: {}", player_id);
                 peers.write().await.remove(&player_id);
-                
+
                 if let Some(app) = app_handle.read().await.as_ref() {
-                    let _ = app.emit("player-left", serde_json::json!({
-                        "playerId": player_id,
-                    }));
+                    let _ = app.emit(
+                        "player-left",
+                        serde_json::json!({
+                            "playerId": player_id,
+                        }),
+                    );
                 }
             }
         }
     }
-    
+
     /// 启动持续的玩家发现广播任务
     async fn start_discovery_broadcast(&self) {
         let local_player_id = Arc::clone(&self.local_player_id);
@@ -473,10 +522,10 @@ impl P2PSignalingService {
         let socket = Arc::clone(&self.socket);
         let actual_port = Arc::clone(&self.actual_port);
         let running = Arc::clone(&self.running);
-        
+
         let handle = tokio::spawn(async move {
             let mut count = 0;
-            
+
             while running.load(Ordering::Relaxed) {
                 // 前10秒每秒发送一次，之后每5秒发送一次
                 let interval = if count < 10 {
@@ -484,10 +533,10 @@ impl P2PSignalingService {
                 } else {
                     tokio::time::Duration::from_secs(5)
                 };
-                
+
                 tokio::time::sleep(interval).await;
                 count += 1;
-                
+
                 // 发送玩家发现广播
                 if let (Some(player_id), Some(player_name)) = (
                     local_player_id.read().await.as_ref(),
@@ -498,18 +547,22 @@ impl P2PSignalingService {
                         player_name: player_name.clone(),
                         port: *actual_port.read().await,
                     };
-                    
+
                     if let Some(sock) = socket.read().await.as_ref() {
                         if let Ok(msg_json) = serde_json::to_string(&message) {
                             let port = *actual_port.read().await;
                             // 使用真实的局域网广播地址，而不是虚拟IP的广播地址
                             // 因为在 no-tun 模式下，虚拟IP不存在于系统网卡中
                             let broadcast_addr = format!("255.255.255.255:{}", port);
-                            
+
                             if let Err(e) = sock.send_to(msg_json.as_bytes(), &broadcast_addr) {
                                 log::warn!("发送玩家发现广播失败: {}", e);
                             } else {
-                                log::debug!("已发送玩家发现广播到 {} (第{}次)", broadcast_addr, count);
+                                log::debug!(
+                                    "已发送玩家发现广播到 {} (第{}次)",
+                                    broadcast_addr,
+                                    count
+                                );
                             }
                         }
                     }
@@ -517,62 +570,70 @@ impl P2PSignalingService {
             }
             log::info!("玩家发现广播任务已退出");
         });
-        
+
         self.task_handles.write().await.push(handle);
         log::info!("✅ 玩家发现广播任务已启动");
     }
-    
-    
+
     /// 广播消息到局域网
     async fn broadcast(&self, message: P2PMessage) -> Result<(), AppError> {
         let socket = self.socket.read().await;
-        let socket_ref = socket.as_ref()
+        let socket_ref = socket
+            .as_ref()
             .ok_or_else(|| AppError::NetworkError("套接字未初始化".to_string()))?;
-        
+
         let msg_json = serde_json::to_string(&message)
             .map_err(|e| AppError::NetworkError(format!("序列化消息失败: {}", e)))?;
-        
+
         // 获取实际端口
         let actual_port = *self.actual_port.read().await;
-        
+
         // 使用真实的局域网广播地址
         let broadcast_addr = format!("255.255.255.255:{}", actual_port);
-        
+
         log::debug!("广播消息到: {}", broadcast_addr);
-        
-        socket_ref.send_to(msg_json.as_bytes(), &broadcast_addr)
+
+        socket_ref
+            .send_to(msg_json.as_bytes(), &broadcast_addr)
             .map_err(|e| AppError::NetworkError(format!("发送广播失败: {}", e)))?;
-        
+
         Ok(())
     }
-    
+
     /// 发送消息到指定玩家
-    pub async fn send_to_player(&self, player_id: &str, message: P2PMessage) -> Result<(), AppError> {
+    pub async fn send_to_player(
+        &self,
+        player_id: &str,
+        message: P2PMessage,
+    ) -> Result<(), AppError> {
         let peers = self.peers.read().await;
-        let peer = peers.get(player_id)
+        let peer = peers
+            .get(player_id)
             .ok_or_else(|| AppError::NetworkError(format!("玩家不存在: {}", player_id)))?;
-        
+
         let addr = peer.addr;
         drop(peers);
-        
+
         let socket = self.socket.read().await;
-        let socket_ref = socket.as_ref()
+        let socket_ref = socket
+            .as_ref()
             .ok_or_else(|| AppError::NetworkError("套接字未初始化".to_string()))?;
-        
+
         let msg_json = serde_json::to_string(&message)
             .map_err(|e| AppError::NetworkError(format!("序列化消息失败: {}", e)))?;
-        
-        socket_ref.send_to(msg_json.as_bytes(), addr)
+
+        socket_ref
+            .send_to(msg_json.as_bytes(), addr)
             .map_err(|e| AppError::NetworkError(format!("发送消息失败: {}", e)))?;
-        
+
         Ok(())
     }
-    
+
     /// 广播消息到所有玩家
     pub async fn broadcast_to_all(&self, message: P2PMessage) -> Result<(), AppError> {
         self.broadcast(message).await
     }
-    
+
     /// 启动心跳任务
     async fn start_heartbeat(&self) {
         let local_player_id = Arc::clone(&self.local_player_id);
@@ -581,21 +642,21 @@ impl P2PSignalingService {
         let peers = Arc::clone(&self.peers);
         let app_handle = Arc::clone(&self.app_handle);
         let running = Arc::clone(&self.running);
-        
+
         let handle = tokio::spawn(async move {
             while running.load(Ordering::Relaxed) {
                 tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
                 if !running.load(Ordering::Relaxed) {
                     break;
                 }
-                
+
                 // 发送心跳
                 if let Some(player_id) = local_player_id.read().await.as_ref() {
                     let message = P2PMessage::Heartbeat {
                         player_id: player_id.clone(),
                         timestamp: chrono::Utc::now().timestamp(),
                     };
-                    
+
                     if let Some(sock) = socket.read().await.as_ref() {
                         if let Ok(msg_json) = serde_json::to_string(&message) {
                             let port = *actual_port.read().await;
@@ -606,12 +667,12 @@ impl P2PSignalingService {
                         }
                     }
                 }
-                
+
                 // 检测超时的玩家（90秒未收到心跳）
                 let timeout_duration = std::time::Duration::from_secs(90);
                 let now = std::time::Instant::now();
                 let mut timeout_players = Vec::new();
-                
+
                 {
                     let peers_read = peers.read().await;
                     for (player_id, peer_info) in peers_read.iter() {
@@ -620,33 +681,36 @@ impl P2PSignalingService {
                         }
                     }
                 }
-                
+
                 // 移除超时的玩家并通知前端
                 if !timeout_players.is_empty() {
                     let mut peers_write = peers.write().await;
                     for player_id in timeout_players {
                         log::warn!("玩家超时: {}", player_id);
                         peers_write.remove(&player_id);
-                        
+
                         // 通知前端玩家离开
                         if let Some(app) = app_handle.read().await.as_ref() {
-                            let _ = app.emit("player-left", serde_json::json!({
-                                "playerId": player_id,
-                            }));
+                            let _ = app.emit(
+                                "player-left",
+                                serde_json::json!({
+                                    "playerId": player_id,
+                                }),
+                            );
                         }
                     }
                 }
             }
             log::info!("心跳任务已退出");
         });
-        
+
         self.task_handles.write().await.push(handle);
     }
-    
+
     /// 停止服务
     pub async fn stop(&self) -> Result<(), AppError> {
         log::info!("停止P2P信令服务");
-        
+
         // 发送离开消息
         if let Some(player_id) = self.local_player_id.read().await.as_ref() {
             let message = P2PMessage::PlayerLeft {
@@ -654,10 +718,10 @@ impl P2PSignalingService {
             };
             let _ = self.broadcast(message).await;
         }
-        
+
         // 标记停止，让后台 loop 任务自行退出
         self.running.store(false, Ordering::SeqCst);
-        
+
         // 强制 abort 所有后台任务（接收/发现广播/心跳），彻底回收任务与克隆的套接字句柄
         {
             let mut handles = self.task_handles.write().await;
@@ -665,17 +729,17 @@ impl P2PSignalingService {
                 handle.abort();
             }
         }
-        
+
         // 关闭套接字
         *self.socket.write().await = None;
-        
+
         // 清理对等节点
         self.peers.write().await.clear();
-        
+
         log::info!("✅ P2P信令服务已停止，后台任务已回收");
         Ok(())
     }
-    
+
     /// 获取所有对等节点
     pub async fn get_peers(&self) -> Vec<PeerInfo> {
         self.peers.read().await.values().cloned().collect()

--- a/src-tauri/src/modules/remote_control.rs
+++ b/src-tauri/src/modules/remote_control.rs
@@ -53,10 +53,10 @@ mod platform {
     use super::RemoteInputEvent;
     use windows::Win32::UI::Input::KeyboardAndMouse::{
         SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYBD_EVENT_FLAGS,
-        KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, KEYEVENTF_UNICODE, MOUSEINPUT, MOUSE_EVENT_FLAGS, MOUSEEVENTF_ABSOLUTE,
+        KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, KEYEVENTF_UNICODE, MOUSEEVENTF_ABSOLUTE,
         MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN,
         MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_MOVE, MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP,
-        MOUSEEVENTF_WHEEL, VIRTUAL_KEY,
+        MOUSEEVENTF_WHEEL, MOUSEINPUT, MOUSE_EVENT_FLAGS, VIRTUAL_KEY,
     };
     use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
 
@@ -163,17 +163,32 @@ mod platform {
             match ev {
                 RemoteInputEvent::MouseMove { x, y } => {
                     let (ax, ay) = to_abs(*x, *y);
-                    inputs.push(mouse_input(ax, ay, 0, MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE));
+                    inputs.push(mouse_input(
+                        ax,
+                        ay,
+                        0,
+                        MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE,
+                    ));
                 }
                 RemoteInputEvent::MouseDown { button, x, y } => {
                     let (ax, ay) = to_abs(*x, *y);
                     // 先移动到目标点，再按下，避免点偏
-                    inputs.push(mouse_input(ax, ay, 0, MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE));
+                    inputs.push(mouse_input(
+                        ax,
+                        ay,
+                        0,
+                        MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE,
+                    ));
                     inputs.push(mouse_input(0, 0, 0, button_flags(*button, true)));
                 }
                 RemoteInputEvent::MouseUp { button, x, y } => {
                     let (ax, ay) = to_abs(*x, *y);
-                    inputs.push(mouse_input(ax, ay, 0, MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE));
+                    inputs.push(mouse_input(
+                        ax,
+                        ay,
+                        0,
+                        MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE,
+                    ));
                     inputs.push(mouse_input(0, 0, 0, button_flags(*button, false)));
                 }
                 RemoteInputEvent::MouseWheel { dx, dy } => {

--- a/src-tauri/src/modules/resource_manager.rs
+++ b/src-tauri/src/modules/resource_manager.rs
@@ -1,7 +1,7 @@
 use crate::modules::error::AppError;
-use std::path::PathBuf;
 use std::fs;
 use std::io::Write;
+use std::path::PathBuf;
 use tauri::Manager;
 
 // 将二进制文件嵌入到可执行文件中
@@ -17,7 +17,7 @@ static WINTUN_DLL_BYTES: &[u8] = include_bytes!("../../resources/binaries/wintun
 static WINDIVERT_SYS_BYTES: &[u8] = include_bytes!("../../resources/binaries/WinDivert64.sys");
 
 /// 资源管理器
-/// 
+///
 /// 负责管理应用程序的资源文件路径
 /// 所有二进制文件都嵌入到exe中，运行时提取到临时目录
 pub struct ResourceManager;
@@ -35,7 +35,11 @@ impl ResourceManager {
             if let Some(exe_dir) = exe_path.parent() {
                 candidates.push(exe_dir.join("binaries").join(filename));
                 candidates.push(exe_dir.join("..\\..\\..\\binaries").join(filename));
-                candidates.push(exe_dir.join("..\\..\\..\\resources\\binaries").join(filename));
+                candidates.push(
+                    exe_dir
+                        .join("..\\..\\..\\resources\\binaries")
+                        .join(filename),
+                );
             }
         }
 
@@ -49,10 +53,10 @@ impl ResourceManager {
     }
 
     /// 获取运行时目录（用于存放提取的二进制文件）
-    /// 
+    ///
     /// # 参数
     /// * `app_handle` - Tauri 应用句柄
-    /// 
+    ///
     /// # 返回
     /// * `Ok(PathBuf)` - 运行时目录路径
     /// * `Err(AppError)` - 获取路径失败
@@ -61,28 +65,25 @@ impl ResourceManager {
         let runtime_dir = app_handle
             .path()
             .app_local_data_dir()
-            .map_err(|e| {
-                AppError::ConfigError(format!("无法获取本地数据目录: {}", e))
-            })?
+            .map_err(|e| AppError::ConfigError(format!("无法获取本地数据目录: {}", e)))?
             .join("runtime");
-        
+
         // 确保运行时目录存在
         if !runtime_dir.exists() {
-            fs::create_dir_all(&runtime_dir).map_err(|e| {
-                AppError::ConfigError(format!("无法创建运行时目录: {}", e))
-            })?;
+            fs::create_dir_all(&runtime_dir)
+                .map_err(|e| AppError::ConfigError(format!("无法创建运行时目录: {}", e)))?;
         }
-        
+
         Ok(runtime_dir)
     }
-    
+
     /// 提取嵌入的二进制文件到运行时目录
-    /// 
+    ///
     /// # 参数
     /// * `app_handle` - Tauri 应用句柄
     /// * `filename` - 文件名
     /// * `bytes` - 文件内容
-    /// 
+    ///
     /// # 返回
     /// * `Ok(PathBuf)` - 提取后的文件路径
     /// * `Err(AppError)` - 提取失败
@@ -94,7 +95,7 @@ impl ResourceManager {
     ) -> Result<PathBuf, AppError> {
         let runtime_dir = Self::get_runtime_dir(app_handle)?;
         let target_path = runtime_dir.join(filename);
-        
+
         // 如果文件已存在且大小一致，跳过提取
         if target_path.exists() {
             if let Ok(metadata) = fs::metadata(&target_path) {
@@ -104,26 +105,24 @@ impl ResourceManager {
                 }
             }
         }
-        
+
         // 提取文件
         log::info!("提取嵌入的二进制文件: {} ({} 字节)", filename, bytes.len());
-        let mut file = fs::File::create(&target_path).map_err(|e| {
-            AppError::ConfigError(format!("无法创建文件 {}: {}", filename, e))
-        })?;
-        
-        file.write_all(bytes).map_err(|e| {
-            AppError::ConfigError(format!("无法写入文件 {}: {}", filename, e))
-        })?;
-        
+        let mut file = fs::File::create(&target_path)
+            .map_err(|e| AppError::ConfigError(format!("无法创建文件 {}: {}", filename, e)))?;
+
+        file.write_all(bytes)
+            .map_err(|e| AppError::ConfigError(format!("无法写入文件 {}: {}", filename, e)))?;
+
         log::info!("成功提取文件到: {:?}", target_path);
         Ok(target_path)
     }
-    
+
     /// 获取 EasyTier 可执行文件的路径
-    /// 
+    ///
     /// # 参数
     /// * `app_handle` - Tauri 应用句柄
-    /// 
+    ///
     /// # 返回
     /// * `Ok(PathBuf)` - EasyTier 可执行文件的完整路径
     /// * `Err(AppError)` - 获取路径失败
@@ -139,7 +138,7 @@ impl ResourceManager {
             log::warn!("开发模式 - 未找到外部 easytier-core.exe，回退到内嵌资源提取");
             return Self::extract_binary(app_handle, "easytier-core.exe", EASYTIER_CORE_BYTES);
         }
-        
+
         // 在生产模式下，从嵌入的二进制文件中提取
         #[cfg(not(debug_assertions))]
         {
@@ -161,7 +160,7 @@ impl ResourceManager {
             Self::extract_binary(app_handle, "easytier-cli.exe", EASYTIER_CLI_BYTES)
         }
     }
-    
+
     /// 获取 Packet.dll 的路径
     pub fn get_packet_dll_path(app_handle: &tauri::AppHandle) -> Result<PathBuf, AppError> {
         #[cfg(debug_assertions)]
@@ -171,13 +170,13 @@ impl ResourceManager {
             }
             return Self::extract_binary(app_handle, "Packet.dll", PACKET_DLL_BYTES);
         }
-        
+
         #[cfg(not(debug_assertions))]
         {
             Self::extract_binary(app_handle, "Packet.dll", PACKET_DLL_BYTES)
         }
     }
-    
+
     /// 获取 wintun.dll 的路径
     pub fn get_wintun_dll_path(app_handle: &tauri::AppHandle) -> Result<PathBuf, AppError> {
         #[cfg(debug_assertions)]
@@ -187,13 +186,13 @@ impl ResourceManager {
             }
             return Self::extract_binary(app_handle, "wintun.dll", WINTUN_DLL_BYTES);
         }
-        
+
         #[cfg(not(debug_assertions))]
         {
             Self::extract_binary(app_handle, "wintun.dll", WINTUN_DLL_BYTES)
         }
     }
-    
+
     /// 获取 WinDivert64.sys 的路径
     pub fn get_windivert_sys_path(app_handle: &tauri::AppHandle) -> Result<PathBuf, AppError> {
         #[cfg(debug_assertions)]
@@ -203,18 +202,18 @@ impl ResourceManager {
             }
             return Self::extract_binary(app_handle, "WinDivert64.sys", WINDIVERT_SYS_BYTES);
         }
-        
+
         #[cfg(not(debug_assertions))]
         {
             Self::extract_binary(app_handle, "WinDivert64.sys", WINDIVERT_SYS_BYTES)
         }
     }
-    
+
     /// 获取配置目录路径
-    /// 
+    ///
     /// # 参数
     /// * `app_handle` - Tauri 应用句柄
-    /// 
+    ///
     /// # 返回
     /// * `Ok(PathBuf)` - 配置目录路径
     /// * `Err(AppError)` - 获取路径失败
@@ -222,25 +221,22 @@ impl ResourceManager {
         let config_dir = app_handle
             .path()
             .app_config_dir()
-            .map_err(|e| {
-                AppError::ConfigError(format!("无法获取配置目录: {}", e))
-            })?;
-        
+            .map_err(|e| AppError::ConfigError(format!("无法获取配置目录: {}", e)))?;
+
         // 确保配置目录存在
         if !config_dir.exists() {
-            std::fs::create_dir_all(&config_dir).map_err(|e| {
-                AppError::ConfigError(format!("无法创建配置目录: {}", e))
-            })?;
+            std::fs::create_dir_all(&config_dir)
+                .map_err(|e| AppError::ConfigError(format!("无法创建配置目录: {}", e)))?;
         }
-        
+
         Ok(config_dir)
     }
-    
+
     /// 获取日志目录路径
-    /// 
+    ///
     /// # 参数
     /// * `app_handle` - Tauri 应用句柄
-    /// 
+    ///
     /// # 返回
     /// * `Ok(PathBuf)` - 日志目录路径
     /// * `Err(AppError)` - 获取路径失败
@@ -248,17 +244,14 @@ impl ResourceManager {
         let log_dir = app_handle
             .path()
             .app_log_dir()
-            .map_err(|e| {
-                AppError::ConfigError(format!("无法获取日志目录: {}", e))
-            })?;
-        
+            .map_err(|e| AppError::ConfigError(format!("无法获取日志目录: {}", e)))?;
+
         // 确保日志目录存在
         if !log_dir.exists() {
-            std::fs::create_dir_all(&log_dir).map_err(|e| {
-                AppError::ConfigError(format!("无法创建日志目录: {}", e))
-            })?;
+            std::fs::create_dir_all(&log_dir)
+                .map_err(|e| AppError::ConfigError(format!("无法创建日志目录: {}", e)))?;
         }
-        
+
         Ok(log_dir)
     }
 }

--- a/src-tauri/src/modules/sonora_audio.rs
+++ b/src-tauri/src/modules/sonora_audio.rs
@@ -96,7 +96,10 @@ pub fn process_voice_frames(mic: Vec<f32>, render: Vec<f32>) -> Result<Vec<f32>,
         .chunks_exact(FRAME_SAMPLES)
         .zip(render.chunks_exact(FRAME_SAMPLES))
     {
-        output.extend(process_voice_frame(mic_frame.to_vec(), render_frame.to_vec())?);
+        output.extend(process_voice_frame(
+            mic_frame.to_vec(),
+            render_frame.to_vec(),
+        )?);
     }
     Ok(output)
 }

--- a/src-tauri/src/modules/system_audio.rs
+++ b/src-tauri/src/modules/system_audio.rs
@@ -53,7 +53,9 @@ mod platform {
     const CHUNK_FRAMES: usize = 768;
 
     fn qpc_100ns_now() -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
-        use windows::Win32::System::Performance::{QueryPerformanceCounter, QueryPerformanceFrequency};
+        use windows::Win32::System::Performance::{
+            QueryPerformanceCounter, QueryPerformanceFrequency,
+        };
         let mut counter = 0_i64;
         let mut frequency = 0_i64;
         unsafe {
@@ -66,9 +68,19 @@ mod platform {
         Ok(counter.saturating_mul(10_000_000) / frequency)
     }
 
-    pub fn capture_loop(app: AppHandle, stop: Arc<AtomicBool>, requested_device_id: Option<String>, requested_device_name: Option<String>) {
+    pub fn capture_loop(
+        app: AppHandle,
+        stop: Arc<AtomicBool>,
+        requested_device_id: Option<String>,
+        requested_device_name: Option<String>,
+    ) {
         while !stop.load(Ordering::Acquire) {
-            if let Err(error) = capture_loop_inner(&app, &stop, requested_device_id.as_deref(), requested_device_name.as_deref()) {
+            if let Err(error) = capture_loop_inner(
+                &app,
+                &stop,
+                requested_device_id.as_deref(),
+                requested_device_name.as_deref(),
+            ) {
                 log::warn!("WASAPI render loopback restarting: {}", error);
                 let _ = app.emit(ERROR_EVENT, error.to_string());
             }
@@ -113,7 +125,9 @@ mod platform {
                 .unwrap_or(enumerator.get_default_device(&Direction::Render)?);
             log::info!(
                 "WASAPI loopback reference output: {} ({})",
-                device.get_friendlyname().unwrap_or_else(|_| "Unknown output".to_string()),
+                device
+                    .get_friendlyname()
+                    .unwrap_or_else(|_| "Unknown output".to_string()),
                 device.get_id().unwrap_or_else(|_| "unknown-id".to_string()),
             );
             let mut audio_client: AudioClient = device.get_iaudioclient()?;
@@ -160,7 +174,8 @@ mod platform {
                     for byte in &mut chunk {
                         *byte = queue.pop_front().unwrap_or_default();
                     }
-                    let chunk_duration_100ns = (CHUNK_FRAMES as i64 * 10_000_000) / SAMPLE_RATE as i64;
+                    let chunk_duration_100ns =
+                        (CHUNK_FRAMES as i64 * 10_000_000) / SAMPLE_RATE as i64;
                     let end_qpc_100ns = queue_start_qpc_100ns
                         .map(|start| start + chunk_duration_100ns)
                         .unwrap_or_else(|| qpc_100ns_now().unwrap_or(anchor_qpc_100ns));
@@ -168,7 +183,8 @@ mod platform {
                         data: STANDARD.encode(chunk),
                         sample_rate: SAMPLE_RATE as u32,
                         channels: CHANNELS as u16,
-                        captured_at_unix_ms: (anchor_unix_100ns + end_qpc_100ns - anchor_qpc_100ns) / 10_000,
+                        captured_at_unix_ms: (anchor_unix_100ns + end_qpc_100ns - anchor_qpc_100ns)
+                            / 10_000,
                     };
                     queue_start_qpc_100ns = Some(end_qpc_100ns);
                     if app.emit(EVENT, payload).is_err() {
@@ -196,7 +212,12 @@ mod platform {
     use super::*;
     use tauri::AppHandle;
 
-    pub fn capture_loop(_app: AppHandle, _stop: Arc<AtomicBool>, _requested_device_id: Option<String>, _requested_device_name: Option<String>) {
+    pub fn capture_loop(
+        _app: AppHandle,
+        _stop: Arc<AtomicBool>,
+        _requested_device_id: Option<String>,
+        _requested_device_name: Option<String>,
+    ) {
         log::debug!("System loopback is only available on Windows");
     }
 }

--- a/src-tauri/src/modules/tauri_commands.rs
+++ b/src-tauri/src/modules/tauri_commands.rs
@@ -1,22 +1,439 @@
 // Tauri Command 接口模块
 // 提供前端调用的所有命令接口
 
-use tauri::State;
-use tauri::Emitter;
-use tauri::Manager;
 use crate::modules::app_core::{AppCore, AppState as CoreAppState};
+use crate::modules::config_manager::UserConfig;
 use crate::modules::lobby_manager::{Lobby, Player};
 use crate::modules::voice_service::AudioDevice;
-use crate::modules::config_manager::UserConfig;
-use std::sync::Arc;
-use std::sync::OnceLock;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::OnceLock;
+use tauri::Emitter;
+use tauri::Manager;
+use tauri::State;
 use tokio::sync::Mutex;
 
 /// 远程文件下载的取消标志注册表（task_id -> 取消标志）
 fn download_cancels() -> &'static dashmap::DashMap<String, Arc<AtomicBool>> {
     static CANCELS: OnceLock<dashmap::DashMap<String, Arc<AtomicBool>>> = OnceLock::new();
     CANCELS.get_or_init(dashmap::DashMap::new)
+}
+
+const MAX_REMOTE_FILE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const MAX_REMOTE_METADATA_BYTES: usize = 4 * 1024 * 1024;
+const MAX_REMOTE_BATCH_FILES: usize = 256;
+const MAX_REMOTE_BATCH_REQUEST_BYTES: usize = 64 * 1024;
+const MAX_REMOTE_BATCH_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const MAX_PATH_GRANTS: usize = 4096;
+const MAX_CHAT_TARGETS: usize = 64;
+const MAX_CHAT_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+const AUTO_LOBBY_CREDENTIAL_TARGET: &str = "MCTier:auto-lobby-password";
+
+#[cfg(windows)]
+fn read_auto_lobby_secret() -> Option<String> {
+    use windows::core::PCWSTR;
+    use windows::Win32::Security::Credentials::{
+        CredFree, CredReadW, CREDENTIALW, CRED_TYPE_GENERIC,
+    };
+
+    let target = AUTO_LOBBY_CREDENTIAL_TARGET
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let mut credential: *mut CREDENTIALW = std::ptr::null_mut();
+    unsafe {
+        CredReadW(
+            PCWSTR(target.as_ptr()),
+            CRED_TYPE_GENERIC,
+            0,
+            &mut credential,
+        )
+        .ok()?;
+        let record = credential.as_ref()?;
+        let bytes =
+            std::slice::from_raw_parts(record.CredentialBlob, record.CredentialBlobSize as usize);
+        let value = String::from_utf8(bytes.to_vec()).ok();
+        CredFree(credential.cast());
+        value.filter(|password| !password.is_empty())
+    }
+}
+
+#[cfg(windows)]
+fn write_auto_lobby_secret(password: &str) -> Result<(), String> {
+    use windows::core::{PCWSTR, PWSTR};
+    use windows::Win32::Security::Credentials::{
+        CredDeleteW, CredWriteW, CREDENTIALW, CRED_MAX_CREDENTIAL_BLOB_SIZE,
+        CRED_PERSIST_LOCAL_MACHINE, CRED_TYPE_GENERIC,
+    };
+
+    let mut target = AUTO_LOBBY_CREDENTIAL_TARGET
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    if password.is_empty() {
+        let _ = unsafe { CredDeleteW(PCWSTR(target.as_ptr()), CRED_TYPE_GENERIC, 0) };
+        return Ok(());
+    }
+    let mut blob = password.as_bytes().to_vec();
+    if blob.len() > CRED_MAX_CREDENTIAL_BLOB_SIZE as usize {
+        return Err("自动大厅密码超过系统凭据库限制".to_string());
+    }
+    let credential = CREDENTIALW {
+        Type: CRED_TYPE_GENERIC,
+        TargetName: PWSTR(target.as_mut_ptr()),
+        CredentialBlobSize: blob.len() as u32,
+        CredentialBlob: blob.as_mut_ptr(),
+        Persist: CRED_PERSIST_LOCAL_MACHINE,
+        ..Default::default()
+    };
+    unsafe { CredWriteW(&credential, 0) }
+        .map_err(|error| format!("保存自动大厅密码到 Windows 凭据管理器失败: {}", error))
+}
+
+#[cfg(not(windows))]
+fn auto_lobby_session_secret() -> &'static StdMutex<Option<String>> {
+    static SECRET: OnceLock<StdMutex<Option<String>>> = OnceLock::new();
+    SECRET.get_or_init(|| StdMutex::new(None))
+}
+
+#[cfg(not(windows))]
+fn read_auto_lobby_secret() -> Option<String> {
+    auto_lobby_session_secret()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+}
+
+#[cfg(not(windows))]
+fn write_auto_lobby_secret(password: &str) -> Result<(), String> {
+    *auto_lobby_session_secret()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+        (!password.is_empty()).then(|| password.to_string());
+    Ok(())
+}
+
+fn overlay_http_host(raw: &str) -> Result<String, String> {
+    let ip = raw
+        .trim()
+        .parse::<std::net::Ipv4Addr>()
+        .map_err(|_| "目标不是有效的 EasyTier 虚拟 IPv4".to_string())?;
+    let octets = ip.octets();
+    if octets[..3] != [10, 126, 126] || octets[3] == 0 || octets[3] == 255 {
+        return Err("目标 IP 不在允许的虚拟网络范围内".to_string());
+    }
+    Ok(ip.to_string())
+}
+
+struct FilePeerTarget {
+    host: String,
+    token: String,
+}
+
+async fn require_file_peer_host(raw: &str, state: &AppState) -> Result<FilePeerTarget, String> {
+    let host = overlay_http_host(raw)?;
+    let target = host
+        .parse::<std::net::Ipv4Addr>()
+        .map_err(|_| "目标不是有效的 EasyTier 虚拟 IPv4".to_string())?;
+    let chat_service = {
+        let core = state.core.lock().await;
+        core.get_chat_service()
+    };
+    let chat = chat_service.lock().await;
+    let token = chat
+        .get_chat_token()
+        .ok_or_else(|| "当前大厅尚未建立文件认证会话".to_string())?;
+    let local = chat
+        .get_virtual_ip()
+        .ok_or_else(|| "当前 EasyTier 虚拟 IP 尚未就绪".to_string())?
+        .parse::<std::net::Ipv4Addr>()
+        .map_err(|_| "当前 EasyTier 虚拟 IP 无效".to_string())?;
+    if local.octets()[..3] != target.octets()[..3] {
+        return Err("目标 IP 不在当前 EasyTier 虚拟子网内".to_string());
+    }
+    if local == target {
+        return Ok(FilePeerTarget { host, token });
+    }
+    if chat
+        .allowed_peer_ips(std::slice::from_ref(&host))
+        .is_empty()
+    {
+        return Err("目标 IP 不属于当前大厅的权威成员".to_string());
+    }
+    Ok(FilePeerTarget { host, token })
+}
+
+/// A renderer must not be able to turn the generic file commands into an
+/// arbitrary filesystem API. Native file pickers and app-generated download
+/// paths register narrowly scoped grants that are checked again by every
+/// read/write/delete/open command.
+#[derive(Clone, Copy)]
+enum PathAccess {
+    ReadFile,
+    WriteFile,
+    DeleteFile,
+    ReadDirectory,
+    WriteDirectory,
+    Open,
+}
+
+#[derive(Default)]
+struct PathGrant {
+    read_file: bool,
+    write_file: bool,
+    delete_file: bool,
+    read_directory: bool,
+    write_directory: bool,
+    open: bool,
+}
+
+#[derive(Default)]
+struct PathGrantStore {
+    entries: HashMap<std::path::PathBuf, PathGrant>,
+}
+
+fn path_grants() -> &'static StdMutex<PathGrantStore> {
+    static GRANTS: OnceLock<StdMutex<PathGrantStore>> = OnceLock::new();
+    GRANTS.get_or_init(|| StdMutex::new(PathGrantStore::default()))
+}
+
+fn path_grant_allows(grant: &mut PathGrant, access: PathAccess) {
+    match access {
+        PathAccess::ReadFile => grant.read_file = true,
+        PathAccess::WriteFile => grant.write_file = true,
+        PathAccess::DeleteFile => grant.delete_file = true,
+        PathAccess::ReadDirectory => grant.read_directory = true,
+        PathAccess::WriteDirectory => grant.write_directory = true,
+        PathAccess::Open => grant.open = true,
+    }
+}
+
+fn path_grant_matches(grant: &PathGrant, access: PathAccess) -> bool {
+    match access {
+        PathAccess::ReadFile => grant.read_file,
+        PathAccess::WriteFile => grant.write_file,
+        PathAccess::DeleteFile => grant.delete_file,
+        PathAccess::ReadDirectory => grant.read_directory,
+        PathAccess::WriteDirectory => grant.write_directory,
+        PathAccess::Open => grant.open,
+    }
+}
+
+#[cfg(windows)]
+fn validate_local_path_component(component: &std::ffi::OsStr) -> Result<(), String> {
+    let value = component
+        .to_str()
+        .ok_or_else(|| "路径包含无法处理的字符".to_string())?;
+    if value.is_empty()
+        || value.contains(':')
+        || value
+            .chars()
+            .any(|ch| matches!(ch, '<' | '>' | '"' | '|' | '?' | '*'))
+        || value != value.trim_end_matches([' ', '.'])
+        || is_windows_reserved_name(value)
+    {
+        return Err("路径包含 Windows 保留名称或非法语法".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn validate_local_path_component(_component: &std::ffi::OsStr) -> Result<(), String> {
+    Ok(())
+}
+
+/// Normalize paths without resolving user-controlled symlinks. All paths used
+/// by these commands are expected to come from a native picker or an app
+/// generated absolute path, so relative paths and parent traversal are denied.
+fn normalize_local_path(raw: &str, allow_missing_leaf: bool) -> Result<std::path::PathBuf, String> {
+    if raw.is_empty() || raw.len() > 32 * 1024 || raw.contains('\0') {
+        return Err("路径为空、过长或包含非法字符".to_string());
+    }
+
+    let input = std::path::Path::new(raw);
+    if !input.is_absolute() {
+        return Err("只允许使用绝对路径".to_string());
+    }
+
+    #[cfg(windows)]
+    {
+        use std::path::Prefix;
+        let text = input.to_string_lossy();
+        if text.starts_with("\\\\") || text.starts_with("//") {
+            return Err("不允许使用网络共享或设备路径".to_string());
+        }
+        if input.components().any(|component| {
+            matches!(component, std::path::Component::Prefix(prefix)
+                if !matches!(prefix.kind(), Prefix::Disk(_)))
+        }) {
+            return Err("不允许使用网络共享或设备路径".to_string());
+        }
+    }
+
+    let mut normalized = std::path::PathBuf::new();
+    for component in input.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                return Err("路径不得包含父目录跳转".to_string());
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(name) => {
+                validate_local_path_component(name)?;
+                normalized.push(name);
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        return Err("路径无效".to_string());
+    }
+
+    // `exists()` follows links and reports false for dangling symlinks. Use
+    // symlink_metadata for the leaf so a new-file grant cannot be registered
+    // on a dangling symlink (which a later overwrite-style API might follow).
+    let parent = normalized
+        .parent()
+        .ok_or_else(|| "路径缺少父目录".to_string())?;
+    let leaf_exists = match std::fs::symlink_metadata(&normalized) {
+        Ok(_) => {
+            ensure_existing_path_has_no_links(&normalized)?;
+            true
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            ensure_existing_path_has_no_links(parent)?;
+            false
+        }
+        Err(error) => return Err(format!("检查路径失败 {}: {}", normalized.display(), error)),
+    };
+
+    if !allow_missing_leaf && !leaf_exists {
+        return Err("路径不存在".to_string());
+    }
+    if allow_missing_leaf {
+        let parent_metadata =
+            std::fs::symlink_metadata(parent).map_err(|e| format!("检查父目录失败: {}", e))?;
+        if !parent_metadata.is_dir() {
+            return Err("父路径不是目录".to_string());
+        }
+    }
+
+    Ok(normalized)
+}
+
+fn ensure_existing_path_has_no_links(path: &std::path::Path) -> Result<(), String> {
+    let mut current = std::path::PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        let metadata = std::fs::symlink_metadata(&current)
+            .map_err(|e| format!("检查路径失败 {}: {}", current.display(), e))?;
+        if is_symlink_or_reparse_point(&metadata) {
+            return Err(format!("拒绝经过符号链接或重解析点: {}", current.display()));
+        }
+    }
+    Ok(())
+}
+
+fn register_path_grant(
+    raw: &str,
+    access: PathAccess,
+    allow_missing_leaf: bool,
+) -> Result<std::path::PathBuf, String> {
+    let path = normalize_local_path(raw, allow_missing_leaf)?;
+    let mut grants = path_grants()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if !grants.entries.contains_key(&path) && grants.entries.len() >= MAX_PATH_GRANTS {
+        return Err("应用文件授权数量已达到上限，请重启应用后重试".to_string());
+    }
+    let grant = grants.entries.entry(path.clone()).or_default();
+    path_grant_allows(grant, access);
+    Ok(path)
+}
+
+fn require_path_grant(
+    raw: &str,
+    access: PathAccess,
+    allow_missing_leaf: bool,
+) -> Result<std::path::PathBuf, String> {
+    let path = normalize_local_path(raw, allow_missing_leaf)?;
+    let grants = path_grants()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if !grants
+        .entries
+        .get(&path)
+        .is_some_and(|grant| path_grant_matches(grant, access))
+    {
+        return Err("路径未通过应用文件选择或内部授权".to_string());
+    }
+    Ok(path)
+}
+
+fn require_existing_file_grant(
+    raw: &str,
+    access: PathAccess,
+) -> Result<std::path::PathBuf, String> {
+    let path = require_path_grant(raw, access, false)?;
+    let metadata = std::fs::symlink_metadata(&path).map_err(|e| format!("检查文件失败: {}", e))?;
+    if is_symlink_or_reparse_point(&metadata) || !metadata.is_file() {
+        return Err("路径不是普通本地文件".to_string());
+    }
+    Ok(path)
+}
+
+fn require_existing_directory_grant(
+    raw: &str,
+    access: PathAccess,
+) -> Result<std::path::PathBuf, String> {
+    let path = require_path_grant(raw, access, false)?;
+    let metadata = std::fs::symlink_metadata(&path).map_err(|e| format!("检查目录失败: {}", e))?;
+    if is_symlink_or_reparse_point(&metadata) || !metadata.is_dir() {
+        return Err("路径不是普通本地目录".to_string());
+    }
+    Ok(path)
+}
+
+fn windows_run_value(exe: &std::path::Path) -> Result<String, String> {
+    let value = exe
+        .to_str()
+        .ok_or_else(|| "程序路径不是有效的 UTF-8".to_string())?;
+    if value.is_empty() || value.contains('\0') || value.contains('"') {
+        return Err("程序路径包含非法字符".to_string());
+    }
+    Ok(format!("\"{}\"", value))
+}
+
+#[cfg(windows)]
+fn windows_system_command(name: &str) -> std::path::PathBuf {
+    std::env::var_os("SystemRoot")
+        .map(std::path::PathBuf::from)
+        .filter(|root| root.is_absolute())
+        .unwrap_or_else(|| std::path::PathBuf::from(r"C:\Windows"))
+        .join("System32")
+        .join(name)
+}
+
+#[cfg(not(windows))]
+fn unix_system_command(name: &str) -> Result<std::path::PathBuf, String> {
+    // Resolve only fixed absolute paths. A renderer-controlled PATH must not
+    // decide which executable handles a path or network diagnostic request.
+    let candidates: &[&str] = match name {
+        #[cfg(target_os = "macos")]
+        "open" => &["/usr/bin/open"],
+        "xdg-open" => &["/usr/bin/xdg-open", "/bin/xdg-open"],
+        "ping" => &["/bin/ping", "/usr/bin/ping", "/sbin/ping"],
+        "pkill" => &["/usr/bin/pkill", "/bin/pkill"],
+        _ => return Err("不支持的系统命令".to_string()),
+    };
+    candidates
+        .iter()
+        .map(std::path::Path::new)
+        .find(|path| path.is_file())
+        .map(std::path::Path::to_path_buf)
+        .ok_or_else(|| format!("找不到系统命令: {}", name))
 }
 
 /// 应用状态包装器（用于 Tauri State）
@@ -27,7 +444,7 @@ pub struct AppState {
 // ==================== 大厅操作命令 ====================
 
 /// 创建大厅
-/// 
+///
 /// # 参数
 /// * `name` - 大厅名称
 /// * `password` - 大厅密码
@@ -35,7 +452,7 @@ pub struct AppState {
 /// * `player_id` - 玩家ID（由前端生成）
 /// * `server_node` - 服务器节点地址
 /// * `signaling_server` - 信令服务器地址
-/// 
+///
 /// # 返回
 /// * `Ok(Lobby)` - 成功创建的大厅信息
 /// * `Err(String)` - 错误信息
@@ -53,111 +470,106 @@ pub async fn create_lobby(
     state: State<'_, AppState>,
 ) -> Result<Lobby, String> {
     log::info!("收到创建大厅命令: name={}, player={}, player_id={}, signaling_server={}, use_domain={:?}, virtual_domain={:?}", name, player_name, player_id, signaling_server, use_domain, virtual_domain);
-    
+
     let core = state.core.lock().await;
-    
+
     // 更新应用状态为连接中
     core.set_state(CoreAppState::Connecting).await;
-    
+
     // 【关键修复】在这里读取配置，避免在 start_easytier 中再次获取 core 的锁
     let (global_config, lobby_config) = {
         let config_manager = core.get_config_manager();
         let cfg_mgr = config_manager.lock().await;
         let user_config = cfg_mgr.get_config();
-        
+
         let global_cfg = user_config.global_easytier_advanced_config.clone();
         let lobby_cfg = user_config.lobby_easytier_advanced_config.clone();
-        
+
         (global_cfg, lobby_cfg)
     };
-    
+
     // 获取各个服务的引用
     let lobby_manager = core.get_lobby_manager();
     let network_service = core.get_network_service();
     let file_transfer = core.get_file_transfer();
     let chat_service = core.get_chat_service();
-    
+
     // 释放 core 的锁，避免死锁
     drop(core);
-    
+
     // 创建大厅
     let mut lobby_mgr = lobby_manager.lock().await;
     let network_svc = network_service.lock().await;
-    
-    match lobby_mgr.create_lobby_with_config(
-        name,
-        password,
-        player_name.clone(),
-        server_node,
-        signaling_server.clone(),
-        use_domain.unwrap_or(false),
-        virtual_domain,
-        &*network_svc,
-        &app_handle,
-        global_config,
-        lobby_config,
-    ).await {
+
+    match lobby_mgr
+        .create_lobby_with_config(
+            name,
+            password,
+            player_name.clone(),
+            server_node,
+            signaling_server.clone(),
+            use_domain.unwrap_or(false),
+            virtual_domain,
+            &*network_svc,
+            &app_handle,
+            global_config,
+            lobby_config,
+        )
+        .await
+    {
         Ok(lobby) => {
             log::info!("大厅创建成功: {}", lobby.name);
-            
+
             // 输出序列化后的JSON用于调试
             if let Ok(json) = serde_json::to_string(&lobby) {
                 log::info!("大厅JSON: {}", json);
             }
-            
+
             // 获取虚拟IP
             let virtual_ip = lobby.virtual_ip.clone();
             drop(lobby_mgr);
             drop(network_svc);
-            
+
             log::info!("使用前端提供的玩家ID: {}", player_id);
-            
+
             // 所有客户端都连接到官方 WebSockets 信令服务器 (wss://mctier.pmhs.top/signaling)
             log::info!("客户端将连接到官方 WebSockets 信令服务器: wss://mctier.pmhs.top/signaling");
-            
+
             // 不再在创建大厅时自动启动HTTP文件服务器
             // HTTP服务器将在第一次添加共享时按需启动
             log::info!("📝 HTTP文件服务器将在添加共享时按需启动");
             let ft_service = file_transfer.lock().await;
             ft_service.set_virtual_ip(virtual_ip.clone());
             drop(ft_service);
-            
-            // 启动P2P聊天服务器
-            log::info!("正在启动P2P聊天服务器...");
+
+            // 聊天服务必须等待信令服务器下发 lobby token 后才能启动。
             let chat_svc = chat_service.lock().await;
+            chat_svc.stop_server().await;
             chat_svc.set_virtual_ip(virtual_ip.clone());
-            match chat_svc.start_server().await {
-                Ok(_) => {
-                    log::info!("✅ P2P聊天服务器启动成功");
-                }
-                Err(e) => {
-                    log::error!("❌ P2P聊天服务器启动失败: {}", e);
-                }
-            }
             drop(chat_svc);
-            
+
             // 更新应用状态为在大厅中
             let core = state.core.lock().await;
             core.set_state(CoreAppState::InLobby).await;
             drop(core);
-            
+
             Ok(lobby)
         }
         Err(e) => {
             log::error!("创建大厅失败: {}", e);
-            
+
             // 更新应用状态为错误
             let core = state.core.lock().await;
             core.set_state(CoreAppState::Error(e.to_string())).await;
             drop(core);
-            
+
             Err(e.to_string())
         }
     }
 }
 
 /// 加入大厅
-/// 
+///
 /// # 参数
 /// * `name` - 大厅名称
 /// * `password` - 大厅密码
@@ -165,7 +577,7 @@ pub async fn create_lobby(
 /// * `player_id` - 玩家ID（由前端生成）
 /// * `server_node` - 服务器节点地址
 /// * `signaling_server` - 信令服务器地址
-/// 
+///
 /// # 返回
 /// * `Ok(Lobby)` - 成功加入的大厅信息
 /// * `Err(String)` - 错误信息
@@ -183,24 +595,24 @@ pub async fn join_lobby(
     state: State<'_, AppState>,
 ) -> Result<Lobby, String> {
     log::info!("收到加入大厅命令: name={}, player={}, player_id={}, signaling_server={}, use_domain={:?}, virtual_domain={:?}", name, player_name, player_id, signaling_server, use_domain, virtual_domain);
-    
+
     let core = state.core.lock().await;
-    
+
     // 更新应用状态为连接中
     core.set_state(CoreAppState::Connecting).await;
-    
+
     // 【关键修复】在这里读取配置，避免在 start_easytier 中再次获取 core 的锁
     let (global_config, lobby_config) = {
         let config_manager = core.get_config_manager();
         let cfg_mgr = config_manager.lock().await;
         let user_config = cfg_mgr.get_config();
-        
+
         let global_cfg = user_config.global_easytier_advanced_config.clone();
         let lobby_cfg = user_config.lobby_easytier_advanced_config.clone();
-        
+
         (global_cfg, lobby_cfg)
     };
-    
+
     // 获取各个服务的引用
     let lobby_manager = core.get_lobby_manager();
     let network_service = core.get_network_service();
@@ -208,30 +620,33 @@ pub async fn join_lobby(
     let p2p_signaling = core.get_p2p_signaling();
     let file_transfer = core.get_file_transfer();
     let chat_service = core.get_chat_service();
-    
+
     // 释放 core 的锁，避免死锁
     drop(core);
-    
+
     // 加入大厅
     let mut lobby_mgr = lobby_manager.lock().await;
     let network_svc = network_service.lock().await;
-    
-    match lobby_mgr.join_lobby_with_config(
-        name,
-        password,
-        player_name.clone(),
-        server_node,
-        signaling_server.clone(),
-        use_domain.unwrap_or(false),
-        virtual_domain,
-        &*network_svc,
-        &app_handle,
-        global_config,
-        lobby_config,
-    ).await {
+
+    match lobby_mgr
+        .join_lobby_with_config(
+            name,
+            password,
+            player_name.clone(),
+            server_node,
+            signaling_server.clone(),
+            use_domain.unwrap_or(false),
+            virtual_domain,
+            &*network_svc,
+            &app_handle,
+            global_config,
+            lobby_config,
+        )
+        .await
+    {
         Ok(lobby) => {
             log::info!("成功加入大厅: {}", lobby.name);
-            
+
             // 初始化语音服务
             let voice_svc = voice_service.lock().await;
             if let Err(e) = voice_svc.initialize().await {
@@ -239,21 +654,24 @@ pub async fn join_lobby(
                 // 语音服务失败不应该阻止加入大厅
             }
             drop(voice_svc);
-            
+
             // 获取虚拟IP（用于P2P信令服务和HTTP文件服务器）
             let virtual_ip = lobby.virtual_ip.clone();
             drop(lobby_mgr);
             drop(network_svc);
-            
+
             log::info!("使用前端提供的玩家ID: {}", player_id);
-            
+
             // 所有客户端都连接到官方 WebSockets 信令服务器 (wss://mctier.pmhs.top/signaling)
             log::info!("客户端将连接到官方 WebSockets 信令服务器: wss://mctier.pmhs.top/signaling");
-            
+
             // 启动P2P信令服务
             log::info!("正在启动P2P信令服务（加入大厅）...");
             let p2p_svc = p2p_signaling.lock().await;
-            match p2p_svc.start(player_id, player_name, virtual_ip.clone()).await {
+            match p2p_svc
+                .start(player_id, player_name, virtual_ip.clone())
+                .await
+            {
                 Ok(_) => {
                     log::info!("✅ P2P信令服务启动成功（加入大厅）");
                 }
@@ -262,110 +680,109 @@ pub async fn join_lobby(
                     // P2P信令服务启动失败应该返回错误，因为没有它就无法发现其他玩家
                     drop(p2p_svc);
                     let core = state.core.lock().await;
-                    core.set_state(CoreAppState::Error(format!("P2P信令服务启动失败: {}", e))).await;
+                    core.set_state(CoreAppState::Error(format!("P2P信令服务启动失败: {}", e)))
+                        .await;
                     drop(core);
                     return Err(format!("P2P信令服务启动失败: {}", e));
                 }
             }
             drop(p2p_svc);
-            
+
             // 不再在加入大厅时自动启动HTTP文件服务器
             // HTTP服务器将在第一次添加共享时按需启动
             log::info!("📝 HTTP文件服务器将在添加共享时按需启动");
             let ft_service = file_transfer.lock().await;
             ft_service.set_virtual_ip(virtual_ip.clone());
             drop(ft_service);
-            
-            // 启动P2P聊天服务器
-            log::info!("正在启动P2P聊天服务器...");
+
+            // 聊天服务必须等待信令服务器下发 lobby token 后才能启动。
             let chat_svc = chat_service.lock().await;
+            chat_svc.stop_server().await;
             chat_svc.set_virtual_ip(virtual_ip.clone());
-            match chat_svc.start_server().await {
-                Ok(_) => {
-                    log::info!("✅ P2P聊天服务器启动成功");
-                }
-                Err(e) => {
-                    log::error!("❌ P2P聊天服务器启动失败: {}", e);
-                }
-            }
             drop(chat_svc);
-            
+
             // 更新应用状态为在大厅中
             let core = state.core.lock().await;
             core.set_state(CoreAppState::InLobby).await;
             drop(core);
-            
+
             Ok(lobby)
         }
         Err(e) => {
             log::error!("加入大厅失败: {}", e);
-            
+
             // 更新应用状态为错误
             let core = state.core.lock().await;
             core.set_state(CoreAppState::Error(e.to_string())).await;
             drop(core);
-            
+
             Err(e.to_string())
         }
     }
 }
 
 /// 退出大厅
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 成功退出
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn leave_lobby(state: State<'_, AppState>) -> Result<(), String> {
     log::info!("收到退出大厅命令");
-    
+
     let core = state.core.lock().await;
-    
+
     // 获取各个服务的引用
     let lobby_manager = core.get_lobby_manager();
     let network_service = core.get_network_service();
     let voice_service = core.get_voice_service();
     let p2p_signaling = core.get_p2p_signaling();
     let file_transfer = core.get_file_transfer();
-    
+    let chat_service = core.get_chat_service();
+
     // 【修复】尽早释放 core 锁，避免在数秒级的 stop_easytier（netsh/pnputil/PowerShell）
     // 期间一直占用 core 锁，导致其它命令阻塞、界面卡死
     drop(core);
-    
+
+    // 先撤销聊天 token、身份映射和历史，再停止虚拟网络。
+    let chat_svc = chat_service.lock().await;
+    chat_svc.stop_server().await;
+    drop(chat_svc);
+
     // 停止HTTP文件服务器
     let ft_service = file_transfer.lock().await;
     ft_service.stop_server().await;
     drop(ft_service);
-    
+
     // 停止P2P信令服务
     let p2p_svc = p2p_signaling.lock().await;
     if let Err(e) = p2p_svc.stop().await {
         log::warn!("停止P2P信令服务失败: {}", e);
     }
     drop(p2p_svc);
-    
+
     // 清理语音服务
     let voice_svc = voice_service.lock().await;
     if let Err(e) = voice_svc.cleanup().await {
         log::warn!("清理语音服务时发生错误: {}", e);
     }
     drop(voice_svc);
-    
+
     // 退出大厅
     let mut lobby_mgr = lobby_manager.lock().await;
     let network_svc = network_service.lock().await;
-    
+
     match lobby_mgr.leave_lobby(&*network_svc).await {
         Ok(_) => {
             log::info!("成功退出大厅");
             drop(lobby_mgr);
             drop(network_svc);
-            
+
             // 更新应用状态为空闲（重新短暂加锁）
             let core = state.core.lock().await;
             core.set_state(CoreAppState::Idle).await;
             drop(core);
-            
+
             Ok(())
         }
         Err(e) => {
@@ -378,29 +795,26 @@ pub async fn leave_lobby(state: State<'_, AppState>) -> Result<(), String> {
 // ==================== 语音控制命令 ====================
 
 /// 切换麦克风状态
-/// 
+///
 /// # 返回
 /// * `Ok(bool)` - 新的麦克风状态（true=开启，false=关闭）
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn toggle_mic(
-    state: State<'_, AppState>,
-    app: tauri::AppHandle,
-) -> Result<bool, String> {
+pub async fn toggle_mic(state: State<'_, AppState>, app: tauri::AppHandle) -> Result<bool, String> {
     log::info!("收到切换麦克风命令");
-    
+
     let core = state.core.lock().await;
-    
+
     // 使用 AppCore 的 toggle_mic 方法，它会正确处理状态切换
     match core.toggle_mic().await {
         Ok(new_state) => {
             log::info!("麦克风状态已切换: {}", new_state);
-            
+
             // 发送事件到前端更新UI
             if let Err(e) = app.emit("mic-toggled", new_state) {
                 log::error!("发送麦克风状态事件失败: {}", e);
             }
-            
+
             Ok(new_state)
         }
         Err(e) => {
@@ -437,8 +851,8 @@ pub async fn set_mic_enabled(
 pub fn open_microphone_privacy_settings() -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
-        std::process::Command::new("cmd")
-            .args(["/C", "start", "", "ms-settings:privacy-microphone"])
+        std::process::Command::new(windows_system_command("explorer.exe"))
+            .arg("ms-settings:privacy-microphone")
             .spawn()
             .map_err(|e| e.to_string())?;
         return Ok(());
@@ -446,7 +860,7 @@ pub fn open_microphone_privacy_settings() -> Result<(), String> {
 
     #[cfg(target_os = "macos")]
     {
-        std::process::Command::new("open")
+        std::process::Command::new(unix_system_command("open")?)
             .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
             .spawn()
             .map_err(|e| e.to_string())?;
@@ -455,7 +869,10 @@ pub fn open_microphone_privacy_settings() -> Result<(), String> {
 
     #[cfg(target_os = "linux")]
     {
-        return Err("当前 Linux 桌面环境无法自动定位麦克风权限页，请在系统设置中手动允许 MCTier 使用麦克风".to_string());
+        return Err(
+            "当前 Linux 桌面环境无法自动定位麦克风权限页，请在系统设置中手动允许 MCTier 使用麦克风"
+                .to_string(),
+        );
     }
 
     #[allow(unreachable_code)]
@@ -488,11 +905,11 @@ pub fn reset_microphone_permission(app: tauri::AppHandle) -> Result<(), String> 
 }
 
 /// 静音或取消静音指定玩家
-/// 
+///
 /// # 参数
 /// * `player_id` - 玩家 ID
 /// * `muted` - true=静音，false=取消静音
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 操作成功
 /// * `Err(String)` - 错误信息
@@ -503,11 +920,11 @@ pub async fn mute_player(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     log::info!("收到静音玩家命令: player_id={}, muted={}", player_id, muted);
-    
+
     let core = state.core.lock().await;
     let voice_service = core.get_voice_service();
     let voice_svc = voice_service.lock().await;
-    
+
     match voice_svc.mute_player(&player_id, muted).await {
         Ok(_) => {
             log::info!("玩家 {} 静音状态已更新: {}", player_id, muted);
@@ -521,21 +938,21 @@ pub async fn mute_player(
 }
 
 /// 全局静音或取消静音所有玩家
-/// 
+///
 /// # 参数
 /// * `muted` - true=静音所有玩家，false=取消静音所有玩家
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 操作成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn mute_all(muted: bool, state: State<'_, AppState>) -> Result<(), String> {
     log::info!("收到全局静音命令: muted={}", muted);
-    
+
     let core = state.core.lock().await;
     let voice_service = core.get_voice_service();
     let voice_svc = voice_service.lock().await;
-    
+
     match voice_svc.mute_all(muted).await {
         Ok(_) => {
             log::info!("全局静音状态已更新: {}", muted);
@@ -551,47 +968,47 @@ pub async fn mute_all(muted: bool, state: State<'_, AppState>) -> Result<(), Str
 // ==================== 配置管理命令 ====================
 
 /// 获取用户配置
-/// 
+///
 /// # 返回
 /// * `Ok(UserConfig)` - 用户配置
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn get_config(state: State<'_, AppState>) -> Result<UserConfig, String> {
     log::info!("收到获取配置命令");
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let config_mgr = config_manager.lock().await;
-    
+
     let config = config_mgr.get_config_clone();
-    
+
     log::debug!("返回配置: {:?}", config);
-    
+
     Ok(config)
 }
 
 /// 更新用户配置
-/// 
+///
 /// # 参数
 /// * `config` - 新的用户配置
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 更新成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn update_config(
-    config: UserConfig,
-    state: State<'_, AppState>,
-) -> Result<(), String> {
+pub async fn update_config(config: UserConfig, state: State<'_, AppState>) -> Result<(), String> {
     log::info!("收到更新配置命令");
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut config_mgr = config_manager.lock().await;
-    
-    match config_mgr.update_config(|cfg| {
-        *cfg = config.clone();
-    }).await {
+
+    match config_mgr
+        .update_config(|cfg| {
+            *cfg = config.clone();
+        })
+        .await
+    {
         Ok(_) => {
             log::info!("配置已更新");
             Ok(())
@@ -604,24 +1021,21 @@ pub async fn update_config(
 }
 
 /// 保存窗口透明度
-/// 
+///
 /// # 参数
 /// * `opacity` - 透明度值 (0.0-1.0)
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 保存成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn save_opacity(
-    opacity: f64,
-    state: State<'_, AppState>,
-) -> Result<(), String> {
+pub async fn save_opacity(opacity: f64, state: State<'_, AppState>) -> Result<(), String> {
     log::info!("收到保存透明度命令: {}", opacity);
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut config_mgr = config_manager.lock().await;
-    
+
     match config_mgr.set_opacity(opacity).await {
         Ok(_) => {
             log::info!("透明度已保存: {}", opacity);
@@ -637,27 +1051,27 @@ pub async fn save_opacity(
 // ==================== 系统信息命令 ====================
 
 /// 获取可用的音频设备列表
-/// 
+///
 /// # 返回
 /// * `Ok(Vec<AudioDevice>)` - 音频设备列表
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn get_audio_devices(state: State<'_, AppState>) -> Result<Vec<AudioDevice>, String> {
     log::info!("收到获取音频设备命令");
-    
+
     let core = state.core.lock().await;
     let voice_service = core.get_voice_service();
     let voice_svc = voice_service.lock().await;
-    
+
     let devices = voice_svc.get_audio_devices().await;
-    
+
     log::info!("返回 {} 个音频设备", devices.len());
-    
+
     Ok(devices)
 }
 
 /// 获取当前应用状态
-/// 
+///
 /// # 返回
 /// * `Ok(String)` - 应用状态的字符串表示
 /// * `Err(String)` - 错误信息
@@ -669,45 +1083,45 @@ pub async fn get_app_state(state: State<'_, AppState>) -> Result<String, String>
 }
 
 /// 获取当前大厅信息
-/// 
+///
 /// # 返回
 /// * `Ok(Option<Lobby>)` - 当前大厅信息，如果未加入大厅则返回 None
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn get_current_lobby(state: State<'_, AppState>) -> Result<Option<Lobby>, String> {
     log::info!("收到获取当前大厅命令");
-    
+
     let core = state.core.lock().await;
     let lobby_manager = core.get_lobby_manager();
     let lobby_mgr = lobby_manager.lock().await;
-    
+
     let lobby = lobby_mgr.get_current_lobby().cloned();
-    
+
     Ok(lobby)
 }
 
 /// 获取玩家列表
-/// 
+///
 /// # 返回
 /// * `Ok(Vec<Player>)` - 玩家列表
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn get_players(state: State<'_, AppState>) -> Result<Vec<Player>, String> {
     log::info!("收到获取玩家列表命令");
-    
+
     let core = state.core.lock().await;
     let lobby_manager = core.get_lobby_manager();
     let lobby_mgr = lobby_manager.lock().await;
-    
+
     let players = lobby_mgr.get_players();
-    
+
     log::info!("返回 {} 个玩家", players.len());
-    
+
     Ok(players)
 }
 
 /// 获取麦克风状态
-/// 
+///
 /// # 返回
 /// * `Ok(bool)` - 麦克风状态（true=开启，false=关闭）
 /// * `Err(String)` - 错误信息
@@ -716,14 +1130,14 @@ pub async fn get_mic_status(state: State<'_, AppState>) -> Result<bool, String> 
     let core = state.core.lock().await;
     let voice_service = core.get_voice_service();
     let voice_svc = voice_service.lock().await;
-    
+
     let status = voice_svc.is_mic_enabled();
-    
+
     Ok(status)
 }
 
 /// 获取全局静音状态
-/// 
+///
 /// # 返回
 /// * `Ok(bool)` - 全局静音状态（true=静音，false=未静音）
 /// * `Err(String)` - 错误信息
@@ -732,17 +1146,17 @@ pub async fn get_global_mute_status(state: State<'_, AppState>) -> Result<bool, 
     let core = state.core.lock().await;
     let voice_service = core.get_voice_service();
     let voice_svc = voice_service.lock().await;
-    
+
     let status = voice_svc.is_global_muted();
-    
+
     Ok(status)
 }
 
 /// 检查玩家是否被静音
-/// 
+///
 /// # 参数
 /// * `player_id` - 玩家 ID
-/// 
+///
 /// # 返回
 /// * `Ok(bool)` - 是否被静音（true=静音，false=未静音）
 /// * `Err(String)` - 错误信息
@@ -754,20 +1168,20 @@ pub async fn is_player_muted(
     let core = state.core.lock().await;
     let voice_service = core.get_voice_service();
     let voice_svc = voice_service.lock().await;
-    
+
     let is_muted = voice_svc.is_player_muted(&player_id).await;
-    
+
     Ok(is_muted)
 }
 
 /// 保存窗口位置
-/// 
+///
 /// # 参数
 /// * `x` - X 坐标
 /// * `y` - Y 坐标
 /// * `width` - 窗口宽度
 /// * `height` - 窗口高度
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 保存成功
 /// * `Err(String)` - 错误信息
@@ -780,43 +1194,56 @@ pub async fn save_window_position(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     use crate::modules::config_manager::WindowPosition;
-    
-    log::info!("保存窗口位置: x={}, y={}, width={}, height={}", x, y, width, height);
-    
+
+    log::info!(
+        "保存窗口位置: x={}, y={}, width={}, height={}",
+        x,
+        y,
+        width,
+        height
+    );
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut cfg_mgr = config_manager.lock().await;
-    
+
     // 检查是否启用了记住窗口位置
-    let remember = cfg_mgr.get_config().remember_window_position.unwrap_or(false);
-    
+    let remember = cfg_mgr
+        .get_config()
+        .remember_window_position
+        .unwrap_or(false);
+
     if remember {
-        let position = WindowPosition { x, y, width, height };
-        cfg_mgr.set_window_position(position).await
+        let position = WindowPosition {
+            x,
+            y,
+            width,
+            height,
+        };
+        cfg_mgr
+            .set_window_position(position)
+            .await
             .map_err(|e| format!("保存窗口位置失败: {}", e))?;
         log::info!("窗口位置已保存");
     } else {
         log::debug!("未启用记住窗口位置，跳过保存");
     }
-    
+
     Ok(())
 }
 
 /// 退出应用程序
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 退出成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn exit_app(
-    state: State<'_, AppState>,
-    app: tauri::AppHandle,
-) -> Result<(), String> {
+pub async fn exit_app(state: State<'_, AppState>, app: tauri::AppHandle) -> Result<(), String> {
     log::info!("收到退出应用命令");
-    
+
     // 先清理资源
     let core = state.core.lock().await;
-    
+
     // 如果在大厅中，先退出大厅
     let lobby_manager = core.get_lobby_manager();
     let lobby_mgr = lobby_manager.lock().await;
@@ -824,14 +1251,14 @@ pub async fn exit_app(
         drop(lobby_mgr);
         let network_service = core.get_network_service();
         let voice_service = core.get_voice_service();
-        
+
         // 清理语音服务
         let voice_svc = voice_service.lock().await;
         if let Err(e) = voice_svc.cleanup().await {
             log::warn!("清理语音服务时发生错误: {}", e);
         }
         drop(voice_svc);
-        
+
         // 退出大厅
         let mut lobby_mgr = lobby_manager.lock().await;
         let network_svc = network_service.lock().await;
@@ -839,19 +1266,19 @@ pub async fn exit_app(
             log::warn!("退出大厅时发生错误: {}", e);
         }
     }
-    
+
     drop(core);
-    
+
     log::info!("资源清理完成，正在退出应用...");
-    
+
     // 退出应用
     app.exit(0);
-    
+
     Ok(())
 }
 
 /// 获取网络连接状态
-/// 
+///
 /// # 返回
 /// * `Ok(String)` - 连接状态的 JSON 字符串
 /// * `Err(String)` - 错误信息
@@ -860,9 +1287,9 @@ pub async fn get_network_status(state: State<'_, AppState>) -> Result<String, St
     let core = state.core.lock().await;
     let network_service = core.get_network_service();
     let network_svc = network_service.lock().await;
-    
+
     let status = network_svc.check_connection().await;
-    
+
     match serde_json::to_string(&status) {
         Ok(json) => Ok(json),
         Err(e) => Err(format!("序列化连接状态失败: {}", e)),
@@ -870,7 +1297,7 @@ pub async fn get_network_status(state: State<'_, AppState>) -> Result<String, St
 }
 
 /// 获取虚拟 IP 地址
-/// 
+///
 /// # 返回
 /// * `Ok(Option<String>)` - 虚拟 IP 地址，如果未连接则返回 None
 /// * `Err(String)` - 错误信息
@@ -879,9 +1306,9 @@ pub async fn get_virtual_ip(state: State<'_, AppState>) -> Result<Option<String>
     let core = state.core.lock().await;
     let network_service = core.get_network_service();
     let network_svc = network_service.lock().await;
-    
+
     let ip = network_svc.get_virtual_ip().await;
-    
+
     Ok(ip)
 }
 
@@ -924,8 +1351,9 @@ pub async fn get_peer_connection_types(
         None => return Ok(vec![]),
     };
 
-    let cli_path = crate::modules::resource_manager::ResourceManager::get_easytier_cli_path(&app_handle)
-        .map_err(|e| format!("获取 easytier-cli 失败: {}", e))?;
+    let cli_path =
+        crate::modules::resource_manager::ResourceManager::get_easytier_cli_path(&app_handle)
+            .map_err(|e| format!("获取 easytier-cli 失败: {}", e))?;
 
     let mut cmd = tokio::process::Command::new(&cli_path);
     cmd.args(["-p", &format!("127.0.0.1:{}", port), "-o", "json", "peer"]);
@@ -943,7 +1371,8 @@ pub async fn get_peer_connection_types(
         return Ok(vec![]);
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or(serde_json::Value::Null);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).unwrap_or(serde_json::Value::Null);
 
     // 递归收集所有含 ipv4 + cost 的对象（兼容单/多实例的 JSON 结构）
     let mut result: Vec<PeerConnType> = Vec::new();
@@ -955,15 +1384,23 @@ pub async fn get_peer_connection_types(
                 let cost = map.get("cost").and_then(|x| x.as_str());
                 if let (false, Some(cost)) = (ip.is_empty(), cost) {
                     if !cost.eq_ignore_ascii_case("local") {
-                        let conn = if cost.eq_ignore_ascii_case("p2p") { "p2p" } else { "relay" };
+                        let conn = if cost.eq_ignore_ascii_case("p2p") {
+                            "p2p"
+                        } else {
+                            "relay"
+                        };
                         // 从 stats 提取延迟/收发字节/丢包（字段名兼容大小写差异）
                         let stats = map.get("stats");
                         let latency_ms = stats
                             .and_then(|s| s.get("latency_us"))
                             .and_then(|v| v.as_u64())
                             .map(|us| us / 1000);
-                        let rx_bytes = stats.and_then(|s| s.get("rx_bytes")).and_then(|v| v.as_u64());
-                        let tx_bytes = stats.and_then(|s| s.get("tx_bytes")).and_then(|v| v.as_u64());
+                        let rx_bytes = stats
+                            .and_then(|s| s.get("rx_bytes"))
+                            .and_then(|v| v.as_u64());
+                        let tx_bytes = stats
+                            .and_then(|s| s.get("tx_bytes"))
+                            .and_then(|v| v.as_u64());
                         let loss_rate = map
                             .get("loss_rate")
                             .and_then(|v| v.as_f64())
@@ -994,42 +1431,36 @@ pub async fn get_peer_connection_types(
 // ==================== 窗口控制命令 ====================
 
 /// 设置窗口置顶状态
-/// 
+///
 /// # 参数
 /// * `always_on_top` - true=置顶，false=取消置顶
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 操作成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn set_always_on_top(
-    always_on_top: bool,
-    window: tauri::Window,
-) -> Result<(), String> {
+pub async fn set_always_on_top(always_on_top: bool, window: tauri::Window) -> Result<(), String> {
     log::info!("设置窗口置顶状态: {}", always_on_top);
-    
+
     window
         .set_always_on_top(always_on_top)
         .map_err(|e| format!("设置窗口置顶失败: {}", e))?;
-    
+
     Ok(())
 }
 
 /// 切换迷你模式
-/// 
+///
 /// # 参数
 /// * `mini_mode` - true=迷你模式，false=正常模式
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 操作成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn toggle_mini_mode(
-    mini_mode: bool,
-    window: tauri::Window,
-) -> Result<(), String> {
+pub async fn toggle_mini_mode(mini_mode: bool, window: tauri::Window) -> Result<(), String> {
     log::info!("切换迷你模式: {}", mini_mode);
-    
+
     if mini_mode {
         // 迷你模式：小窗口 + 置顶
         window
@@ -1038,11 +1469,11 @@ pub async fn toggle_mini_mode(
                 height: 480,
             }))
             .map_err(|e| format!("设置窗口大小失败: {}", e))?;
-        
+
         window
             .set_always_on_top(true)
             .map_err(|e| format!("设置窗口置顶失败: {}", e))?;
-        
+
         window
             .set_resizable(false)
             .map_err(|e| format!("设置窗口不可调整大小失败: {}", e))?;
@@ -1054,32 +1485,29 @@ pub async fn toggle_mini_mode(
                 height: 700,
             }))
             .map_err(|e| format!("设置窗口大小失败: {}", e))?;
-        
+
         window
             .set_always_on_top(false)
             .map_err(|e| format!("取消窗口置顶失败: {}", e))?;
-        
+
         window
             .set_resizable(true)
             .map_err(|e| format!("设置窗口可调整大小失败: {}", e))?;
     }
-    
+
     Ok(())
 }
 
 /// 设置窗口透明度
-/// 
+///
 /// # 参数
 /// * `opacity` - 透明度值（0.0-1.0）
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 操作成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn set_window_opacity(
-    opacity: f64,
-    window: tauri::Window,
-) -> Result<(), String> {
+pub async fn set_window_opacity(opacity: f64, window: tauri::Window) -> Result<(), String> {
     let clamped_opacity = opacity.max(0.3).min(1.0);
 
     // 注意：不再使用 WS_EX_LAYERED + SetLayeredWindowAttributes(LWA_ALPHA)。
@@ -1093,14 +1521,13 @@ pub async fn set_window_opacity(
     Ok(())
 }
 
-
 // ==================== WebRTC 语音通信命令 ====================
 
 /// 发送信令消息
-/// 
+///
 /// # 参数
 /// * `message` - 信令消息内容（JSON格式）
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 发送成功
 /// * `Err(String)` - 错误信息
@@ -1110,53 +1537,73 @@ pub async fn send_signaling_message(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     log::info!("收到信令消息: {:?}", message);
-    
+
     let core = state.core.lock().await;
     let p2p_signaling = core.get_p2p_signaling();
     let p2p_svc = p2p_signaling.lock().await;
-    
+
     // 解析信令消息
     let msg_type = message.get("type").and_then(|v| v.as_str()).unwrap_or("");
-    let from = message.get("from").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let from = message
+        .get("from")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
     let to = message.get("to").and_then(|v| v.as_str());
-    
+
     let p2p_message = match msg_type {
         "offer" => {
-            let sdp = message.get("sdp").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let sdp = message
+                .get("sdp")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
             crate::modules::p2p_signaling::P2PMessage::Offer { from, sdp }
         }
         "answer" => {
-            let sdp = message.get("sdp").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let sdp = message
+                .get("sdp")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
             crate::modules::p2p_signaling::P2PMessage::Answer { from, sdp }
         }
         "ice-candidate" => {
-            let candidate = message.get("candidate").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let candidate = message
+                .get("candidate")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
             crate::modules::p2p_signaling::P2PMessage::IceCandidate { from, candidate }
         }
         _ => {
             return Err("未知的信令消息类型".to_string());
         }
     };
-    
+
     // 发送消息
     if let Some(target) = to {
-        p2p_svc.send_to_player(target, p2p_message).await
+        p2p_svc
+            .send_to_player(target, p2p_message)
+            .await
             .map_err(|e| e.to_string())?;
     } else {
-        p2p_svc.broadcast_to_all(p2p_message).await
+        p2p_svc
+            .broadcast_to_all(p2p_message)
+            .await
             .map_err(|e| e.to_string())?;
     }
-    
+
     log::debug!("信令消息已处理");
     Ok(())
 }
 
 /// 广播状态更新
-/// 
+///
 /// # 参数
 /// * `player_id` - 玩家ID
 /// * `mic_enabled` - 麦克风状态
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 广播成功
 /// * `Err(String)` - 错误信息
@@ -1167,31 +1614,33 @@ pub async fn broadcast_status_update(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     log::info!("广播状态更新: player={}, mic={}", player_id, mic_enabled);
-    
+
     let core = state.core.lock().await;
     let p2p_signaling = core.get_p2p_signaling();
     let p2p_svc = p2p_signaling.lock().await;
-    
+
     // 创建状态更新消息
     let message = crate::modules::p2p_signaling::P2PMessage::StatusUpdate {
         player_id,
         mic_enabled,
     };
-    
+
     // 广播消息
-    p2p_svc.broadcast_to_all(message).await
+    p2p_svc
+        .broadcast_to_all(message)
+        .await
         .map_err(|e| e.to_string())?;
-    
+
     log::debug!("状态更新已广播");
     Ok(())
 }
 
 /// 发送心跳
-/// 
+///
 /// # 参数
 /// * `player_id` - 玩家ID
 /// * `timestamp` - 时间戳
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 发送成功
 /// * `Err(String)` - 错误信息
@@ -1202,36 +1651,37 @@ pub async fn send_heartbeat(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     log::debug!("收到心跳: player={}, timestamp={}", player_id, timestamp);
-    
+
     let core = state.core.lock().await;
     let voice_service = core.get_voice_service();
     let voice_svc = voice_service.lock().await;
-    
-    voice_svc.send_heartbeat(&player_id).await
+
+    voice_svc
+        .send_heartbeat(&player_id)
+        .await
         .map_err(|e| e.to_string())?;
-    
+
     log::debug!("心跳已发送");
     Ok(())
 }
 
-
 // ==================== 网络管理命令 ====================
 
 /// 强制停止所有EasyTier进程
-/// 
+///
 /// 在创建或加入大厅前调用，确保没有残留的EasyTier进程
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 停止成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn force_stop_easytier(state: State<'_, AppState>) -> Result<(), String> {
     log::info!("🔧 收到强制停止EasyTier进程命令");
-    
+
     let core = state.core.lock().await;
     let network_service = core.get_network_service();
     let network_svc = network_service.lock().await;
-    
+
     // 调用NetworkService的stop_easytier方法
     // 该方法已经包含了完整的清理逻辑：
     // 1. 优雅关闭进程（SIGTERM）
@@ -1266,7 +1716,7 @@ pub async fn cancel_lobby_connecting() -> Result<(), String> {
     {
         const CREATE_NO_WINDOW: u32 = 0x08000000;
         for image in ["easytier-core.exe", "easytier-cli.exe"] {
-            let _ = tokio::process::Command::new("taskkill")
+            let _ = tokio::process::Command::new(windows_system_command("taskkill.exe"))
                 .args(["/F", "/IM", image])
                 .creation_flags(CREATE_NO_WINDOW)
                 .output()
@@ -1276,7 +1726,8 @@ pub async fn cancel_lobby_connecting() -> Result<(), String> {
 
     #[cfg(not(target_os = "windows"))]
     {
-        let _ = tokio::process::Command::new("pkill")
+        let pkill = unix_system_command("pkill")?;
+        let _ = tokio::process::Command::new(pkill)
             .args(["-9", "-f", "easytier-core"])
             .output()
             .await;
@@ -1289,38 +1740,38 @@ pub async fn cancel_lobby_connecting() -> Result<(), String> {
 // ==================== 网络诊断命令 ====================
 
 /// 检查虚拟网卡是否存在
-/// 
+///
 /// # 返回
 /// * `Ok(bool)` - true 表示虚拟网卡存在
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn check_virtual_adapter() -> Result<bool, String> {
     log::info!("检查虚拟网卡...");
-    
+
     #[cfg(windows)]
     {
-        use std::process::Command;
         use std::os::windows::process::CommandExt;
+        use std::process::Command;
         const CREATE_NO_WINDOW: u32 = 0x08000000;
-        
+
         // 使用 ipconfig 命令查找 EasyTier 创建的虚拟网卡
-        let output = Command::new("ipconfig")
+        let output = Command::new(windows_system_command("ipconfig.exe"))
             .arg("/all")
             .creation_flags(CREATE_NO_WINDOW)
             .output()
             .map_err(|e| format!("执行 ipconfig 失败: {}", e))?;
-        
+
         let output_str = String::from_utf8_lossy(&output.stdout);
-        
+
         // 查找包含 "EasyTier" 或 "WinTun" 的网卡
-        let has_adapter = output_str.contains("EasyTier") || 
-                         output_str.contains("WinTun") ||
-                         output_str.contains("wintun");
-        
+        let has_adapter = output_str.contains("EasyTier")
+            || output_str.contains("WinTun")
+            || output_str.contains("wintun");
+
         log::info!("虚拟网卡检查结果: {}", has_adapter);
         Ok(has_adapter)
     }
-    
+
     #[cfg(not(windows))]
     {
         // 非 Windows 平台暂不支持
@@ -1329,38 +1780,38 @@ pub async fn check_virtual_adapter() -> Result<bool, String> {
 }
 
 /// 检查防火墙规则
-/// 
+///
 /// # 返回
 /// * `Ok(bool)` - true 表示防火墙规则正常
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn check_firewall_rules() -> Result<bool, String> {
     log::info!("检查防火墙规则...");
-    
+
     #[cfg(windows)]
     {
-        use std::process::Command;
         use std::os::windows::process::CommandExt;
+        use std::process::Command;
         const CREATE_NO_WINDOW: u32 = 0x08000000;
-        
+
         // 检查 Windows 防火墙是否已存在 MCTier 的放行规则
         // 注意：必须与 add_firewall_rules 中添加的规则名保持一致
-        let output = Command::new("netsh")
+        let output = Command::new(windows_system_command("netsh.exe"))
             .args(&["advfirewall", "firewall", "show", "rule", "name=all"])
             .creation_flags(CREATE_NO_WINDOW)
             .output()
             .map_err(|e| format!("执行 netsh 失败: {}", e))?;
-        
+
         let output_str = String::from_utf8_lossy(&output.stdout);
-        
+
         // 检查是否存在 MCTier 自身添加的放行规则
         // add_firewall_rules 添加的规则名为：MCTier-in/-out、MCTier-EasyTier-in/-out
         let has_rules = output_str.contains("MCTier");
-        
+
         log::info!("防火墙规则检查结果: {}", has_rules);
         Ok(has_rules)
     }
-    
+
     #[cfg(not(windows))]
     {
         Ok(true)
@@ -1373,7 +1824,9 @@ pub async fn is_admin() -> bool {
     #[cfg(windows)]
     {
         use windows::Win32::Foundation::HANDLE;
-        use windows::Win32::Security::{GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY};
+        use windows::Win32::Security::{
+            GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+        };
         use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
         unsafe {
             let mut token: HANDLE = HANDLE::default();
@@ -1412,7 +1865,9 @@ pub async fn add_firewall_rules(app_handle: tauri::AppHandle) -> Result<String, 
         if let Ok(exe) = std::env::current_exe() {
             programs.push(("MCTier".to_string(), exe));
         }
-        if let Ok(et) = crate::modules::resource_manager::ResourceManager::get_easytier_path(&app_handle) {
+        if let Ok(et) =
+            crate::modules::resource_manager::ResourceManager::get_easytier_path(&app_handle)
+        {
             programs.push(("MCTier-EasyTier".to_string(), et));
         }
 
@@ -1427,15 +1882,24 @@ pub async fn add_firewall_rules(app_handle: tauri::AppHandle) -> Result<String, 
             for (suffix, dir) in [("-in", "in"), ("-out", "out")] {
                 let rule_name = format!("{}{}", base_name, suffix);
                 // 先删除同名旧规则避免重复堆积
-                let _ = tokio::process::Command::new("netsh")
-                    .args(&["advfirewall", "firewall", "delete", "rule", &format!("name={}", rule_name)])
+                let _ = tokio::process::Command::new(windows_system_command("netsh.exe"))
+                    .args(&[
+                        "advfirewall",
+                        "firewall",
+                        "delete",
+                        "rule",
+                        &format!("name={}", rule_name),
+                    ])
                     .creation_flags(CREATE_NO_WINDOW)
                     .output()
                     .await;
 
-                let output = tokio::process::Command::new("netsh")
+                let output = tokio::process::Command::new(windows_system_command("netsh.exe"))
                     .args(&[
-                        "advfirewall", "firewall", "add", "rule",
+                        "advfirewall",
+                        "firewall",
+                        "add",
+                        "rule",
                         &format!("name={}", rule_name),
                         &format!("dir={}", dir),
                         "action=allow",
@@ -1463,7 +1927,10 @@ pub async fn add_firewall_rules(app_handle: tauri::AppHandle) -> Result<String, 
             log::info!("✅ 已添加 {} 条防火墙放行规则", added);
             Ok(format!("已添加 {} 条防火墙放行规则", added))
         } else {
-            Err(format!("添加防火墙规则失败（可能需要管理员权限）: {}", last_err))
+            Err(format!(
+                "添加防火墙规则失败（可能需要管理员权限）: {}",
+                last_err
+            ))
         }
     }
     #[cfg(not(windows))]
@@ -1482,16 +1949,19 @@ pub async fn restart_as_admin(app_handle: tauri::AppHandle) -> Result<(), String
         const CREATE_NO_WINDOW: u32 = 0x08000000;
 
         let exe = std::env::current_exe().map_err(|e| format!("无法获取程序路径: {}", e))?;
-        let exe_str = exe.to_string_lossy().replace('\'', "''");
-
-        // 用 PowerShell 以管理员身份(RunAs)重新启动
-        let spawn = std::process::Command::new("powershell")
+        // Keep the executable path out of PowerShell source. Passing it via an
+        // environment variable prevents quote/command substitution when an
+        // installation directory contains PowerShell metacharacters.
+        let powershell = windows_system_command("WindowsPowerShell\\v1.0\\powershell.exe");
+        let spawn = std::process::Command::new(powershell)
             .args(&[
                 "-NoProfile",
-                "-WindowStyle", "Hidden",
+                "-WindowStyle",
+                "Hidden",
                 "-Command",
-                &format!("Start-Process -FilePath '{}' -Verb RunAs", exe_str),
+                "Start-Process -FilePath $env:MCTIER_EXE -Verb RunAs",
             ])
+            .env("MCTIER_EXE", &exe)
             .creation_flags(CREATE_NO_WINDOW)
             .spawn();
 
@@ -1512,56 +1982,64 @@ pub async fn restart_as_admin(app_handle: tauri::AppHandle) -> Result<(), String
         Err("当前平台不支持".to_string())
     }
 }
-/// 
+///
 /// # 参数
 /// * `ip` - 要 ping 的 IP 地址
-/// 
+///
 /// # 返回
 /// * `Ok(bool)` - true 表示可以 ping 通
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn ping_virtual_ip(ip: String) -> Result<bool, String> {
     log::info!("Ping 虚拟 IP: {}", ip);
-    
+
+    let target = ip
+        .parse::<std::net::IpAddr>()
+        .map_err(|_| "只允许 Ping 有效的 IP 地址".to_string())?;
+    if target.is_unspecified() || target.is_multicast() || target.is_loopback() {
+        return Err("不允许 Ping 未指定、组播或回环地址".to_string());
+    }
+    let target = target.to_string();
+
     use std::process::Command;
-    
+
     #[cfg(windows)]
     let output = {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x08000000;
-        Command::new("ping")
-            .args(&["-n", "2", "-w", "1000", &ip])
+        Command::new(windows_system_command("ping.exe"))
+            .args(["-n", "2", "-w", "1000", &target])
             .creation_flags(CREATE_NO_WINDOW)
             .output()
             .map_err(|e| format!("执行 ping 失败: {}", e))?
     };
-    
+
     #[cfg(not(windows))]
-    let output = Command::new("ping")
-        .args(&["-c", "2", "-W", "1", &ip])
+    let output = Command::new(unix_system_command("ping")?)
+        .args(["-c", "2", "-W", "1", &target])
         .output()
         .map_err(|e| format!("执行 ping 失败: {}", e))?;
-    
+
     let success = output.status.success();
     log::info!("Ping 结果: {}", success);
-    
+
     Ok(success)
 }
 
 /// 检查 UDP 端口是否可用
-/// 
+///
 /// # 参数
 /// * `port` - 要检查的端口号
-/// 
+///
 /// # 返回
 /// * `Ok(bool)` - true 表示端口可用
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn check_udp_port(port: u16) -> Result<bool, String> {
     log::info!("检查 UDP 端口: {}", port);
-    
+
     use std::net::UdpSocket;
-    
+
     // 尝试绑定端口
     match UdpSocket::bind(format!("0.0.0.0:{}", port)) {
         Ok(_) => {
@@ -1578,10 +2056,10 @@ pub async fn check_udp_port(port: u16) -> Result<bool, String> {
 // ==================== 系统设置命令 ====================
 
 /// 设置开机自启动
-/// 
+///
 /// # 参数
 /// * `enable` - true=启用自启动，false=禁用自启动
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 操作成功
 /// * `Err(String)` - 错误信息
@@ -1591,8 +2069,8 @@ pub async fn set_auto_start(enable: bool) -> Result<(), String> {
 
     #[cfg(windows)]
     {
-        use std::process::Command;
         use std::os::windows::process::CommandExt;
+        use std::process::Command;
         let app_name = "MCTier";
         let app_path = std::env::current_exe()
             .map_err(|e| format!("获取程序路径失败: {}", e))?
@@ -1600,27 +2078,20 @@ pub async fn set_auto_start(enable: bool) -> Result<(), String> {
             .replace("/", "\\");
 
         if enable {
-            // 获取exe所在目录
-            let exe_dir = std::path::Path::new(&app_path)
-                .parent()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_default();
-            
-            // 使用 PowerShell 的 -WindowStyle Hidden 参数实现完全无窗口启动
-            // 同时设置工作目录，确保便携版能找到资源文件
-            let reg_value = format!(
-                "powershell -WindowStyle Hidden -Command \"Set-Location '{}'; Start-Process '{}'\"",
-                exe_dir.replace("\\", "\\\\"),
-                app_path.replace("\\", "\\\\")
-            );
-            
-            let output = Command::new("reg")
+            // A quoted executable path is sufficient for a Run key. Avoid
+            // storing a PowerShell script in the registry value.
+            let reg_value = windows_run_value(&std::path::PathBuf::from(&app_path))?;
+
+            let output = Command::new(windows_system_command("reg.exe"))
                 .args([
                     "add",
                     "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
-                    "/v", app_name,
-                    "/t", "REG_SZ",
-                    "/d", &reg_value,
+                    "/v",
+                    app_name,
+                    "/t",
+                    "REG_SZ",
+                    "/d",
+                    &reg_value,
                     "/f",
                 ])
                 .creation_flags(0x08000000)
@@ -1636,11 +2107,12 @@ pub async fn set_auto_start(enable: bool) -> Result<(), String> {
             Ok(())
         } else {
             // 删除注册表项
-            let output = Command::new("reg")
+            let output = Command::new(windows_system_command("reg.exe"))
                 .args([
                     "delete",
                     "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
-                    "/v", app_name,
+                    "/v",
+                    app_name,
                     "/f",
                 ])
                 .creation_flags(0x08000000)
@@ -1650,7 +2122,7 @@ pub async fn set_auto_start(enable: bool) -> Result<(), String> {
             if !output.status.success() {
                 log::warn!("删除注册表开机自启项时出现警告（可能本就不存在）");
             }
-            
+
             log::info!("开机自启动已禁用");
             Ok(())
         }
@@ -1673,14 +2145,15 @@ pub async fn check_auto_start() -> Result<bool, String> {
 
     #[cfg(windows)]
     {
-        use std::process::Command;
         use std::os::windows::process::CommandExt;
+        use std::process::Command;
         let app_name = "MCTier";
-        let output = Command::new("reg")
+        let output = Command::new(windows_system_command("reg.exe"))
             .args([
                 "query",
                 "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
-                "/v", app_name,
+                "/v",
+                app_name,
             ])
             .creation_flags(0x08000000)
             .output()
@@ -1700,12 +2173,12 @@ pub async fn check_auto_start() -> Result<bool, String> {
 // ==================== Magic DNS 命令 ====================
 
 /// 添加玩家域名映射到hosts文件
-/// 
+///
 /// # 参数
 /// * `domain` - 域名（如：qyzz.mct.net）
 /// * `ip` - 虚拟IP地址
 /// * `state` - 应用状态
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 添加成功
 /// * `Err(String)` - 错误信息
@@ -1716,11 +2189,11 @@ pub async fn add_player_domain(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     log::info!("收到添加玩家域名映射命令: {} -> {}", domain, ip);
-    
+
     let core = state.core.lock().await;
     let lobby_manager = core.get_lobby_manager();
     let manager = lobby_manager.lock().await;
-    
+
     // 获取当前大厅信息
     let lobby_name = if let Some(lobby) = manager.get_current_lobby() {
         lobby.name.clone()
@@ -1728,41 +2201,46 @@ pub async fn add_player_domain(
         log::warn!("⚠️ 当前不在大厅中，无法添加域名映射");
         return Err("当前不在大厅中".to_string());
     };
-    
+
     // 获取或创建HostsManager
     let hosts_manager = if let Some(hm) = manager.get_hosts_manager() {
         // 已存在，直接使用
         hm.add_entry(&domain, &ip)
             .map_err(|e| format!("添加域名映射失败: {}", e))?;
-        
+
         log::info!("✅ 域名映射已添加: {} -> {}", domain, ip);
         Ok(())
     } else {
         // 不存在，动态创建
         log::info!("📝 HostsManager不存在，动态创建...");
         drop(manager); // 释放锁，以便调用set_hosts_manager
-        
+
         let new_hosts_manager = crate::modules::hosts_manager::HostsManager::new(&lobby_name);
-        new_hosts_manager.add_entry(&domain, &ip)
+        new_hosts_manager
+            .add_entry(&domain, &ip)
             .map_err(|e| format!("添加域名映射失败: {}", e))?;
-        
+
         // 重新获取锁并设置HostsManager
         let mut manager = lobby_manager.lock().await;
         manager.set_hosts_manager(Some(new_hosts_manager));
-        
-        log::info!("✅ 域名映射已添加（动态创建HostsManager）: {} -> {}", domain, ip);
+
+        log::info!(
+            "✅ 域名映射已添加（动态创建HostsManager）: {} -> {}",
+            domain,
+            ip
+        );
         Ok(())
     };
-    
+
     hosts_manager
 }
 
 /// 删除玩家域名映射
-/// 
+///
 /// # 参数
 /// * `domain` - 要删除的域名
 /// * `state` - 应用状态
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 删除成功
 /// * `Err(String)` - 错误信息
@@ -1772,16 +2250,17 @@ pub async fn remove_player_domain(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     log::info!("收到删除玩家域名映射命令: {}", domain);
-    
+
     let core = state.core.lock().await;
     let lobby_manager = core.get_lobby_manager();
     let manager = lobby_manager.lock().await;
-    
+
     // 获取HostsManager
     if let Some(hosts_manager) = manager.get_hosts_manager() {
-        hosts_manager.remove_entry(&domain)
+        hosts_manager
+            .remove_entry(&domain)
             .map_err(|e| format!("删除域名映射失败: {}", e))?;
-        
+
         log::info!("✅ 域名映射已删除: {}", domain);
         Ok(())
     } else {
@@ -1790,7 +2269,6 @@ pub async fn remove_player_domain(
         Ok(())
     }
 }
-
 
 // ==================== 文件共享操作命令 ====================
 
@@ -1818,9 +2296,9 @@ pub struct FileInfo {
 #[tauri::command]
 pub async fn get_folder_name(path: String) -> Result<String, String> {
     log::info!("获取文件夹名称: {}", path);
-    
-    let path_obj = Path::new(&path);
-    
+
+    let path_obj = require_existing_directory_grant(&path, PathAccess::ReadDirectory)?;
+
     if let Some(name) = path_obj.file_name() {
         if let Some(name_str) = name.to_str() {
             Ok(name_str.to_string())
@@ -1843,20 +2321,11 @@ pub async fn get_folder_name(path: String) -> Result<String, String> {
 #[tauri::command]
 pub async fn get_folder_info(path: String) -> Result<serde_json::Value, String> {
     log::info!("获取文件夹信息: {}", path);
-    
-    let path_obj = Path::new(&path);
-    
-    if !path_obj.exists() {
-        return Err("文件夹不存在".to_string());
-    }
-    
-    if !path_obj.is_dir() {
-        return Err("路径不是文件夹".to_string());
-    }
-    
-    let (file_count, total_size) = count_files_and_size(path_obj)
-        .map_err(|e| format!("统计文件失败: {}", e))?;
-    
+    let path_obj = require_existing_directory_grant(&path, PathAccess::ReadDirectory)?;
+
+    let (file_count, total_size) =
+        count_files_and_size(&path_obj).map_err(|e| format!("统计文件失败: {}", e))?;
+
     Ok(serde_json::json!({
         "fileCount": file_count,
         "totalSize": total_size,
@@ -1865,23 +2334,32 @@ pub async fn get_folder_info(path: String) -> Result<serde_json::Value, String> 
 
 /// 递归统计文件数量和总大小
 fn count_files_and_size(path: &Path) -> std::io::Result<(usize, u64)> {
-    let mut file_count = 0;
-    let mut total_size = 0;
-    
-    if path.is_file() {
+    let mut file_count: usize = 0;
+    let mut total_size: u64 = 0;
+
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Ok((0, 0));
+    }
+    if metadata.is_file() {
         file_count = 1;
-        total_size = path.metadata()?.len();
-    } else if path.is_dir() {
+        total_size = metadata.len();
+    } else if metadata.is_dir() {
         for entry in std::fs::read_dir(path)? {
             let entry = entry?;
             let entry_path = entry.path();
-            
+
+            let entry_metadata = std::fs::symlink_metadata(&entry_path)?;
+            if is_symlink_or_reparse_point(&entry_metadata) {
+                continue;
+            }
+
             let (count, size) = count_files_and_size(&entry_path)?;
-            file_count += count;
-            total_size += size;
+            file_count = file_count.saturating_add(count);
+            total_size = total_size.saturating_add(size);
         }
     }
-    
+
     Ok((file_count, total_size))
 }
 
@@ -1896,56 +2374,48 @@ fn count_files_and_size(path: &Path) -> std::io::Result<(usize, u64)> {
 #[tauri::command]
 pub async fn list_directory_files(path: String) -> Result<Vec<FileInfo>, String> {
     log::info!("📂 列出目录文件: {}", path);
-    
-    let path_obj = Path::new(&path);
-    
-    if !path_obj.exists() {
-        log::error!("❌ 目录不存在: {}", path);
-        return Err("目录不存在".to_string());
-    }
-    
-    if !path_obj.is_dir() {
-        log::error!("❌ 路径不是目录: {}", path);
-        return Err("路径不是目录".to_string());
-    }
-    
+    let path_obj = require_existing_directory_grant(&path, PathAccess::ReadDirectory)?;
+
     let mut files = Vec::new();
-    
-    let entries = std::fs::read_dir(path_obj)
-        .map_err(|e| format!("读取目录失败: {}", e))?;
-    
+
+    let entries = std::fs::read_dir(&path_obj).map_err(|e| format!("读取目录失败: {}", e))?;
+
     for entry in entries {
         let entry = entry.map_err(|e| format!("读取条目失败: {}", e))?;
         let entry_path = entry.path();
-        
-        let metadata = entry_path.metadata()
-            .map_err(|e| format!("获取元数据失败: {}", e))?;
-        
-        let name = entry.file_name()
-            .to_str()
-            .unwrap_or("未知")
-            .to_string();
-        
-        let relative_path = entry_path.strip_prefix(path_obj)
+
+        let metadata =
+            std::fs::symlink_metadata(&entry_path).map_err(|e| format!("获取元数据失败: {}", e))?;
+        if is_symlink_or_reparse_point(&metadata) {
+            log::warn!("跳过目录中的符号链接或重解析点: {}", entry_path.display());
+            continue;
+        }
+
+        let name = entry.file_name().to_str().unwrap_or("未知").to_string();
+
+        let relative_path = entry_path
+            .strip_prefix(&path_obj)
             .unwrap_or(&entry_path)
             .to_str()
             .unwrap_or("")
             .to_string();
-        
-        let modified_time = metadata.modified()
+
+        let modified_time = metadata
+            .modified()
             .ok()
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
             .map(|d| d.as_secs())
             .unwrap_or(0);
-        
+
         let is_dir = metadata.is_dir();
-        
-        log::info!("  - {}: {} (is_directory: {})", 
-            if is_dir { "📁" } else { "📄" }, 
-            name, 
+
+        log::info!(
+            "  - {}: {} (is_directory: {})",
+            if is_dir { "📁" } else { "📄" },
+            name,
             is_dir
         );
-        
+
         files.push(FileInfo {
             name,
             path: relative_path,
@@ -1954,7 +2424,7 @@ pub async fn list_directory_files(path: String) -> Result<Vec<FileInfo>, String>
             modified_time,
         });
     }
-    
+
     // 按名称排序（文件夹在前）
     files.sort_by(|a, b| {
         if a.is_directory == b.is_directory {
@@ -1965,9 +2435,9 @@ pub async fn list_directory_files(path: String) -> Result<Vec<FileInfo>, String>
             std::cmp::Ordering::Greater
         }
     });
-    
+
     log::info!("✅ 返回 {} 个文件/文件夹", files.len());
-    
+
     Ok(files)
 }
 
@@ -1982,19 +2452,16 @@ pub async fn list_directory_files(path: String) -> Result<Vec<FileInfo>, String>
 #[tauri::command]
 pub async fn read_file_bytes(path: String) -> Result<Vec<u8>, String> {
     log::info!("读取文件: {}", path);
-    
-    let path_obj = Path::new(&path);
-    
-    if !path_obj.exists() {
-        return Err("文件不存在".to_string());
+
+    const MAX_GENERIC_FILE_BYTES: u64 = 256 * 1024 * 1024;
+    let path_obj = require_existing_file_grant(&path, PathAccess::ReadFile)?;
+    let metadata =
+        std::fs::symlink_metadata(&path_obj).map_err(|e| format!("检查文件失败: {}", e))?;
+    if metadata.len() > MAX_GENERIC_FILE_BYTES {
+        return Err("文件超过通用读取大小限制".to_string());
     }
-    
-    if !path_obj.is_file() {
-        return Err("路径不是文件".to_string());
-    }
-    
-    std::fs::read(path_obj)
-        .map_err(|e| format!("读取文件失败: {}", e))
+
+    std::fs::read(path_obj).map_err(|e| format!("读取文件失败: {}", e))
 }
 
 /// 写入文件内容（字节数组）
@@ -2009,17 +2476,29 @@ pub async fn read_file_bytes(path: String) -> Result<Vec<u8>, String> {
 #[tauri::command]
 pub async fn write_file_bytes(path: String, data: Vec<u8>) -> Result<(), String> {
     log::info!("写入文件: {} ({} 字节)", path, data.len());
-    
-    let path_obj = Path::new(&path);
-    
-    // 确保父目录存在
-    if let Some(parent) = path_obj.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("创建目录失败: {}", e))?;
+
+    const MAX_GENERIC_FILE_BYTES: usize = 256 * 1024 * 1024;
+    if data.len() > MAX_GENERIC_FILE_BYTES {
+        return Err("文件超过通用写入大小限制".to_string());
     }
-    
-    std::fs::write(path_obj, data)
-        .map_err(|e| format!("写入文件失败: {}", e))
+    let path_obj = require_path_grant(&path, PathAccess::WriteFile, true)?;
+    if path_obj.exists() {
+        return Err("目标文件已存在，拒绝覆盖".to_string());
+    }
+
+    use tokio::io::AsyncWriteExt;
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path_obj)
+        .await
+        .map_err(|e| format!("创建文件失败: {}", e))?;
+    file.write_all(&data)
+        .await
+        .map_err(|e| format!("写入文件失败: {}", e))?;
+    file.sync_all()
+        .await
+        .map_err(|e| format!("同步文件失败: {}", e))
 }
 
 /// 选择文件夹
@@ -2030,15 +2509,17 @@ pub async fn write_file_bytes(path: String, data: Vec<u8>) -> Result<(), String>
 #[tauri::command]
 pub async fn select_folder() -> Result<Option<String>, String> {
     log::info!("打开文件夹选择对话框");
-    
+
     use rfd::FileDialog;
-    
+
     let result = FileDialog::new()
         .set_title("选择要共享的文件夹")
         .pick_folder();
-    
+
     if let Some(path) = result {
         if let Some(path_str) = path.to_str() {
+            register_path_grant(path_str, PathAccess::ReadDirectory, false)?;
+            register_path_grant(path_str, PathAccess::Open, false)?;
             log::info!("用户选择了文件夹: {}", path_str);
             Ok(Some(path_str.to_string()))
         } else {
@@ -2060,17 +2541,23 @@ pub async fn select_file_share_download_folder() -> Result<Option<String>, Strin
         .set_title("选择文件共享下载目录")
         .pick_folder();
 
-    result.map(|path| {
-        path.to_str()
-            .map(|value| value.to_string())
-            .ok_or_else(|| "无法转换下载目录路径".to_string())
-    }).transpose()
+    result
+        .map(|path| {
+            let value = path
+                .to_str()
+                .ok_or_else(|| "无法转换下载目录路径".to_string())?;
+            register_path_grant(value, PathAccess::WriteDirectory, false)?;
+            register_path_grant(value, PathAccess::Open, false)?;
+            Ok(value.to_string())
+        })
+        .transpose()
 }
 
 fn default_file_share_download_dir() -> std::path::PathBuf {
     dirs::download_dir()
         .or_else(dirs::home_dir)
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .or_else(dirs::data_local_dir)
+        .unwrap_or_else(std::env::temp_dir)
         .join("MCTier")
 }
 
@@ -2083,14 +2570,132 @@ fn effective_file_share_download_dir(config: &UserConfig) -> std::path::PathBuf 
         .unwrap_or_else(default_file_share_download_dir)
 }
 
+/// Resolve the download directory through the same authorization path used by
+/// all generic filesystem commands. A persisted custom directory is only
+/// usable after the native picker has granted it in this process; otherwise a
+/// modified config file could turn a filename-only download helper into an
+/// arbitrary directory writer.
+fn prepare_file_share_download_dir(config: &UserConfig) -> Result<std::path::PathBuf, String> {
+    if config
+        .file_share_download_dir
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        let directory = effective_file_share_download_dir(config);
+        let directory = require_existing_directory_grant(
+            directory
+                .to_str()
+                .ok_or_else(|| "无法转换下载目录路径".to_string())?,
+            PathAccess::WriteDirectory,
+        )
+        .map_err(|_| "自定义下载目录需要在本次运行中重新选择".to_string())?;
+        register_path_grant(
+            directory
+                .to_str()
+                .ok_or_else(|| "无法转换下载目录路径".to_string())?,
+            PathAccess::ReadDirectory,
+            false,
+        )?;
+        register_path_grant(
+            directory
+                .to_str()
+                .ok_or_else(|| "无法转换下载目录路径".to_string())?,
+            PathAccess::Open,
+            false,
+        )?;
+        return Ok(directory);
+    }
+
+    let directory = default_file_share_download_dir();
+    std::fs::create_dir_all(&directory).map_err(|e| format!("创建下载目录失败: {}", e))?;
+    let directory = register_path_grant(
+        directory
+            .to_str()
+            .ok_or_else(|| "无法转换下载目录路径".to_string())?,
+        PathAccess::ReadDirectory,
+        false,
+    )?;
+    register_path_grant(
+        directory
+            .to_str()
+            .ok_or_else(|| "无法转换下载目录路径".to_string())?,
+        PathAccess::WriteDirectory,
+        false,
+    )?;
+    register_path_grant(
+        directory
+            .to_str()
+            .ok_or_else(|| "无法转换下载目录路径".to_string())?,
+        PathAccess::Open,
+        false,
+    )?;
+    Ok(directory)
+}
+
+fn validate_download_file_name(file_name: &str) -> Result<&str, String> {
+    if file_name.is_empty()
+        || file_name == "."
+        || file_name == ".."
+        || file_name.contains('\0')
+        || file_name.contains('/')
+        || file_name.contains('\\')
+        || file_name.contains(':')
+        || file_name.chars().any(char::is_control)
+        || file_name
+            .chars()
+            .any(|ch| matches!(ch, '<' | '>' | '"' | '|' | '?' | '*'))
+    {
+        return Err("文件名无效".to_string());
+    }
+
+    let trimmed = file_name.trim_end_matches([' ', '.']);
+    if trimmed.is_empty() || trimmed != file_name {
+        return Err("文件名无效".to_string());
+    }
+
+    let stem = file_name
+        .split('.')
+        .next()
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    if matches!(
+        stem.as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    ) {
+        return Err("文件名无效".to_string());
+    }
+
+    Ok(file_name)
+}
+
 /// 获取文件夹共享的有效下载目录。目录不存在时会自动创建。
 #[tauri::command]
 pub async fn get_file_share_download_dir(state: State<'_, AppState>) -> Result<String, String> {
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let cfg_mgr = config_manager.lock().await;
-    let directory = effective_file_share_download_dir(cfg_mgr.get_config());
-    std::fs::create_dir_all(&directory).map_err(|e| format!("创建下载目录失败: {}", e))?;
+    let directory = prepare_file_share_download_dir(cfg_mgr.get_config())?;
     directory
         .to_str()
         .map(|value| value.to_string())
@@ -2106,16 +2711,24 @@ pub async fn set_file_share_download_dir(
     let normalized = path
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    if let Some(directory) = normalized.as_deref() {
-        std::fs::create_dir_all(directory).map_err(|e| format!("创建下载目录失败: {}", e))?;
-    }
+    let normalized = normalized
+        .map(|directory| {
+            let path = require_existing_directory_grant(&directory, PathAccess::WriteDirectory)?;
+            path.to_str()
+                .map(|value| value.to_string())
+                .ok_or_else(|| "无法转换下载目录路径".to_string())
+        })
+        .transpose()?;
 
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut cfg_mgr = config_manager.lock().await;
-    cfg_mgr.update_config(|config| {
-        config.file_share_download_dir = normalized.clone();
-    }).await.map_err(|e| format!("保存下载目录失败: {}", e))
+    cfg_mgr
+        .update_config(|config| {
+            config.file_share_download_dir = normalized.clone();
+        })
+        .await
+        .map_err(|e| format!("保存下载目录失败: {}", e))
 }
 
 /// 根据文件名生成文件夹共享下载路径，统一处理 Windows 路径分隔符。
@@ -2127,14 +2740,20 @@ pub async fn get_file_share_download_path(
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let cfg_mgr = config_manager.lock().await;
-    let directory = effective_file_share_download_dir(cfg_mgr.get_config());
-    let safe_name = std::path::Path::new(&file_name)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
-        .ok_or_else(|| "文件名无效".to_string())?;
-    std::fs::create_dir_all(&directory).map_err(|e| format!("创建下载目录失败: {}", e))?;
-    Ok(directory.join(safe_name).to_string_lossy().into_owned())
+    let safe_name = validate_download_file_name(&file_name)?;
+    let directory = prepare_file_share_download_dir(cfg_mgr.get_config())?;
+    let path = directory.join(safe_name);
+    if std::fs::symlink_metadata(&path).is_ok() {
+        return Err("目标文件已存在".to_string());
+    }
+    let path = path
+        .to_str()
+        .ok_or_else(|| "无法转换下载文件路径".to_string())?;
+    register_path_grant(path, PathAccess::WriteFile, true)?;
+    register_path_grant(path, PathAccess::ReadFile, true)?;
+    register_path_grant(path, PathAccess::DeleteFile, true)?;
+    register_path_grant(path, PathAccess::Open, true)?;
+    Ok(path.to_string())
 }
 
 /// 选择保存位置
@@ -2147,17 +2766,20 @@ pub async fn get_file_share_download_path(
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn select_save_location(default_name: String) -> Result<Option<String>, String> {
+    let default_name = validate_download_file_name(&default_name)?;
     log::info!("打开保存位置选择对话框: {}", default_name);
-    
+
     use rfd::FileDialog;
-    
+
     let result = FileDialog::new()
         .set_title("选择保存位置")
-        .set_file_name(&default_name)
+        .set_file_name(default_name)
         .save_file();
-    
+
     if let Some(path) = result {
         if let Some(path_str) = path.to_str() {
+            register_path_grant(path_str, PathAccess::WriteFile, true)?;
+            register_path_grant(path_str, PathAccess::Open, true)?;
             log::info!("用户选择了保存位置: {}", path_str);
             Ok(Some(path_str.to_string()))
         } else {
@@ -2177,16 +2799,36 @@ pub async fn select_save_location(default_name: String) -> Result<Option<String>
 #[tauri::command]
 pub async fn select_file() -> Result<Option<String>, String> {
     log::info!("打开文件选择对话框");
-    
+
     use rfd::FileDialog;
-    
+
     let result = FileDialog::new()
         .set_title("选择配置文件")
         .add_filter("JSON 文件", &["json"])
         .pick_file();
-    
+
     if let Some(path) = result {
         if let Some(path_str) = path.to_str() {
+            let path = normalize_local_path(path_str, false)?;
+            if path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_none_or(|extension| !extension.eq_ignore_ascii_case("json"))
+            {
+                return Err("配置文件必须使用 .json 扩展名".to_string());
+            }
+            register_path_grant(
+                path.to_str()
+                    .ok_or_else(|| "无法转换文件路径".to_string())?,
+                PathAccess::ReadFile,
+                false,
+            )?;
+            register_path_grant(
+                path.to_str()
+                    .ok_or_else(|| "无法转换文件路径".to_string())?,
+                PathAccess::Open,
+                false,
+            )?;
             log::info!("用户选择了文件: {}", path_str);
             Ok(Some(path_str.to_string()))
         } else {
@@ -2209,14 +2851,15 @@ pub async fn select_file() -> Result<Option<String>, String> {
 #[tauri::command]
 pub async fn open_file_location(path: String) -> Result<(), String> {
     log::info!("打开文件位置: {}", path);
-    
+
+    let path = require_existing_file_grant(&path, PathAccess::Open)?;
     use std::process::Command;
-    
+
     #[cfg(target_os = "windows")]
     {
         // Windows: 使用 explorer.exe /select,<path>
-        match Command::new("explorer.exe")
-            .args(&["/select,", &path])
+        match Command::new(windows_system_command("explorer.exe"))
+            .args(["/select,", path.to_string_lossy().as_ref()])
             .spawn()
         {
             Ok(_) => {
@@ -2229,12 +2872,12 @@ pub async fn open_file_location(path: String) -> Result<(), String> {
             }
         }
     }
-    
+
     #[cfg(target_os = "macos")]
     {
         // macOS: 使用 open -R <path>
-        match Command::new("open")
-            .args(&["-R", &path])
+        match Command::new(unix_system_command("open")?)
+            .args(["-R", path.to_string_lossy().as_ref()])
             .spawn()
         {
             Ok(_) => {
@@ -2247,15 +2890,15 @@ pub async fn open_file_location(path: String) -> Result<(), String> {
             }
         }
     }
-    
+
     #[cfg(target_os = "linux")]
     {
         // Linux: 使用 xdg-open 打开父目录
         use std::path::Path;
-        let path_obj = Path::new(&path);
+        let path_obj = &path;
         if let Some(parent) = path_obj.parent() {
             if let Some(parent_str) = parent.to_str() {
-                match Command::new("xdg-open")
+                match Command::new(unix_system_command("xdg-open")?)
                     .arg(parent_str)
                     .spawn()
                 {
@@ -2275,7 +2918,7 @@ pub async fn open_file_location(path: String) -> Result<(), String> {
             Err("无法获取父目录".to_string())
         }
     }
-    
+
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     {
         Err("不支持的操作系统".to_string())
@@ -2293,13 +2936,14 @@ pub async fn open_file_location(path: String) -> Result<(), String> {
 #[tauri::command]
 pub async fn open_folder(path: String) -> Result<(), String> {
     log::info!("打开文件夹: {}", path);
-    
+
+    let path = require_existing_directory_grant(&path, PathAccess::Open)?;
     use std::process::Command;
-    
+
     #[cfg(target_os = "windows")]
     {
         // Windows: 直接使用 explorer.exe 打开文件夹
-        match Command::new("explorer.exe")
+        match Command::new(windows_system_command("explorer.exe"))
             .arg(&path)
             .spawn()
         {
@@ -2313,11 +2957,11 @@ pub async fn open_folder(path: String) -> Result<(), String> {
             }
         }
     }
-    
+
     #[cfg(target_os = "macos")]
     {
         // macOS: 使用 open 打开文件夹
-        match Command::new("open")
+        match Command::new(unix_system_command("open")?)
             .arg(&path)
             .spawn()
         {
@@ -2331,11 +2975,11 @@ pub async fn open_folder(path: String) -> Result<(), String> {
             }
         }
     }
-    
+
     #[cfg(target_os = "linux")]
     {
         // Linux: 使用 xdg-open 打开文件夹
-        match Command::new("xdg-open")
+        match Command::new(unix_system_command("xdg-open")?)
             .arg(&path)
             .spawn()
         {
@@ -2349,7 +2993,7 @@ pub async fn open_folder(path: String) -> Result<(), String> {
             }
         }
     }
-    
+
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     {
         Err("不支持的操作系统".to_string())
@@ -2374,21 +3018,21 @@ pub async fn start_file_server(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     log::info!("启动HTTP文件服务器: {}", virtual_ip);
-    
+
     let core = state.core.lock().await;
     let file_transfer = core.get_file_transfer();
     let ft_service = file_transfer.lock().await;
-    
+
     // 先尝试停止旧的服务器（如果存在）
     ft_service.stop_server().await;
     log::info!("已停止旧的HTTP文件服务器（如果存在）");
-    
+
     // 等待端口完全释放
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-    
+
     // 设置虚拟IP
     ft_service.set_virtual_ip(virtual_ip);
-    
+
     // 启动服务器
     match ft_service.start_server().await {
         Ok(_) => {
@@ -2406,11 +3050,11 @@ pub async fn start_file_server(
 #[tauri::command]
 pub async fn stop_file_server(state: State<'_, AppState>) -> Result<(), String> {
     log::info!("停止HTTP文件服务器");
-    
+
     let core = state.core.lock().await;
     let file_transfer = core.get_file_transfer();
     let ft_service = file_transfer.lock().await;
-    
+
     ft_service.stop_server().await;
     log::info!("✅ HTTP文件服务器已停止");
     Ok(())
@@ -2422,31 +3066,40 @@ pub async fn check_file_server_status(state: State<'_, AppState>) -> Result<bool
     let core = state.core.lock().await;
     let file_transfer = core.get_file_transfer();
     let ft_service = file_transfer.lock().await;
-    
+
     // 检查服务器句柄是否存在
     let is_running = ft_service.is_running();
-    log::info!("📊 HTTP文件服务器状态: {}", if is_running { "运行中" } else { "未运行" });
+    log::info!(
+        "📊 HTTP文件服务器状态: {}",
+        if is_running { "运行中" } else { "未运行" }
+    );
     Ok(is_running)
 }
 
 /// 添加共享文件夹
 #[tauri::command]
 pub async fn add_shared_folder(
-    share: SharedFolder,
+    mut share: SharedFolder,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     log::info!("📁 添加共享文件夹: {} ({})", share.name, share.id);
-    
+
+    let shared_path = require_existing_directory_grant(&share.path, PathAccess::ReadDirectory)?;
+    share.path = shared_path
+        .to_str()
+        .ok_or_else(|| "无法转换共享目录路径".to_string())?
+        .to_string();
+
     let core = state.core.lock().await;
     let file_transfer = core.get_file_transfer();
     let ft_service = file_transfer.lock().await;
-    
+
     // 检查HTTP服务器是否已启动
     let is_running = ft_service.is_running();
-    
+
     if !is_running {
         log::info!("🚀 首次添加共享，启动HTTP文件服务器...");
-        
+
         // 启动HTTP服务器
         match ft_service.start_server().await {
             Ok(_) => {
@@ -2460,7 +3113,7 @@ pub async fn add_shared_folder(
     } else {
         log::info!("📡 HTTP文件服务器已在运行中");
     }
-    
+
     // 添加共享
     ft_service.add_share(share)
 }
@@ -2472,11 +3125,11 @@ pub async fn remove_shared_folder(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     log::debug!("删除共享文件夹: {}", share_id);
-    
+
     let core = state.core.lock().await;
     let file_transfer = core.get_file_transfer();
     let ft_service = file_transfer.lock().await;
-    
+
     ft_service.remove_share(&share_id)
 }
 
@@ -2486,7 +3139,7 @@ pub async fn get_local_shares(state: State<'_, AppState>) -> Result<Vec<SharedFo
     let core = state.core.lock().await;
     let file_transfer = core.get_file_transfer();
     let ft_service = file_transfer.lock().await;
-    
+
     Ok(ft_service.get_shares())
 }
 
@@ -2494,53 +3147,67 @@ pub async fn get_local_shares(state: State<'_, AppState>) -> Result<Vec<SharedFo
 #[tauri::command]
 pub async fn cleanup_expired_shares(state: State<'_, AppState>) -> Result<(), String> {
     log::debug!("清理过期共享");
-    
+
     let core = state.core.lock().await;
     let file_transfer = core.get_file_transfer();
     let ft_service = file_transfer.lock().await;
-    
+
     ft_service.cleanup_expired_shares();
     Ok(())
 }
 
 /// 获取远程共享列表（通过HTTP API）
 #[tauri::command]
-pub async fn get_remote_shares(peer_ip: String) -> Result<Vec<SharedFolderSummary>, String> {
+pub async fn get_remote_shares(
+    peer_ip: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<SharedFolderSummary>, String> {
     log::debug!("📡 正在获取远程共享列表: {}", peer_ip);
-    
-    let url = format!("http://{}:14539/api/shares", peer_ip);
+    let target = require_file_peer_host(&peer_ip, &state).await?;
+    let url = format!("http://{}:14539/api/shares", target.host);
     log::info!("🔗 请求URL: {}", url);
-    
+
     // 设置超时时间为5秒
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
+        .connect_timeout(std::time::Duration::from_secs(2))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| {
             log::error!("❌ 创建HTTP客户端失败: {}", e);
             format!("创建HTTP客户端失败: {}", e)
         })?;
-    
-    match client.get(&url).send().await {
+
+    match client
+        .get(&url)
+        .header(
+            crate::modules::file_transfer::LOBBY_TOKEN_HEADER,
+            &target.token,
+        )
+        .send()
+        .await
+    {
         Ok(response) => {
             let status = response.status();
             log::info!("📥 收到响应，状态码: {}", status);
-            
+
             if !status.is_success() {
                 log::error!("❌ HTTP请求失败，状态码: {}", status);
                 return Err(format!("HTTP请求失败: {}", status));
             }
-            
-            match response.json::<serde_json::Value>().await {
+
+            let body = match read_remote_body_limited(response, MAX_REMOTE_METADATA_BYTES).await {
+                Ok(body) => body,
+                Err(error) => {
+                    log::error!("❌ 读取响应失败: {}", error);
+                    return Err(format!("读取响应失败: {}", error));
+                }
+            };
+            match serde_json::from_slice::<serde_json::Value>(&body) {
                 Ok(json) => {
                     if let Some(shares) = json.get("shares") {
                         match serde_json::from_value::<Vec<SharedFolderSummary>>(shares.clone()) {
                             Ok(shares_vec) => {
-                                // 归一化：兼容仅返回明文 password、没有 has_password 的旧节点，
-                                // 同时确保任何密码内容都不会继续传向前端。
-                                let shares_vec: Vec<SharedFolderSummary> = shares_vec
-                                    .into_iter()
-                                    .map(SharedFolderSummary::normalized)
-                                    .collect();
                                 log::debug!("✅ 成功获取 {} 个共享", shares_vec.len());
                                 for (i, share) in shares_vec.iter().enumerate() {
                                     log::debug!("  {}. {} (ID: {})", i + 1, share.name, share.id);
@@ -2582,29 +3249,56 @@ pub async fn get_remote_files(
     share_id: String,
     path: Option<String>,
     password: Option<String>,
+    state: State<'_, AppState>,
 ) -> Result<Vec<FileTransferFileInfo>, String> {
     log::info!("获取远程文件列表: {} / {} / {:?}", peer_ip, share_id, path);
-    
-    let mut url = format!("http://{}:14539/api/shares/{}/files", peer_ip, share_id);
+
+    let target = require_file_peer_host(&peer_ip, &state).await?;
+    let mut url = format!(
+        "http://{}:14539/api/shares/{}/files",
+        target.host,
+        urlencoding::encode(&share_id)
+    );
     if let Some(p) = path {
         url = format!("{}?path={}", url, urlencoding::encode(&p));
     }
-    
-    let client = reqwest::Client::new();
-    let mut req = client.get(&url);
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(2))
+        .timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| format!("创建HTTP客户端失败: {}", e))?;
+    let mut req = client.get(&url).header(
+        crate::modules::file_transfer::LOBBY_TOKEN_HEADER,
+        &target.token,
+    );
     // 携带共享密码头，否则有密码保护的共享会返回 401
     if let Some(pwd) = password {
         if !pwd.is_empty() {
             req = req.header("x-share-password", pwd);
         }
     }
-    
+
     match req.send().await {
         Ok(response) => {
             if response.status().as_u16() == 401 {
                 return Err("访问被拒绝：密码错误或未提供密码".to_string());
             }
-            match response.json::<serde_json::Value>().await {
+            if response.status().as_u16() == 410 {
+                return Err("共享已过期".to_string());
+            }
+            if !response.status().is_success() {
+                return Err(format!("获取文件列表失败: HTTP {}", response.status()));
+            }
+            let body = match read_remote_body_limited(response, MAX_REMOTE_METADATA_BYTES).await {
+                Ok(body) => body,
+                Err(error) => {
+                    log::error!("❌ 读取响应失败: {}", error);
+                    return Err(format!("读取响应失败: {}", error));
+                }
+            };
+            match serde_json::from_slice::<serde_json::Value>(&body) {
                 Ok(json) => {
                     if let Some(files) = json.get("files") {
                         match serde_json::from_value::<Vec<FileTransferFileInfo>>(files.clone()) {
@@ -2640,19 +3334,55 @@ pub async fn verify_share_password(
     peer_ip: String,
     share_id: String,
     password: String,
+    state: State<'_, AppState>,
 ) -> Result<bool, String> {
     log::debug!("验证共享密码: {} / {}", peer_ip, share_id);
-    
-    let url = format!("http://{}:14539/api/shares/{}/verify", peer_ip, share_id);
-    let client = reqwest::Client::new();
-    
+
+    let target = require_file_peer_host(&peer_ip, &state).await?;
+    let url = format!(
+        "http://{}:14539/api/shares/{}/verify",
+        target.host,
+        urlencoding::encode(&share_id)
+    );
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(2))
+        .timeout(std::time::Duration::from_secs(5))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| format!("创建HTTP客户端失败: {}", e))?;
+
     let body = serde_json::json!({
         "password": password
     });
-    
-    match client.post(&url).json(&body).send().await {
+
+    match client
+        .post(&url)
+        .header(
+            crate::modules::file_transfer::LOBBY_TOKEN_HEADER,
+            &target.token,
+        )
+        .json(&body)
+        .send()
+        .await
+    {
         Ok(response) => {
-            match response.json::<serde_json::Value>().await {
+            if response.status().as_u16() == 410 {
+                return Err("共享已过期".to_string());
+            }
+            if response.status().as_u16() == 401 {
+                return Err("访问被拒绝：密码错误或未提供密码".to_string());
+            }
+            if !response.status().is_success() {
+                return Err(format!("验证失败: HTTP {}", response.status()));
+            }
+            let body = match read_remote_body_limited(response, MAX_REMOTE_METADATA_BYTES).await {
+                Ok(body) => body,
+                Err(error) => {
+                    log::error!("❌ 读取响应失败: {}", error);
+                    return Err(format!("读取响应失败: {}", error));
+                }
+            };
+            match serde_json::from_slice::<serde_json::Value>(&body) {
                 Ok(json) => {
                     if let Some(success) = json.get("success").and_then(|v| v.as_bool()) {
                         log::info!("✅ 密码验证结果: {}", success);
@@ -2680,14 +3410,73 @@ pub async fn get_download_url(
     peer_ip: String,
     share_id: String,
     file_path: String,
+    state: State<'_, AppState>,
 ) -> Result<String, String> {
+    let target = require_file_peer_host(&peer_ip, &state).await?;
     let url = format!(
         "http://{}:14539/api/shares/{}/download/{}",
-        peer_ip,
-        share_id,
+        target.host,
+        urlencoding::encode(&share_id),
         urlencoding::encode(&file_path)
     );
     Ok(url)
+}
+
+async fn read_remote_body_limited(
+    response: reqwest::Response,
+    limit: usize,
+) -> Result<Vec<u8>, String> {
+    use futures_util::StreamExt;
+
+    if response
+        .content_length()
+        .is_some_and(|length| length > limit as u64)
+    {
+        return Err("远程响应超过元数据大小限制".to_string());
+    }
+
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| format!("读取远程响应失败: {}", error))?;
+        let next_len = body
+            .len()
+            .checked_add(chunk.len())
+            .ok_or_else(|| "远程响应大小溢出".to_string())?;
+        if next_len > limit {
+            return Err("远程响应超过元数据大小限制".to_string());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+/// Publish a completed download without replacing an existing destination.
+///
+/// The temporary file is created in the destination directory, so hard-linking
+/// it is an atomic, same-filesystem publication on the supported desktop
+/// platforms. Unlike rename on Unix, hard_link never replaces an existing
+/// destination.
+async fn commit_download_part_noreplace(
+    part_path: &std::path::Path,
+    destination: &std::path::Path,
+) -> Result<(), String> {
+    tokio::fs::hard_link(part_path, destination)
+        .await
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                "目标文件已存在".to_string()
+            } else {
+                format!("提交下载文件失败: {}", error)
+            }
+        })?;
+
+    if let Err(error) = tokio::fs::remove_file(part_path).await {
+        // Keep the published destination intact. Removing it here could delete
+        // a file that another process replaced between the link and cleanup.
+        log::warn!("下载已提交，但清理临时硬链接失败: {}", error);
+    }
+    Ok(())
 }
 
 /// 流式下载远程文件到本地磁盘（边下边写，避免大文件占满内存导致 OOM/卡死）
@@ -2703,27 +3492,50 @@ pub async fn download_remote_file(
     file_path: String,
     save_path: String,
     password: Option<String>,
+    expected_size: Option<u64>,
     app_handle: tauri::AppHandle,
+    state: State<'_, AppState>,
 ) -> Result<(), String> {
     use futures_util::StreamExt;
     use tokio::io::AsyncWriteExt;
 
-    log::info!("⬇️ 开始流式下载: task={} {}/{} -> {}", task_id, peer_ip, share_id, save_path);
+    log::info!(
+        "⬇️ 开始流式下载: task={} {}/{} -> {}",
+        task_id,
+        peer_ip,
+        share_id,
+        save_path
+    );
 
     let cancel_flag = Arc::new(AtomicBool::new(false));
     download_cancels().insert(task_id.clone(), cancel_flag.clone());
 
     // 用闭包包裹，确保无论成功失败都能清理取消标志
+    let mut part_path: Option<std::path::PathBuf> = None;
+    let mut committed = false;
     let result: Result<(), String> = async {
+        let destination = require_path_grant(&save_path, PathAccess::WriteFile, true)?;
+        let target = require_file_peer_host(&peer_ip, &state).await?;
+        if expected_size.is_some_and(|size| size > MAX_REMOTE_FILE_BYTES) {
+            return Err("文件超过远程下载大小限制".to_string());
+        }
+
         let url = format!(
             "http://{}:14539/api/shares/{}/download/{}",
-            peer_ip,
-            share_id,
+            target.host,
+            urlencoding::encode(&share_id),
             urlencoding::encode(&file_path)
         );
 
-        let client = reqwest::Client::new();
-        let mut req = client.get(&url);
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| format!("创建HTTP客户端失败: {}", e))?;
+        let mut req = client.get(&url).header(
+            crate::modules::file_transfer::LOBBY_TOKEN_HEADER,
+            &target.token,
+        );
         if let Some(pwd) = &password {
             if !pwd.is_empty() {
                 req = req.header("x-share-password", pwd);
@@ -2735,20 +3547,53 @@ pub async fn download_remote_file(
         if status.as_u16() == 401 {
             return Err("访问被拒绝：密码错误或未提供密码".to_string());
         }
+        if status.as_u16() == 410 {
+            return Err("共享已过期".to_string());
+        }
+        if status == reqwest::StatusCode::PARTIAL_CONTENT {
+            return Err("服务器返回了意外的部分响应".to_string());
+        }
         if !status.is_success() {
             return Err(format!("下载失败: HTTP {}", status));
         }
 
-        let total = resp.content_length().unwrap_or(0);
+        let content_length = resp.content_length();
+        if content_length.is_some_and(|size| size > MAX_REMOTE_FILE_BYTES) {
+            return Err("响应超过远程下载大小限制".to_string());
+        }
+        if let (Some(expected), Some(advertised)) = (expected_size, content_length) {
+            if expected != advertised {
+                return Err(format!(
+                    "响应长度与预期不匹配: expected={}, advertised={}",
+                    expected, advertised
+                ));
+            }
+        }
+        let total = expected_size.or(content_length).unwrap_or(0);
 
-        // 确保父目录存在
-        if let Some(parent) = std::path::Path::new(&save_path).parent() {
-            let _ = tokio::fs::create_dir_all(parent).await;
+        if tokio::fs::try_exists(&destination)
+            .await
+            .map_err(|e| format!("检查目标文件失败: {}", e))?
+        {
+            return Err("目标文件已存在".to_string());
         }
 
-        let mut file = tokio::fs::File::create(&save_path)
+        let file_name = destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| "目标文件名无效".to_string())?;
+        let parent = destination
+            .parent()
+            .ok_or_else(|| "目标目录无效".to_string())?;
+        let candidate = parent.join(format!(".{}.{}.part", file_name, uuid::Uuid::new_v4()));
+        part_path = Some(candidate.clone());
+        let mut file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
             .await
-            .map_err(|e| format!("创建文件失败: {}", e))?;
+            .map_err(|e| format!("创建下载临时文件失败: {}", e))?;
 
         let mut downloaded: u64 = 0;
         let mut stream = resp.bytes_stream();
@@ -2757,16 +3602,23 @@ pub async fn download_remote_file(
         while let Some(chunk) = stream.next().await {
             // 检查取消
             if cancel_flag.load(Ordering::Relaxed) {
-                drop(file);
-                let _ = tokio::fs::remove_file(&save_path).await;
                 return Err("已取消".to_string());
             }
 
             let chunk = chunk.map_err(|e| format!("下载中断: {}", e))?;
+            let next_downloaded = downloaded
+                .checked_add(chunk.len() as u64)
+                .ok_or_else(|| "下载大小溢出".to_string())?;
+            let limit = expected_size
+                .or(content_length)
+                .unwrap_or(MAX_REMOTE_FILE_BYTES);
+            if next_downloaded > limit {
+                return Err("响应内容超过预期长度".to_string());
+            }
             file.write_all(&chunk)
                 .await
                 .map_err(|e| format!("写入文件失败: {}", e))?;
-            downloaded += chunk.len() as u64;
+            downloaded = next_downloaded;
 
             // 每 200ms 上报一次进度
             if last_emit.elapsed().as_millis() >= 200 {
@@ -2782,7 +3634,26 @@ pub async fn download_remote_file(
             }
         }
 
-        file.flush().await.map_err(|e| format!("刷新文件失败: {}", e))?;
+        if cancel_flag.load(Ordering::Relaxed) {
+            return Err("已取消".to_string());
+        }
+        if let Some(limit) = expected_size.or(content_length) {
+            if downloaded != limit {
+                return Err(format!(
+                    "下载长度不匹配: expected={}, received={}",
+                    limit, downloaded
+                ));
+            }
+        }
+        file.flush()
+            .await
+            .map_err(|e| format!("刷新文件失败: {}", e))?;
+        file.sync_all()
+            .await
+            .map_err(|e| format!("同步文件失败: {}", e))?;
+
+        commit_download_part_noreplace(&candidate, &destination).await?;
+        committed = true;
 
         // 最后上报一次 100% 进度
         let _ = app_handle.emit(
@@ -2798,6 +3669,12 @@ pub async fn download_remote_file(
         Ok(())
     }
     .await;
+
+    if !committed {
+        if let Some(path) = part_path {
+            let _ = tokio::fs::remove_file(path).await;
+        }
+    }
 
     download_cancels().remove(&task_id);
     result
@@ -2822,21 +3699,54 @@ pub async fn download_remote_batch(
     save_path: String,
     password: Option<String>,
     app_handle: tauri::AppHandle,
+    state: State<'_, AppState>,
 ) -> Result<(), String> {
     use futures_util::StreamExt;
     use tokio::io::AsyncWriteExt;
 
-    log::info!("⬇️ 开始流式批量下载: task={} {}/{} ({} 个文件)", task_id, peer_ip, share_id, file_paths.len());
+    log::info!(
+        "⬇️ 开始流式批量下载: task={} {}/{} ({} 个文件)",
+        task_id,
+        peer_ip,
+        share_id,
+        file_paths.len()
+    );
+
+    if file_paths.is_empty() || file_paths.len() > MAX_REMOTE_BATCH_FILES {
+        return Err("批量下载文件数量超过限制".to_string());
+    }
+    let request_body = serde_json::to_vec(&serde_json::json!({ "file_paths": file_paths }))
+        .map_err(|_| "批量下载请求无法编码".to_string())?;
+    if request_body.len() > MAX_REMOTE_BATCH_REQUEST_BYTES {
+        return Err("批量下载请求过大".to_string());
+    }
 
     let cancel_flag = Arc::new(AtomicBool::new(false));
     download_cancels().insert(task_id.clone(), cancel_flag.clone());
 
+    let mut part_path: Option<std::path::PathBuf> = None;
+    let mut committed = false;
     let result: Result<(), String> = async {
-        let url = format!("http://{}:14539/api/shares/{}/batch-download", peer_ip, share_id);
-        let client = reqwest::Client::new();
+        let destination = require_path_grant(&save_path, PathAccess::WriteFile, true)?;
+        let target = require_file_peer_host(&peer_ip, &state).await?;
+        let url = format!(
+            "http://{}:14539/api/shares/{}/batch-download",
+            target.host,
+            urlencoding::encode(&share_id)
+        );
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| format!("创建HTTP客户端失败: {}", e))?;
         let mut req = client
             .post(&url)
-            .json(&serde_json::json!({ "file_paths": file_paths }));
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(
+                crate::modules::file_transfer::LOBBY_TOKEN_HEADER,
+                &target.token,
+            )
+            .body(request_body);
         if let Some(pwd) = &password {
             if !pwd.is_empty() {
                 req = req.header("x-share-password", pwd);
@@ -2848,30 +3758,65 @@ pub async fn download_remote_batch(
         if status.as_u16() == 401 {
             return Err("访问被拒绝：密码错误或未提供密码".to_string());
         }
+        if status.as_u16() == 410 {
+            return Err("共享已过期".to_string());
+        }
+        if status == reqwest::StatusCode::PARTIAL_CONTENT {
+            return Err("服务器返回了意外的部分响应".to_string());
+        }
         if !status.is_success() {
             return Err(format!("打包下载失败: HTTP {}", status));
         }
 
-        let total = resp.content_length().unwrap_or(0);
-        if let Some(parent) = std::path::Path::new(&save_path).parent() {
-            let _ = tokio::fs::create_dir_all(parent).await;
+        let content_length = resp.content_length();
+        if content_length.is_some_and(|size| size > MAX_REMOTE_BATCH_BYTES) {
+            return Err("批量响应超过临时磁盘预算".to_string());
         }
-        let mut file = tokio::fs::File::create(&save_path)
+        let total = content_length.unwrap_or(0);
+        if tokio::fs::try_exists(&destination)
             .await
-            .map_err(|e| format!("创建文件失败: {}", e))?;
+            .map_err(|e| format!("检查目标文件失败: {}", e))?
+        {
+            return Err("目标文件已存在".to_string());
+        }
+        let file_name = destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| "目标文件名无效".to_string())?;
+        let parent = destination
+            .parent()
+            .ok_or_else(|| "目标目录无效".to_string())?;
+        let candidate = parent.join(format!(
+            ".{}.{}.part",
+            file_name,
+            uuid::Uuid::new_v4()
+        ));
+        part_path = Some(candidate.clone());
+        let mut file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+            .await
+            .map_err(|e| format!("创建下载临时文件失败: {}", e))?;
 
         let mut downloaded: u64 = 0;
         let mut stream = resp.bytes_stream();
         let mut last_emit = std::time::Instant::now();
         while let Some(chunk) = stream.next().await {
             if cancel_flag.load(Ordering::Relaxed) {
-                drop(file);
-                let _ = tokio::fs::remove_file(&save_path).await;
                 return Err("已取消".to_string());
             }
             let chunk = chunk.map_err(|e| format!("下载中断: {}", e))?;
+            let next_downloaded = downloaded
+                .checked_add(chunk.len() as u64)
+                .ok_or_else(|| "下载大小溢出".to_string())?;
+            let limit = content_length.unwrap_or(MAX_REMOTE_BATCH_BYTES);
+            if next_downloaded > limit {
+                return Err("响应内容超过声明长度或临时磁盘预算".to_string());
+            }
             file.write_all(&chunk).await.map_err(|e| format!("写入文件失败: {}", e))?;
-            downloaded += chunk.len() as u64;
+            downloaded = next_downloaded;
             if last_emit.elapsed().as_millis() >= 200 {
                 let _ = app_handle.emit(
                     "download-progress",
@@ -2880,7 +3825,21 @@ pub async fn download_remote_batch(
                 last_emit = std::time::Instant::now();
             }
         }
+        if cancel_flag.load(Ordering::Relaxed) {
+            return Err("已取消".to_string());
+        }
+        if let Some(limit) = content_length {
+            if downloaded != limit {
+                return Err(format!(
+                    "下载长度不匹配: expected={}, received={}",
+                    limit, downloaded
+                ));
+            }
+        }
         file.flush().await.map_err(|e| format!("刷新文件失败: {}", e))?;
+        file.sync_all().await.map_err(|e| format!("同步文件失败: {}", e))?;
+        commit_download_part_noreplace(&candidate, &destination).await?;
+        committed = true;
         let _ = app_handle.emit(
             "download-progress",
             serde_json::json!({ "taskId": task_id, "downloaded": downloaded, "total": if total == 0 { downloaded } else { total } }),
@@ -2889,6 +3848,12 @@ pub async fn download_remote_batch(
         Ok(())
     }
     .await;
+
+    if !committed {
+        if let Some(path) = part_path {
+            let _ = tokio::fs::remove_file(path).await;
+        }
+    }
 
     download_cancels().remove(&task_id);
     result
@@ -3013,7 +3978,7 @@ pub async fn detect_security_software() -> Vec<String> {
             ("egui.exe", "ESET NOD32"),
         ];
 
-        let output = tokio::process::Command::new("tasklist")
+        let output = tokio::process::Command::new(windows_system_command("tasklist.exe"))
             .args(&["/fo", "csv", "/nh"])
             .creation_flags(CREATE_NO_WINDOW)
             .output()
@@ -3066,15 +4031,15 @@ pub async fn export_logs(_app_handle: tauri::AppHandle) -> Result<String, String
     let log_dir_clone = log_dir.clone();
     let zip_path_clone = zip_path.clone();
     tokio::task::spawn_blocking(move || -> Result<(), String> {
-        let zip_file = std::fs::File::create(&zip_path_clone)
-            .map_err(|e| format!("创建zip失败: {}", e))?;
+        let zip_file =
+            std::fs::File::create(&zip_path_clone).map_err(|e| format!("创建zip失败: {}", e))?;
         let mut zip = zip::ZipWriter::new(zip_file);
         let options = zip::write::SimpleFileOptions::default()
             .compression_method(zip::CompressionMethod::Deflated)
             .compression_level(Some(6));
 
-        let entries = std::fs::read_dir(&log_dir_clone)
-            .map_err(|e| format!("读取日志目录失败: {}", e))?;
+        let entries =
+            std::fs::read_dir(&log_dir_clone).map_err(|e| format!("读取日志目录失败: {}", e))?;
         let mut count = 0;
         for entry in entries.flatten() {
             let path = entry.path();
@@ -3103,90 +4068,126 @@ pub async fn export_logs(_app_handle: tauri::AppHandle) -> Result<String, String
     .await
     .map_err(|e| format!("打包任务失败: {}", e))??;
 
-    Ok(zip_path.to_string_lossy().to_string())
+    let zip_path = zip_path
+        .to_str()
+        .ok_or_else(|| "无法转换日志导出路径".to_string())?;
+    register_path_grant(zip_path, PathAccess::Open, false)?;
+    register_path_grant(zip_path, PathAccess::DeleteFile, false)?;
+    Ok(zip_path.to_string())
 }
 
 /// 诊断文件共享连接
-/// 
+///
 /// # 参数
 /// * `peer_ip` - 对方的虚拟IP
-/// 
+///
 /// # 返回
 /// * `Ok(String)` - 诊断结果（JSON格式）
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn diagnose_file_share_connection(peer_ip: String) -> Result<String, String> {
+pub async fn diagnose_file_share_connection(
+    peer_ip: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
     log::info!("🔍 开始诊断文件共享连接: {}", peer_ip);
-    
+    let target = require_file_peer_host(&peer_ip, &state).await?;
+
     let mut results = serde_json::json!({
         "peer_ip": peer_ip,
         "tests": []
     });
-    
+
     // 测试1: Ping虚拟IP
     log::info!("📡 测试1: Ping虚拟IP...");
     let ping_result = ping_virtual_ip(peer_ip.clone()).await;
     let ping_success = ping_result.is_ok() && ping_result.unwrap_or(false);
-    results["tests"].as_array_mut().unwrap().push(serde_json::json!({
-        "name": "Ping虚拟IP",
-        "success": ping_success,
-        "message": if ping_success {
-            "✅ 虚拟网络连接正常"
-        } else {
-            "❌ 无法ping通虚拟IP，虚拟网络可能未连接"
-        }
-    }));
-    
+    results["tests"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "name": "Ping虚拟IP",
+            "success": ping_success,
+            "message": if ping_success {
+                "✅ 虚拟网络连接正常"
+            } else {
+                "❌ 无法ping通虚拟IP，虚拟网络可能未连接"
+            }
+        }));
+
     // 测试2: 检查HTTP服务器端口
     log::info!("🔌 测试2: 检查HTTP服务器端口...");
-    let url = format!("http://{}:14539/api/shares", peer_ip);
+    let url = format!("http://{}:14539/api/shares", target.host);
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| format!("创建HTTP客户端失败: {}", e))?;
-    
-    let http_result = client.get(&url).send().await;
+
+    let http_result = client
+        .get(&url)
+        .header(
+            crate::modules::file_transfer::LOBBY_TOKEN_HEADER,
+            &target.token,
+        )
+        .send()
+        .await;
     let http_message = if http_result.is_ok() {
         "✅ HTTP文件服务器可访问".to_string()
     } else {
-        format!("❌ 无法连接HTTP服务器: {}", http_result.as_ref().err().unwrap())
+        format!(
+            "❌ 无法连接HTTP服务器: {}",
+            http_result.as_ref().err().unwrap()
+        )
     };
-    
-    results["tests"].as_array_mut().unwrap().push(serde_json::json!({
-        "name": "HTTP服务器连接",
-        "success": http_result.is_ok(),
-        "message": http_message
-    }));
-    
+
+    results["tests"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "name": "HTTP服务器连接",
+            "success": http_result.is_ok(),
+            "message": http_message
+        }));
+
     // 测试3: 获取共享列表
     if http_result.is_ok() {
         log::info!("📋 测试3: 获取共享列表...");
-        match get_remote_shares(peer_ip.clone()).await {
+        match get_remote_shares(peer_ip.clone(), state).await {
             Ok(shares) => {
-                results["tests"].as_array_mut().unwrap().push(serde_json::json!({
-                    "name": "获取共享列表",
-                    "success": true,
-                    "message": format!("✅ 成功获取 {} 个共享", shares.len())
-                }));
+                results["tests"]
+                    .as_array_mut()
+                    .unwrap()
+                    .push(serde_json::json!({
+                        "name": "获取共享列表",
+                        "success": true,
+                        "message": format!("✅ 成功获取 {} 个共享", shares.len())
+                    }));
             }
             Err(e) => {
-                results["tests"].as_array_mut().unwrap().push(serde_json::json!({
-                    "name": "获取共享列表",
-                    "success": false,
-                    "message": format!("❌ 获取共享列表失败: {}", e)
-                }));
+                results["tests"]
+                    .as_array_mut()
+                    .unwrap()
+                    .push(serde_json::json!({
+                        "name": "获取共享列表",
+                        "success": false,
+                        "message": format!("❌ 获取共享列表失败: {}", e)
+                    }));
             }
         }
     }
-    
+
     log::info!("✅ 诊断完成");
-    
+
     Ok(serde_json::to_string_pretty(&results).unwrap())
 }
 
 // ==================== 文件下载命令 ====================
 
 // ZIP extraction helpers keep every output path inside the selected directory.
+const MAX_ZIP_ENTRIES: usize = 4096;
+const MAX_ZIP_ENTRY_UNCOMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
 fn is_symlink_or_reparse_point(metadata: &std::fs::Metadata) -> bool {
     if metadata.file_type().is_symlink() {
         return true;
@@ -3205,9 +4206,111 @@ fn is_symlink_or_reparse_point(metadata: &std::fs::Metadata) -> bool {
     false
 }
 
+fn is_windows_reserved_name(name: &str) -> bool {
+    let trimmed = name.trim_end_matches([' ', '.']);
+    let stem = trimmed.split('.').next().unwrap_or("").to_ascii_uppercase();
+    matches!(
+        stem.as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    )
+}
+
+/// Normalize a ZIP entry using Windows path rules on every platform. Archives
+/// are often produced on Linux and extracted on Windows, so backslashes,
+/// device names and alternate data stream syntax must be rejected uniformly.
+fn safe_zip_entry_path(name: &str) -> Result<(std::path::PathBuf, String), String> {
+    if name.is_empty() || name.contains('\0') {
+        return Err(format!("拒绝空或包含NUL的ZIP条目: {}", name));
+    }
+
+    let normalized = name.replace('\\', "/");
+    if normalized.starts_with('/') || normalized.starts_with("//") {
+        return Err(format!("拒绝绝对ZIP条目路径: {}", name));
+    }
+
+    // ZIP directory entries conventionally end in one slash. Strip only that
+    // marker while rejecting repeated separators and empty path components.
+    let components_text = normalized.strip_suffix('/').unwrap_or(&normalized);
+    if components_text.is_empty() || components_text.ends_with('/') {
+        return Err(format!("拒绝不安全的ZIP条目路径: {}", name));
+    }
+
+    let mut path = std::path::PathBuf::new();
+    let mut components = Vec::new();
+    for component in components_text.split('/') {
+        if component == "." || component == ".." {
+            return Err(format!("拒绝不安全的ZIP条目路径: {}", name));
+        }
+        if component.chars().any(|ch| ch.is_control())
+            || component.contains(':')
+            || component
+                .chars()
+                .any(|ch| matches!(ch, '<' | '>' | '"' | '|' | '?' | '*'))
+            || component != component.trim_end_matches([' ', '.'])
+            || is_windows_reserved_name(component)
+        {
+            return Err(format!("拒绝不安全的ZIP条目名称: {}", name));
+        }
+        path.push(component);
+        components.push(component.to_string());
+    }
+
+    if components.is_empty() {
+        return Err(format!("拒绝空的ZIP条目路径: {}", name));
+    }
+
+    let key = components
+        .iter()
+        .map(|component| component.to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join("/");
+
+    Ok((path, key))
+}
+
+fn ensure_no_link_components(path: &std::path::Path) -> Result<(), String> {
+    let mut current = std::path::PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if is_symlink_or_reparse_point(&metadata) => {
+                return Err(format!("拒绝经过符号链接或重解析点: {}", current.display()));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+            Err(error) => {
+                return Err(format!("检查路径失败 {}: {}", current.display(), error));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn ensure_safe_zip_directory(
     extraction_root: &std::path::Path,
     relative_path: &std::path::Path,
+    created_dirs: &mut Vec<std::path::PathBuf>,
 ) -> Result<std::path::PathBuf, String> {
     use std::io::ErrorKind;
     use std::path::Component;
@@ -3235,6 +4338,7 @@ fn ensure_safe_zip_directory(
             Err(error) if error.kind() == ErrorKind::NotFound => {
                 std::fs::create_dir(&current)
                     .map_err(|e| format!("创建目录失败 {}: {}", current.display(), e))?;
+                created_dirs.push(current.clone());
             }
             Err(error) => {
                 return Err(format!("检查解压目录失败 {}: {}", current.display(), error));
@@ -3255,73 +4359,183 @@ fn ensure_safe_zip_directory(
 fn extract_zip_archive(
     zip_path: &std::path::Path,
     extract_dir: &std::path::Path,
+    requested_total_budget: Option<u64>,
 ) -> Result<Vec<String>, String> {
+    use std::collections::HashSet;
     use std::fs::{File, OpenOptions};
-    use std::io::ErrorKind;
+    use std::io::{ErrorKind, Read};
     use zip::ZipArchive;
 
-    std::fs::create_dir_all(extract_dir)
-        .map_err(|e| format!("创建解压目标目录失败: {}", e))?;
-    let extraction_root = std::fs::canonicalize(extract_dir)
-        .map_err(|e| format!("规范化解压目标目录失败: {}", e))?;
+    let zip_metadata =
+        std::fs::symlink_metadata(zip_path).map_err(|e| format!("检查ZIP文件失败: {}", e))?;
+    if is_symlink_or_reparse_point(&zip_metadata) || !zip_metadata.is_file() {
+        return Err(format!("ZIP路径不是普通本地文件: {}", zip_path.display()));
+    }
 
-    let file = File::open(zip_path)
-        .map_err(|e| format!("打开ZIP文件失败: {}", e))?;
-    let mut archive = ZipArchive::new(file)
-        .map_err(|e| format!("读取ZIP文件失败: {}", e))?;
+    ensure_no_link_components(
+        extract_dir
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new(".")),
+    )?;
+    match std::fs::symlink_metadata(extract_dir) {
+        Ok(metadata) => {
+            if is_symlink_or_reparse_point(&metadata) || !metadata.is_dir() {
+                return Err(format!(
+                    "解压目标目录不能是符号链接或非目录: {}",
+                    extract_dir.display()
+                ));
+            }
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            std::fs::create_dir_all(extract_dir)
+                .map_err(|e| format!("创建解压目标目录失败: {}", e))?;
+            ensure_no_link_components(extract_dir)?;
+        }
+        Err(error) => {
+            return Err(format!("检查解压目标目录失败: {}", error));
+        }
+    }
+    let extraction_root =
+        std::fs::canonicalize(extract_dir).map_err(|e| format!("规范化解压目标目录失败: {}", e))?;
+    let root_metadata = std::fs::symlink_metadata(extract_dir)
+        .map_err(|e| format!("检查解压目标目录失败: {}", e))?;
+    if is_symlink_or_reparse_point(&root_metadata) || !root_metadata.is_dir() {
+        return Err(format!(
+            "解压目标目录不能是符号链接或非目录: {}",
+            extract_dir.display()
+        ));
+    }
+
+    let file = File::open(zip_path).map_err(|e| format!("打开ZIP文件失败: {}", e))?;
+    let mut archive = ZipArchive::new(file).map_err(|e| format!("读取ZIP文件失败: {}", e))?;
+
+    if archive.len() > MAX_ZIP_ENTRIES {
+        return Err(format!("ZIP条目数量超过限制: {}", MAX_ZIP_ENTRIES));
+    }
+
+    let total_budget = requested_total_budget
+        .unwrap_or(MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES)
+        .min(MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES);
+    let mut total_uncompressed = 0u64;
+    let mut seen = HashSet::new();
+    let mut files = HashSet::new();
+    let mut plans = Vec::with_capacity(archive.len());
 
     // Validate every entry before writing anything so a malicious archive
     // cannot leave a partially extracted payload behind.
     for i in 0..archive.len() {
-        let entry = archive.by_index(i)
+        let entry = archive
+            .by_index(i)
             .map_err(|e| format!("读取ZIP条目失败: {}", e))?;
-        let enclosed_path = entry.enclosed_name()
-            .ok_or_else(|| format!("拒绝不安全的ZIP条目路径: {}", entry.name()))?;
-
-        if enclosed_path.as_os_str().is_empty() {
-            return Err("拒绝空的ZIP条目路径".to_string());
+        if entry.is_symlink() {
+            return Err(format!("拒绝ZIP中的符号链接条目: {}", entry.name()));
         }
 
-        if entry.unix_mode().is_some_and(|mode| mode & 0o170000 == 0o120000) {
-            return Err(format!("拒绝ZIP中的符号链接条目: {}", entry.name()));
+        let (relative_path, key) = safe_zip_entry_path(entry.name())?;
+        if !seen.insert(key.clone()) {
+            return Err(format!("拒绝ZIP中的重复条目: {}", entry.name()));
+        }
+
+        let entry_size = entry.size();
+        if entry_size > MAX_ZIP_ENTRY_UNCOMPRESSED_BYTES {
+            return Err(format!("ZIP单条目解压大小超过限制: {}", entry.name()));
+        }
+        total_uncompressed = total_uncompressed
+            .checked_add(entry_size)
+            .ok_or_else(|| "ZIP总解压大小溢出".to_string())?;
+        if total_uncompressed > total_budget {
+            return Err(format!("ZIP总解压大小超过预算: {}", total_budget));
+        }
+
+        if !entry.is_dir() {
+            files.insert(key.clone());
+        }
+        plans.push((i, relative_path, key, entry.is_dir(), entry_size));
+    }
+
+    // Reject a file used as a parent directory before touching the output.
+    for key in &files {
+        let mut prefix = String::new();
+        let parts: Vec<&str> = key.split('/').collect();
+        for component in parts.iter().take(parts.len().saturating_sub(1)) {
+            if !prefix.is_empty() {
+                prefix.push('/');
+            }
+            prefix.push_str(component);
+            if files.contains(&prefix) {
+                return Err(format!("ZIP条目文件与目录冲突: {}", key));
+            }
         }
     }
 
     let mut extracted_files = Vec::new();
-    for i in 0..archive.len() {
-        let mut entry = archive.by_index(i)
-            .map_err(|e| format!("读取ZIP条目失败: {}", e))?;
-        let enclosed_path = entry.enclosed_name()
-            .ok_or_else(|| format!("拒绝不安全的ZIP条目路径: {}", entry.name()))?;
+    let mut created_files = Vec::new();
+    let mut created_dirs = Vec::new();
+    let extraction_result: Result<(), String> = (|| {
+        for (index, relative_path, _key, is_dir, entry_size) in plans {
+            let mut entry = archive
+                .by_index(index)
+                .map_err(|e| format!("读取ZIP条目失败: {}", e))?;
 
-        if entry.is_dir() {
-            let directory = ensure_safe_zip_directory(&extraction_root, &enclosed_path)?;
-            log::info!("📁 创建目录: {:?}", directory);
-            continue;
+            if is_dir {
+                let directory =
+                    ensure_safe_zip_directory(&extraction_root, &relative_path, &mut created_dirs)?;
+                log::info!("📁 创建目录: {:?}", directory);
+                continue;
+            }
+
+            let file_name = relative_path
+                .file_name()
+                .ok_or_else(|| format!("ZIP条目缺少文件名: {}", entry.name()))?;
+            let parent_path = relative_path
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(""));
+            let safe_parent =
+                ensure_safe_zip_directory(&extraction_root, parent_path, &mut created_dirs)?;
+            let outpath = safe_parent.join(file_name);
+
+            // create_new prevents following a pre-existing symlink/hard link
+            // and avoids silently overwriting files in the selected directory.
+            let mut outfile = match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&outpath)
+            {
+                Ok(file) => file,
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                    return Err(format!("目标文件已存在，拒绝覆盖: {}", outpath.display()));
+                }
+                Err(error) => {
+                    return Err(format!("创建文件失败 {}: {}", outpath.display(), error));
+                }
+            };
+            created_files.push(outpath.clone());
+
+            log::info!("📄 解压文件: {:?}", outpath);
+            let mut limited_entry = (&mut entry).take(entry_size.saturating_add(1));
+            let copied = std::io::copy(&mut limited_entry, &mut outfile)
+                .map_err(|e| format!("写入文件失败: {}", e))?;
+            if copied != entry_size {
+                return Err(format!(
+                    "ZIP条目实际解压大小与声明不匹配: {} ({} != {})",
+                    entry.name(),
+                    copied,
+                    entry_size
+                ));
+            }
+            extracted_files.push(outpath.to_string_lossy().to_string());
         }
+        Ok(())
+    })();
 
-        let file_name = enclosed_path.file_name()
-            .ok_or_else(|| format!("ZIP条目缺少文件名: {}", entry.name()))?;
-        let parent_path = enclosed_path.parent().unwrap_or_else(|| std::path::Path::new(""));
-        let safe_parent = ensure_safe_zip_directory(&extraction_root, parent_path)?;
-        let outpath = safe_parent.join(file_name);
-
-        // create_new prevents following a pre-existing symlink/hard link and
-        // avoids silently overwriting files in the selected directory.
-        let mut outfile = match OpenOptions::new().write(true).create_new(true).open(&outpath) {
-            Ok(file) => file,
-            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
-                return Err(format!("目标文件已存在，拒绝覆盖: {}", outpath.display()));
-            }
-            Err(error) => {
-                return Err(format!("创建文件失败 {}: {}", outpath.display(), error));
-            }
-        };
-
-        log::info!("📄 解压文件: {:?}", outpath);
-        std::io::copy(&mut entry, &mut outfile)
-            .map_err(|e| format!("写入文件失败: {}", e))?;
-        extracted_files.push(outpath.to_string_lossy().to_string());
+    if let Err(error) = extraction_result {
+        for path in created_files.iter().rev() {
+            let _ = std::fs::remove_file(path);
+        }
+        for path in created_dirs.iter().rev() {
+            let _ = std::fs::remove_dir(path);
+        }
+        return Err(error);
     }
 
     Ok(extracted_files)
@@ -3332,21 +4546,110 @@ fn extract_zip_archive(
 /// # 参数
 /// * `zip_path` - ZIP文件路径
 /// * `extract_dir` - 解压目标目录
+/// * `max_total_bytes` - 本次解压允许的最大总字节数；为空时使用硬上限
 ///
 /// # 返回
 /// * `Ok(Vec<String>)` - 解压的文件列表
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn extract_zip(zip_path: String, extract_dir: String) -> Result<Vec<String>, String> {
+pub async fn extract_zip(
+    zip_path: String,
+    extract_dir: String,
+    max_total_bytes: Option<u64>,
+) -> Result<Vec<String>, String> {
     log::info!("📦 解压ZIP文件: {} -> {}", zip_path, extract_dir);
 
-    let extracted_files = extract_zip_archive(
-        std::path::Path::new(&zip_path),
-        std::path::Path::new(&extract_dir),
-    )?;
+    let zip_path = require_existing_file_grant(&zip_path, PathAccess::ReadFile)?;
+    let extract_dir = require_existing_directory_grant(&extract_dir, PathAccess::WriteDirectory)?;
+
+    let extracted_files = tokio::task::spawn_blocking(move || {
+        extract_zip_archive(&zip_path, &extract_dir, max_total_bytes)
+    })
+    .await
+    .map_err(|e| format!("解压任务失败: {}", e))??;
 
     log::info!("✅ ZIP文件解压完成，共 {} 个文件", extracted_files.len());
     Ok(extracted_files)
+}
+
+#[cfg(test)]
+mod path_security_tests {
+    use super::{
+        normalize_local_path, overlay_http_host, register_path_grant, require_existing_file_grant,
+        validate_download_file_name, PathAccess,
+    };
+
+    #[test]
+    fn remote_http_targets_stay_inside_the_fixed_overlay() {
+        assert_eq!(overlay_http_host("10.126.126.1").unwrap(), "10.126.126.1");
+        assert_eq!(
+            overlay_http_host("10.126.126.254").unwrap(),
+            "10.126.126.254"
+        );
+        for target in [
+            "10.126.126.0",
+            "10.126.126.255",
+            "10.126.125.1",
+            "192.168.1.10",
+            "8.8.8.8",
+        ] {
+            assert!(overlay_http_host(target).is_err(), "accepted {target}");
+        }
+    }
+
+    #[test]
+    fn file_grants_are_required_for_existing_files() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let path = temp.path().join("safe.txt");
+        std::fs::write(&path, b"safe").expect("create file");
+        let path = path.to_str().expect("UTF-8 path");
+
+        assert!(require_existing_file_grant(path, PathAccess::ReadFile).is_err());
+        register_path_grant(path, PathAccess::ReadFile, false).expect("register read grant");
+        assert!(require_existing_file_grant(path, PathAccess::ReadFile).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn new_file_grants_reject_dangling_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let target = temp.path().join("missing-target");
+        let link = temp.path().join("dangling-link");
+        symlink(&target, &link).expect("create dangling symlink");
+
+        assert!(normalize_local_path(link.to_str().expect("UTF-8 path"), true).is_err());
+    }
+
+    #[test]
+    fn download_and_picker_names_reject_path_syntax() {
+        for name in [
+            "nested/file.txt",
+            "nested\\file.txt",
+            "payload:stream",
+            "bad<name>.txt",
+            "trailing.",
+            "CON.txt",
+        ] {
+            assert!(
+                validate_download_file_name(name).is_err(),
+                "accepted {name:?}"
+            );
+        }
+        assert!(validate_download_file_name("normal-file.txt").is_ok());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn local_paths_reject_ads_and_device_names() {
+        for path in [r"C:\safe\payload::$DATA", r"C:\safe\CON.txt"] {
+            assert!(
+                normalize_local_path(path, true).is_err(),
+                "accepted {path:?}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -3374,10 +4677,14 @@ mod zip_extraction_tests {
         let extract_dir = temp.path().join("output");
         create_zip(&zip_path, &[("nested/file.txt", b"safe")]);
 
-        let extracted = extract_zip_archive(&zip_path, &extract_dir).expect("extract valid zip");
+        let extracted =
+            extract_zip_archive(&zip_path, &extract_dir, None).expect("extract valid zip");
 
         assert_eq!(extracted.len(), 1);
-        assert_eq!(std::fs::read(extract_dir.join("nested/file.txt")).unwrap(), b"safe");
+        assert_eq!(
+            std::fs::read(extract_dir.join("nested/file.txt")).unwrap(),
+            b"safe"
+        );
     }
 
     #[test]
@@ -3387,10 +4694,14 @@ mod zip_extraction_tests {
         let extract_dir = temp.path().join("output");
         create_zip(
             &zip_path,
-            &[("safe.txt", b"must not be written"), ("../escape.txt", b"pwned")],
+            &[
+                ("safe.txt", b"must not be written"),
+                ("../escape.txt", b"pwned"),
+            ],
         );
 
-        let error = extract_zip_archive(&zip_path, &extract_dir).expect_err("reject traversal");
+        let error =
+            extract_zip_archive(&zip_path, &extract_dir, None).expect_err("reject traversal");
 
         assert!(error.contains("不安全的ZIP条目路径"));
         assert!(!extract_dir.join("safe.txt").exists());
@@ -3406,146 +4717,426 @@ mod zip_extraction_tests {
         std::fs::write(extract_dir.join("existing.txt"), b"original").unwrap();
         create_zip(&zip_path, &[("existing.txt", b"replacement")]);
 
-        let error = extract_zip_archive(&zip_path, &extract_dir).expect_err("reject overwrite");
+        let error =
+            extract_zip_archive(&zip_path, &extract_dir, None).expect_err("reject overwrite");
 
         assert!(error.contains("拒绝覆盖"));
-        assert_eq!(std::fs::read(extract_dir.join("existing.txt")).unwrap(), b"original");
+        assert_eq!(
+            std::fs::read(extract_dir.join("existing.txt")).unwrap(),
+            b"original"
+        );
+    }
+
+    #[test]
+    fn normalizes_backslashes_but_rejects_device_names_and_ads() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+
+        let zip_path = temp.path().join("backslash.zip");
+        let extract_dir = temp.path().join("backslash-output");
+        create_zip(&zip_path, &[(r"nested\file.txt", b"safe")]);
+        extract_zip_archive(&zip_path, &extract_dir, None).expect("extract backslash path");
+        assert_eq!(
+            std::fs::read(extract_dir.join("nested/file.txt")).unwrap(),
+            b"safe"
+        );
+
+        for (archive_name, label) in [("CON.txt", "device"), ("payload:stream", "ads")] {
+            let zip_path = temp.path().join(format!("{}.zip", label));
+            let output = temp.path().join(format!("{}-output", label));
+            create_zip(&zip_path, &[(archive_name, b"blocked")]);
+            let error = extract_zip_archive(&zip_path, &output, None)
+                .expect_err("reject Windows-special ZIP name");
+            assert!(error.contains("ZIP条目名称"));
+            assert!(!output.join(archive_name).exists());
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_normalized_entries() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let zip_path = temp.path().join("duplicate.zip");
+        let extract_dir = temp.path().join("output");
+        create_zip(&zip_path, &[("same/txt", b"one"), (r"same\txt", b"two")]);
+
+        let error = extract_zip_archive(&zip_path, &extract_dir, None)
+            .expect_err("reject duplicate normalized entries");
+        assert!(error.contains("重复条目"));
+        assert!(!extract_dir.exists() || std::fs::read_dir(&extract_dir).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn enforces_requested_uncompressed_budget() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let zip_path = temp.path().join("budget.zip");
+        let extract_dir = temp.path().join("output");
+        create_zip(&zip_path, &[("payload.bin", b"1234")]);
+
+        let error = extract_zip_archive(&zip_path, &extract_dir, Some(3))
+            .expect_err("reject over-budget archive");
+        assert!(error.contains("总解压大小超过预算"));
+        assert!(!extract_dir.join("payload.bin").exists());
+    }
+
+    #[test]
+    fn rolls_back_files_created_before_later_failure() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let zip_path = temp.path().join("rollback.zip");
+        let extract_dir = temp.path().join("output");
+        std::fs::create_dir_all(&extract_dir).unwrap();
+        std::fs::write(extract_dir.join("second.txt"), b"original").unwrap();
+        create_zip(
+            &zip_path,
+            &[("first.txt", b"temporary"), ("second.txt", b"blocked")],
+        );
+
+        let error = extract_zip_archive(&zip_path, &extract_dir, None)
+            .expect_err("reject collision and roll back");
+        assert!(error.contains("拒绝覆盖"));
+        assert!(!extract_dir.join("first.txt").exists());
+        assert_eq!(
+            std::fs::read(extract_dir.join("second.txt")).unwrap(),
+            b"original"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_extraction_root() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let outside = temp.path().join("outside");
+        let root = temp.path().join("root");
+        std::fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, &root).unwrap();
+        let zip_path = temp.path().join("root-symlink.zip");
+        create_zip(&zip_path, &[("file.txt", b"blocked")]);
+
+        let error = extract_zip_archive(&zip_path, &root, None)
+            .expect_err("reject symlink extraction root");
+        assert!(error.contains("不能是符号链接"));
+        assert!(!outside.join("file.txt").exists());
     }
 }
 
 /// 删除文件
-/// 
+///
 /// # 参数
 /// * `path` - 文件路径
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn delete_file(path: String) -> Result<(), String> {
     log::info!("🗑️ 删除文件: {}", path);
-    
-    use tokio::fs;
-    
-    fs::remove_file(&path)
+
+    let path = require_existing_file_grant(&path, PathAccess::DeleteFile)?;
+    tokio::fs::remove_file(&path)
         .await
         .map_err(|e| format!("删除文件失败: {}", e))?;
-    
-    log::info!("✅ 文件已删除: {}", path);
+
+    log::info!("✅ 文件已删除: {}", path.display());
     Ok(())
 }
 
 /// 保存文件
-/// 
+///
 /// # 参数
 /// * `path` - 文件路径
 /// * `data` - 文件数据（字节数组）
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 保存成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn save_file(path: String, data: Vec<u8>) -> Result<(), String> {
     log::info!("保存文件: {}, 大小: {} bytes", path, data.len());
-    
-    use tokio::fs;
-    use std::path::Path;
-    
-    // 确保父目录存在
-    if let Some(parent) = Path::new(&path).parent() {
-        if !parent.exists() {
-            fs::create_dir_all(parent)
-                .await
-                .map_err(|e| format!("创建目录失败: {}", e))?;
-        }
+
+    const MAX_GENERIC_FILE_BYTES: usize = 256 * 1024 * 1024;
+    if data.len() > MAX_GENERIC_FILE_BYTES {
+        return Err("文件超过通用写入大小限制".to_string());
     }
-    
-    // 写入文件
-    fs::write(&path, data)
+    let path = require_path_grant(&path, PathAccess::WriteFile, true)?;
+    if path.exists() {
+        return Err("目标文件已存在，拒绝覆盖".to_string());
+    }
+
+    use tokio::io::AsyncWriteExt;
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .await
+        .map_err(|e| format!("创建文件失败: {}", e))?;
+    file.write_all(&data)
         .await
         .map_err(|e| format!("写入文件失败: {}", e))?;
-    
-    log::info!("✅ 文件保存成功: {}", path);
+    file.sync_all()
+        .await
+        .map_err(|e| format!("同步文件失败: {}", e))?;
+
+    log::info!("✅ 文件保存成功: {}", path.display());
     Ok(())
 }
 
 /// 保存聊天图片
-/// 
+///
 /// # 参数
 /// * `image_data` - Base64编码的图片数据
-/// 
+///
 /// # 返回
 /// * `Ok(String)` - 保存的文件路径
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn save_chat_image(image_data: String) -> Result<String, String> {
+    use base64::{engine::general_purpose, Engine as _};
     use tokio::fs;
-    use base64::{Engine as _, engine::general_purpose};
-    
+
     log::info!("保存聊天图片，数据长度: {} bytes", image_data.len());
-    
+
     // 解码Base64数据
     let bytes = general_purpose::STANDARD
         .decode(&image_data)
         .map_err(|e| format!("Base64解码失败: {}", e))?;
-    
+
     log::info!("解码后图片大小: {} bytes", bytes.len());
-    
+
     // 获取下载目录
-    let download_dir = dirs::download_dir()
-        .ok_or_else(|| "无法获取下载目录".to_string())?;
-    
+    let download_dir = dirs::download_dir().ok_or_else(|| "无法获取下载目录".to_string())?;
+
     // 生成文件名
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_millis();
     let filename = format!("MCTier_聊天图片_{}.png", timestamp);
-    
+
     // 构建完整路径
     let file_path = download_dir.join(filename);
     let path_str = file_path.to_string_lossy().to_string();
-    
+
     log::info!("保存图片到: {}", path_str);
-    
+
     // 写入文件
     fs::write(&file_path, bytes)
         .await
         .map_err(|e| format!("写入文件失败: {}", e))?;
-    
+
     log::info!("✅ 聊天图片保存成功: {}", path_str);
     Ok(path_str)
 }
 
 /// 读取文件
-/// 
+///
 /// # 参数
 /// * `path` - 文件路径
-/// 
+///
 /// # 返回
 /// * `Ok(Vec<u8>)` - 文件内容
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn read_file(path: String) -> Result<Vec<u8>, String> {
     log::info!("读取文件: {}", path);
-    
-    use tokio::fs;
-    
-    // 读取文件
-    let data = fs::read(&path)
+
+    const MAX_GENERIC_FILE_BYTES: u64 = 256 * 1024 * 1024;
+    let path = require_existing_file_grant(&path, PathAccess::ReadFile)?;
+    let metadata = std::fs::symlink_metadata(&path).map_err(|e| format!("检查文件失败: {}", e))?;
+    if metadata.len() > MAX_GENERIC_FILE_BYTES {
+        return Err("文件超过通用读取大小限制".to_string());
+    }
+    let data = tokio::fs::read(&path)
         .await
         .map_err(|e| format!("读取文件失败: {}", e))?;
-    
-    log::info!("✅ 文件读取成功: {}, 大小: {} bytes", path, data.len());
+
+    log::info!(
+        "✅ 文件读取成功: {}, 大小: {} bytes",
+        path.display(),
+        data.len()
+    );
     Ok(data)
 }
 
 // ==================== P2P 聊天命令 ====================
 
-use crate::modules::chat_service::{ChatMessage as ChatServiceMessage, MessageType, SendMessageRequest};
+use crate::modules::chat_service::{
+    is_message_id_for_player, ChatMessage as ChatServiceMessage, ChatPeerIdentity, MessageType,
+    SendMessageRequest, CHAT_TOKEN_HEADER, MAX_ANNOUNCE_BYTES, MAX_AVATAR_BYTES,
+    MAX_CLIPBOARD_BYTES, MAX_HISTORY_MESSAGES, MAX_IMAGE_BYTES, MAX_IMAGE_CONTENT_BYTES,
+    MAX_RECALL_BYTES, MAX_TEXT_BYTES, MAX_TODO_BYTES, MAX_VOICE_GROUP_BYTES, MAX_WHITEBOARD_BYTES,
+    RECALL_WINDOW_SECS,
+};
+
+fn chat_http_host(raw: &str) -> Result<String, String> {
+    let ip = raw
+        .parse::<std::net::IpAddr>()
+        .map_err(|_| "聊天目标不是有效的虚拟IP".to_string())?;
+    if ip.is_unspecified() || ip.is_loopback() || ip.is_multicast() {
+        return Err("聊天目标IP不在允许范围内".to_string());
+    }
+    Ok(match ip {
+        std::net::IpAddr::V4(ip) => ip.to_string(),
+        std::net::IpAddr::V6(ip) => format!("[{}]", ip),
+    })
+}
+
+fn current_unix_seconds() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn validate_outgoing_chat_payload(
+    message_type: &MessageType,
+    content: &str,
+    image_data: Option<&Vec<u8>>,
+    local_player_id: &str,
+    local_is_host: bool,
+    local_messages: &[ChatServiceMessage],
+) -> Result<(), String> {
+    let content_bytes = content.as_bytes().len();
+    match message_type {
+        MessageType::Text => {
+            if content_bytes == 0 || content_bytes > MAX_TEXT_BYTES || image_data.is_some() {
+                return Err("文本消息为空、过长或包含多余图片数据".to_string());
+            }
+        }
+        MessageType::Image => {
+            if content_bytes > MAX_IMAGE_CONTENT_BYTES {
+                return Err("图片消息说明过长".to_string());
+            }
+            let image = image_data.ok_or_else(|| "图片消息缺少图片数据".to_string())?;
+            if image.is_empty() || image.len() > MAX_IMAGE_BYTES {
+                return Err("图片数据大小无效".to_string());
+            }
+        }
+        MessageType::Announce => {
+            if content_bytes > MAX_ANNOUNCE_BYTES || image_data.is_some() {
+                return Err("公告消息大小或数据类型无效".to_string());
+            }
+            if !local_is_host {
+                return Err("只有房主可以发送公告".to_string());
+            }
+        }
+        MessageType::VoiceGroup => {
+            if content_bytes > MAX_VOICE_GROUP_BYTES || image_data.is_some() {
+                return Err("语音小队消息大小或数据类型无效".to_string());
+            }
+            let group = content
+                .parse::<u8>()
+                .map_err(|_| "语音小队编号无效".to_string())?;
+            if group > 4 {
+                return Err("语音小队编号超出范围".to_string());
+            }
+        }
+        MessageType::Clipboard => {
+            if content_bytes > MAX_CLIPBOARD_BYTES || image_data.is_some() {
+                return Err("剪贴板消息大小或数据类型无效".to_string());
+            }
+        }
+        MessageType::Todo => {
+            if content_bytes > MAX_TODO_BYTES || image_data.is_some() {
+                return Err("待办消息大小或数据类型无效".to_string());
+            }
+        }
+        MessageType::Whiteboard => {
+            if content_bytes > MAX_WHITEBOARD_BYTES || image_data.is_some() {
+                return Err("白板消息大小或数据类型无效".to_string());
+            }
+        }
+        MessageType::Recall => {
+            if content_bytes == 0 || content_bytes > MAX_RECALL_BYTES || image_data.is_some() {
+                return Err("撤回消息参数无效".to_string());
+            }
+            let target = local_messages
+                .iter()
+                .find(|message| message.id == content)
+                .ok_or_else(|| "只能撤回本地已知消息".to_string())?;
+            if target.player_id != local_player_id
+                || current_unix_seconds().saturating_sub(target.timestamp) > RECALL_WINDOW_SECS
+            {
+                return Err("只能撤回自己两分钟内发送的消息".to_string());
+            }
+        }
+        MessageType::Avatar => {
+            if content_bytes > MAX_AVATAR_BYTES || image_data.is_some() {
+                return Err("头像消息大小或数据类型无效".to_string());
+            }
+            if !content.is_empty() && !content.starts_with("data:image/") {
+                return Err("头像消息必须使用图片 data URL".to_string());
+            }
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn configure_p2p_chat(
+    chat_token: String,
+    chat_token_epoch: u64,
+    player_id: String,
+    player_name: String,
+    host_id: Option<String>,
+    peers: Vec<ChatPeerIdentity>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    if peers.len() > MAX_CHAT_TARGETS {
+        return Err("大厅聊天成员数量超过限制".to_string());
+    }
+    let file_token = chat_token.clone();
+    let (chat_service, file_transfer) = {
+        let core = state.core.lock().await;
+        (core.get_chat_service(), core.get_file_transfer())
+    };
+    let chat_svc = chat_service.lock().await;
+    chat_svc.set_session(
+        chat_token,
+        chat_token_epoch,
+        player_id,
+        player_name,
+        host_id,
+        peers,
+    )?;
+    chat_svc
+        .start_server()
+        .await
+        .map_err(|error| format!("启动聊天服务失败: {}", error))?;
+    drop(chat_svc);
+    let result = file_transfer.lock().await.set_lobby_token(file_token);
+    result
+}
+
+#[tauri::command]
+pub async fn update_p2p_chat_peers(
+    peers: Vec<ChatPeerIdentity>,
+    host_id: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    if peers.len() > MAX_CHAT_TARGETS {
+        return Err("大厅聊天成员数量超过限制".to_string());
+    }
+    let chat_service = {
+        let core = state.core.lock().await;
+        core.get_chat_service()
+    };
+    let chat_svc = chat_service.lock().await;
+    chat_svc.update_peer_identities(peers, host_id)
+}
+
+#[tauri::command]
+pub async fn stop_p2p_chat(state: State<'_, AppState>) -> Result<(), String> {
+    let (chat_service, file_transfer) = {
+        let core = state.core.lock().await;
+        (core.get_chat_service(), core.get_file_transfer())
+    };
+    file_transfer.lock().await.clear_lobby_token();
+    chat_service.lock().await.stop_server().await;
+    Ok(())
+}
 
 /// 发送P2P聊天消息
-/// 
+///
 /// # 参数
 /// * `player_id` - 玩家ID
 /// * `player_name` - 玩家名称
@@ -3553,7 +5144,7 @@ use crate::modules::chat_service::{ChatMessage as ChatServiceMessage, MessageTyp
 /// * `message_type` - 消息类型（text/image）
 /// * `image_data` - 图片数据（可选）
 /// * `peer_ips` - 目标玩家的虚拟IP列表
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 发送成功
 /// * `Err(String)` - 错误信息
@@ -3568,14 +5159,30 @@ pub async fn send_p2p_chat_message(
     peer_ips: Vec<String>,
     state: State<'_, AppState>,
 ) -> Result<serde_json::Value, String> {
-    log::info!("💬 发送P2P聊天消息: {} - {}", player_name, content);
-    
+    let _ = player_name;
+    if peer_ips.len() > MAX_CHAT_TARGETS {
+        return Err("聊天目标数量超过限制".to_string());
+    }
+
     let core = state.core.lock().await;
     let chat_service = core.get_chat_service();
     let chat_svc = chat_service.lock().await;
-    
-    // 解析消息类型
+
+    // The renderer supplies these fields for wire compatibility only. The
+    // active chat session is the authority for both identity and targets.
+    let local_identity = chat_svc
+        .get_local_identity()
+        .ok_or_else(|| "聊天会话尚未初始化".to_string())?;
+    if player_id != local_identity.player_id {
+        return Err("聊天发送者身份与当前会话不匹配".to_string());
+    }
+    let chat_token = chat_svc
+        .get_chat_token()
+        .ok_or_else(|| "聊天令牌尚未就绪".to_string())?;
+    let local_is_host = chat_svc.local_is_host();
+
     let msg_type = match message_type.as_str() {
+        "text" => MessageType::Text,
         "image" => MessageType::Image,
         "announce" => MessageType::Announce,
         "voicegroup" => MessageType::VoiceGroup,
@@ -3584,84 +5191,124 @@ pub async fn send_p2p_chat_message(
         "whiteboard" => MessageType::Whiteboard,
         "recall" => MessageType::Recall,
         "avatar" => MessageType::Avatar,
-        _ => MessageType::Text,
+        _ => return Err("聊天消息类型无效".to_string()),
     };
-    
-    // 创建消息
+
+    let local_messages = chat_svc.get_local_messages(None);
+    validate_outgoing_chat_payload(
+        &msg_type,
+        &content,
+        image_data.as_ref(),
+        &local_identity.player_id,
+        local_is_host,
+        &local_messages,
+    )?;
+
+    let message_id = message_id
+        .filter(|id| !id.is_empty())
+        .unwrap_or_else(|| format!("msg-{}-{}", local_identity.player_id, uuid::Uuid::new_v4()));
+    if !is_message_id_for_player(&message_id, &local_identity.player_id) {
+        return Err("聊天消息ID无效".to_string());
+    }
+
+    // The renderer may request a subset for UI reasons, but it never chooses
+    // network destinations. Broadcast to the authoritative signaling roster.
+    let authoritative_peers = chat_svc.authoritative_peers();
+
     let message = ChatServiceMessage {
-        id: message_id.unwrap_or_else(|| format!("msg-{}-{}", player_id, std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis())),
-        player_id: player_id.clone(),
-        player_name: player_name.clone(),
+        id: message_id.clone(),
+        player_id: local_identity.player_id.clone(),
+        player_name: local_identity.player_name.clone(),
         content: content.clone(),
         message_type: msg_type.clone(),
-        timestamp: std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+        timestamp: current_unix_seconds(),
         image_data: image_data.clone(),
     };
-    
-    // 保存到本地消息队列
-    let message_id = message.id.clone();
-    chat_svc.add_local_message(message);
-    
-    // 【修复】获取本机虚拟IP，避免发送消息给自己
-    let my_virtual_ip = chat_svc.get_virtual_ip();
-    
+
+    // Keep an origin copy of every validated message. Remote history fetches
+    // accept only messages authored by the queried peer, preventing one peer
+    // from forging another member's history.
+    if !chat_svc.add_local_message(message) {
+        return Err("聊天消息ID重复或本地历史已满".to_string());
+    }
+
     drop(chat_svc);
     drop(core);
-    
-    // 【修复】过滤掉自己的IP
-    let other_peer_ips: Vec<String> = peer_ips.into_iter()
-        .filter(|ip| {
-            if let Some(ref my_ip) = my_virtual_ip {
-                ip != my_ip
-            } else {
-                true
-            }
-        })
-        .collect();
-    
-    log::info!("📤 [ChatService] 向 {} 个其他玩家并发发送消息 (排除自己)", other_peer_ips.len());
-    
-    let total = other_peer_ips.len();
+
+    log::info!(
+        "📤 [ChatService] 向 {} 个已授权玩家发送 {} 字节消息",
+        authoritative_peers.len(),
+        content.as_bytes().len()
+    );
+
+    let total = authoritative_peers.len();
 
     // 【优化】使用并发发送，提高图片传输速度
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10)) // 设置超时
+        .connect_timeout(std::time::Duration::from_secs(3))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| format!("创建HTTP客户端失败: {}", e))?;
-    
+
     let mut tasks = Vec::new();
-    
-    for peer_ip in other_peer_ips {
-        let url = format!("http://{}:14540/api/chat/send", peer_ip);
+
+    for peer in authoritative_peers {
+        let peer_ip = peer.virtual_ip;
+        let host = chat_http_host(&peer_ip)?;
+        let url = format!("http://{}:14540/api/chat/send", host);
         let request = SendMessageRequest {
             id: Some(message_id.clone()),
-            player_id: player_id.clone(),
-            player_name: player_name.clone(),
+            player_id: local_identity.player_id.clone(),
+            player_name: local_identity.player_name.clone(),
             content: content.clone(),
             message_type: msg_type.clone(),
             image_data: image_data.clone(),
         };
-        
+
         let client_clone = client.clone();
         let url_clone = url.clone();
-        
+        let chat_token_clone = chat_token.clone();
+
         // 创建并发任务，返回是否送达成功（带一次快速重试，降低瞬时抖动导致的漏发）
         let task = tokio::spawn(async move {
             for attempt in 0..2 {
                 let start = std::time::Instant::now();
-                match client_clone.post(&url_clone).json(&request).send().await {
+                match client_clone
+                    .post(&url_clone)
+                    .header(CHAT_TOKEN_HEADER, &chat_token_clone)
+                    .json(&request)
+                    .send()
+                    .await
+                {
                     Ok(response) => {
                         let elapsed = start.elapsed();
                         if response.status().is_success() {
-                            log::info!("✅ 消息已发送到: {} (耗时: {:?}, 第{}次)", url_clone, elapsed, attempt + 1);
+                            log::info!(
+                                "✅ 消息已发送到: {} (耗时: {:?}, 第{}次)",
+                                url_clone,
+                                elapsed,
+                                attempt + 1
+                            );
                             return true;
                         } else {
-                            log::warn!("⚠️ 发送消息失败 ({}): HTTP {} (第{}次)", url_clone, response.status(), attempt + 1);
+                            log::warn!(
+                                "⚠️ 发送消息失败 ({}): HTTP {} (第{}次)",
+                                url_clone,
+                                response.status(),
+                                attempt + 1
+                            );
                         }
                     }
                     Err(e) => {
                         let elapsed = start.elapsed();
-                        log::warn!("⚠️ 发送消息失败 ({}, 耗时: {:?}, 第{}次): {}", url_clone, elapsed, attempt + 1, e);
+                        log::warn!(
+                            "⚠️ 发送消息失败 ({}, 耗时: {:?}, 第{}次): {}",
+                            url_clone,
+                            elapsed,
+                            attempt + 1,
+                            e
+                        );
                     }
                 }
                 if attempt == 0 {
@@ -3671,10 +5318,10 @@ pub async fn send_p2p_chat_message(
             }
             false
         });
-        
+
         tasks.push(task);
     }
-    
+
     // 等待所有发送完成，统计送达数量（用于给前端回执）
     let mut delivered = 0usize;
     for task in tasks {
@@ -3682,96 +5329,74 @@ pub async fn send_p2p_chat_message(
             delivered += 1;
         }
     }
-    log::info!("🎉 [ChatService] 消息发送完成：送达 {}/{}", delivered, total);
-    
+    log::info!(
+        "🎉 [ChatService] 消息发送完成：送达 {}/{}",
+        delivered,
+        total
+    );
+
     Ok(serde_json::json!({ "delivered": delivered, "total": total, "messageId": message_id }))
 }
 
-/// 下发大厅身份名册（player_id -> 虚拟IP），用于校验聊天消息发送者身份
-///
-/// # 参数
-/// * `entries` - 大厅成员的 (player_id, virtual_ip) 列表
-/// * `state` - 应用状态
-///
-/// # 返回
-/// * `Ok(())` - 设置成功
-/// * `Err(String)` - 错误信息
-#[tauri::command]
-pub async fn set_chat_peer_roster(
-    entries: Vec<(String, String)>,
-    readers: Option<Vec<String>>,
-    state: State<'_, AppState>,
-) -> Result<(), String> {
-    let core = state.core.lock().await;
-    let chat_service = core.get_chat_service();
-    let chat_svc = chat_service.lock().await;
-    chat_svc.set_peer_roster(entries);
-    // readers 为 None/空表示"名单尚未就绪"，此时清空以放行（见 set_allowed_readers 说明）
-    chat_svc.set_allowed_readers(readers.unwrap_or_default());
-    Ok(())
-}
-
-/// 下发允许访问文件共享的大厅成员虚拟IP列表
-///
-/// # 参数
-/// * `ips` - 大厅成员虚拟IP列表（含自己）
-/// * `state` - 应用状态
-///
-/// # 返回
-/// * `Ok(())` - 设置成功
-/// * `Err(String)` - 错误信息
-#[tauri::command]
-pub async fn set_share_allowed_peers(
-    ips: Vec<String>,
-    state: State<'_, AppState>,
-) -> Result<(), String> {
-    let core = state.core.lock().await;
-    let file_transfer = core.get_file_transfer();
-    let ft_service = file_transfer.lock().await;
-    ft_service.set_allowed_peers(ips);
-    Ok(())
-}
-
-/// 清空允许访问文件共享的成员列表（退出大厅时调用）
-///
-/// # 参数
-/// * `state` - 应用状态
-///
-/// # 返回
-/// * `Ok(())` - 清空成功
-/// * `Err(String)` - 错误信息
-#[tauri::command]
-pub async fn clear_share_allowed_peers(state: State<'_, AppState>) -> Result<(), String> {
-    let core = state.core.lock().await;
-    let file_transfer = core.get_file_transfer();
-    let ft_service = file_transfer.lock().await;
-    ft_service.clear_allowed_peers();
-    Ok(())
-}
-
-/// 清空大厅身份名册（退出大厅时调用）
-///
-/// # 参数
-/// * `state` - 应用状态
-///
-/// # 返回
-/// * `Ok(())` - 清空成功
-/// * `Err(String)` - 错误信息
-#[tauri::command]
-pub async fn clear_chat_peer_roster(state: State<'_, AppState>) -> Result<(), String> {
-    let core = state.core.lock().await;
-    let chat_service = core.get_chat_service();
-    let chat_svc = chat_service.lock().await;
-    chat_svc.clear_peer_roster();
-    Ok(())
+fn is_safe_remote_chat_message(
+    message: &ChatServiceMessage,
+    expected: &ChatPeerIdentity,
+    host_id: Option<&str>,
+) -> bool {
+    if message.player_id != expected.player_id
+        || message.player_name != expected.player_name
+        || !is_message_id_for_player(&message.id, &message.player_id)
+    {
+        return false;
+    }
+    let content_bytes = message.content.as_bytes().len();
+    let shape_is_valid = match message.message_type {
+        MessageType::Text => {
+            content_bytes > 0 && content_bytes <= MAX_TEXT_BYTES && message.image_data.is_none()
+        }
+        MessageType::Image => {
+            content_bytes <= MAX_IMAGE_CONTENT_BYTES
+                && message
+                    .image_data
+                    .as_ref()
+                    .is_some_and(|image| !image.is_empty() && image.len() <= MAX_IMAGE_BYTES)
+        }
+        MessageType::Announce => {
+            content_bytes <= MAX_ANNOUNCE_BYTES
+                && message.image_data.is_none()
+                && host_id == Some(message.player_id.as_str())
+        }
+        MessageType::VoiceGroup => {
+            content_bytes <= MAX_VOICE_GROUP_BYTES
+                && message.image_data.is_none()
+                && message.content.parse::<u8>().is_ok_and(|group| group <= 4)
+        }
+        MessageType::Clipboard => {
+            content_bytes <= MAX_CLIPBOARD_BYTES && message.image_data.is_none()
+        }
+        MessageType::Todo => content_bytes <= MAX_TODO_BYTES && message.image_data.is_none(),
+        MessageType::Whiteboard => {
+            content_bytes <= MAX_WHITEBOARD_BYTES && message.image_data.is_none()
+        }
+        MessageType::Recall => {
+            content_bytes > 0 && content_bytes <= MAX_RECALL_BYTES && message.image_data.is_none()
+        }
+        MessageType::Avatar => {
+            content_bytes <= MAX_AVATAR_BYTES
+                && message.image_data.is_none()
+                && (message.content.is_empty() || message.content.starts_with("data:image/"))
+        }
+    };
+    shape_is_valid
+        && serde_json::to_vec(message).is_ok_and(|encoded| encoded.len() <= MAX_CHAT_RESPONSE_BYTES)
 }
 
 /// 获取P2P聊天消息
-/// 
+///
 /// # 参数
 /// * `peer_ips` - 玩家的虚拟IP列表
 /// * `since` - 获取此时间戳之后的消息（可选）
-/// 
+///
 /// # 返回
 /// * `Ok(Vec<ChatMessage>)` - 消息列表
 /// * `Err(String)` - 错误信息
@@ -3781,131 +5406,145 @@ pub async fn get_p2p_chat_messages(
     since: Option<u64>,
     state: State<'_, AppState>,
 ) -> Result<Vec<ChatServiceMessage>, String> {
-    let core = state.core.lock().await;
-    let chat_service = core.get_chat_service();
+    if peer_ips.len() > MAX_CHAT_TARGETS {
+        return Err("聊天目标数量超过限制".to_string());
+    }
+    let chat_service = {
+        let core = state.core.lock().await;
+        core.get_chat_service()
+    };
     let chat_svc = chat_service.lock().await;
-    
-    // 获取本地消息
     let mut all_messages = chat_svc.get_local_messages(since);
-    
-    // 【修复】获取本机虚拟IP，避免从自己这里重复获取消息
-    let my_virtual_ip = chat_svc.get_virtual_ip();
-    
+    let authoritative_peers = chat_svc.authoritative_peers();
+    let chat_token = chat_svc
+        .get_chat_token()
+        .ok_or_else(|| "聊天令牌尚未就绪".to_string())?;
+    let host_id = chat_svc.get_host_id();
     drop(chat_svc);
-    drop(core);
-    
-    // 【修复】过滤掉自己的IP，只从其他玩家获取消息
-    let other_peer_ips: Vec<String> = peer_ips.into_iter()
-        .filter(|ip| {
-            if let Some(ref my_ip) = my_virtual_ip {
-                ip != my_ip
-            } else {
-                true
-            }
-        })
-        .collect();
-    
-    log::info!("📥 [ChatService] 从 {} 个其他玩家获取消息 (排除自己)", other_peer_ips.len());
-    
-    // 【优化】创建HTTP客户端，设置更短的超时时间以减少延迟
+
+    log::info!(
+        "📥 [ChatService] 从 {} 个权威玩家获取消息",
+        authoritative_peers.len()
+    );
+
     let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_millis(800)) // 800ms超时
-        .connect_timeout(std::time::Duration::from_millis(300)) // 300ms连接超时
+        .timeout(std::time::Duration::from_secs(3))
+        .connect_timeout(std::time::Duration::from_millis(800))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| format!("创建HTTP客户端失败: {}", e))?;
 
-    // 【#13 修复】并发从所有其他玩家获取消息。
-    // 之前是顺序 await，某个玩家若发送了大图片，其响应体大、耗时长，会阻塞
-    // 拉取其它所有玩家的消息（队头阻塞）。改为每个 peer 一个并发任务后，
-    // 单个大响应不再拖慢其他人的消息接收。
     let mut tasks = Vec::new();
-    for peer_ip in other_peer_ips {
+    for peer in authoritative_peers {
+        let host = chat_http_host(&peer.virtual_ip)?;
         let url = if let Some(ts) = since {
-            format!("http://{}:14540/api/chat/messages?since={}", peer_ip, ts)
+            format!("http://{}:14540/api/chat/messages?since={}", host, ts)
         } else {
-            format!("http://{}:14540/api/chat/messages", peer_ip)
+            format!("http://{}:14540/api/chat/messages", host)
         };
         let client_clone = client.clone();
-        let peer_ip_clone = peer_ip.clone();
+        let token = chat_token.clone();
+        let expected = peer.clone();
+        let expected_ip = peer.virtual_ip.clone();
+        let expected_host_id = host_id.clone();
         tasks.push(tokio::spawn(async move {
-            match client_clone.get(&url).send().await {
+            match client_clone
+                .get(&url)
+                .header(CHAT_TOKEN_HEADER, token)
+                .send()
+                .await
+            {
                 Ok(response) => {
                     if response.status().is_success() {
-                        match response.json::<Vec<ChatServiceMessage>>().await {
-                            Ok(messages) => {
-                                log::debug!("✅ 从 {} 获取到 {} 条消息", peer_ip_clone, messages.len());
-                                messages
+                        let body = match read_remote_body_limited(response, MAX_CHAT_RESPONSE_BYTES)
+                            .await
+                        {
+                            Ok(body) => body,
+                            Err(error) => {
+                                log::warn!("⚠️ 聊天历史响应超限 ({}): {}", expected_ip, error);
+                                return Vec::new();
                             }
-                            Err(e) => {
-                                log::warn!("⚠️ 解析消息失败 ({}): {}", peer_ip_clone, e);
-                                Vec::new()
-                            }
+                        };
+                        let Ok(mut messages) =
+                            serde_json::from_slice::<Vec<ChatServiceMessage>>(&body)
+                        else {
+                            log::warn!("⚠️ 聊天历史 JSON 无效 ({})", expected_ip);
+                            return Vec::new();
+                        };
+                        if messages.len() > MAX_HISTORY_MESSAGES {
+                            log::warn!("⚠️ 聊天历史条数超限 ({})", expected_ip);
+                            return Vec::new();
                         }
+                        messages.retain(|message| {
+                            is_safe_remote_chat_message(
+                                message,
+                                &expected,
+                                expected_host_id.as_deref(),
+                            )
+                        });
+                        log::debug!("✅ 从 {} 获取到 {} 条本人消息", expected_ip, messages.len());
+                        messages
                     } else {
-                        log::warn!("⚠️ HTTP请求失败 ({}): 状态码 {}", peer_ip_clone, response.status());
+                        log::warn!(
+                            "⚠️ HTTP请求失败 ({}): 状态码 {}",
+                            expected_ip,
+                            response.status()
+                        );
                         Vec::new()
                     }
                 }
                 Err(e) => {
-                    // 超时或连接失败不打印警告，避免日志刷屏
-                    log::debug!("⚠️ 获取消息失败 ({}): {}", peer_ip_clone, e);
+                    log::debug!("⚠️ 获取消息失败 ({}): {}", expected_ip, e);
                     Vec::new()
                 }
             }
         }));
     }
 
-    // 汇总所有并发任务的结果
     for task in tasks {
         if let Ok(messages) = task.await {
             all_messages.extend(messages);
         }
     }
-    
-    // 按时间戳排序
+
     all_messages.sort_by_key(|msg| msg.timestamp);
-    
-    // 去重（基于消息ID）
     let mut seen_ids = std::collections::HashSet::new();
     all_messages.retain(|msg| seen_ids.insert(msg.id.clone()));
-    
+
     Ok(all_messages)
 }
 
 /// 清空本地聊天消息
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 清空成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn clear_p2p_chat_messages(
-    state: State<'_, AppState>,
-) -> Result<(), String> {
+pub async fn clear_p2p_chat_messages(state: State<'_, AppState>) -> Result<(), String> {
     log::info!("🗑️ 清空本地聊天消息");
-    
+
     let core = state.core.lock().await;
     let chat_service = core.get_chat_service();
     let chat_svc = chat_service.lock().await;
-    
+
     chat_svc.clear_local_messages();
-    
+
     Ok(())
 }
-
 
 // ==================== 屏幕共享命令 ====================
 
 /// 打开屏幕查看窗口
-/// 
+///
 /// # 参数
 /// * `share_id` - 共享ID
 /// 打开屏幕查看窗口
-/// 
+///
 /// # 参数
 /// * `share_id` - 共享ID
 /// * `player_name` - 共享者名称
 /// * `app` - Tauri应用句柄
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 成功
 /// * `Err(String)` - 错误信息
@@ -3915,11 +5554,15 @@ pub async fn open_screen_viewer_window(
     player_name: String,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    log::info!("打开屏幕查看窗口: share_id={}, player_name={}", share_id, player_name);
-    
+    log::info!(
+        "打开屏幕查看窗口: share_id={}, player_name={}",
+        share_id,
+        player_name
+    );
+
     use tauri::Manager;
     use tauri::WebviewWindowBuilder;
-    
+
     // 检查窗口是否已存在
     let window_label = "screen-viewer";
     if let Some(existing_window) = app.get_webview_window(window_label) {
@@ -3928,13 +5571,14 @@ pub async fn open_screen_viewer_window(
         // 等待窗口关闭
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     }
-    
+
     // 构建URL，包含查询参数
-    let url = format!("index.html?screen-viewer=true&shareId={}&playerName={}", 
-        urlencoding::encode(&share_id), 
+    let url = format!(
+        "index.html?screen-viewer=true&shareId={}&playerName={}",
+        urlencoding::encode(&share_id),
         urlencoding::encode(&player_name)
     );
-    
+
     // 创建新窗口
     let _window = WebviewWindowBuilder::new(
         &app,
@@ -3950,7 +5594,7 @@ pub async fn open_screen_viewer_window(
     .center()
     .build()
     .map_err(|e| format!("创建窗口失败: {}", e))?;
-    
+
     log::info!("✅ 屏幕查看窗口已打开");
     Ok(())
 }
@@ -4039,17 +5683,21 @@ pub async fn open_game_hud_window(app: tauri::AppHandle) -> Result<(), String> {
         let _ = existing.set_ignore_cursor_events(true);
         return Ok(());
     }
-    let mut builder = WebviewWindowBuilder::new(&app, label, tauri::WebviewUrl::App("index.html?gamehud=true".into()))
-        .title("MCTier HUD")
-        .decorations(false)
-        .transparent(true)
-        .always_on_top(true)
-        .skip_taskbar(true)
-        .shadow(false)
-        .resizable(false)
-        .focused(false)
-        .visible(false)
-        .inner_size(600.0, 600.0);
+    let mut builder = WebviewWindowBuilder::new(
+        &app,
+        label,
+        tauri::WebviewUrl::App("index.html?gamehud=true".into()),
+    )
+    .title("MCTier HUD")
+    .decorations(false)
+    .transparent(true)
+    .always_on_top(true)
+    .skip_taskbar(true)
+    .shadow(false)
+    .resizable(false)
+    .focused(false)
+    .visible(false)
+    .inner_size(600.0, 600.0);
     // 设为主窗口的子(owner)窗口：主程序进程结束时，HUD 窗口由系统随父窗口一并立即销毁，
     // 避免主程序被杀后 HUD 还残留几秒。
     if let Some(main_win) = app.get_webview_window("main") {
@@ -4176,34 +5824,33 @@ pub async fn save_danmaku_image(data_url: String) -> Result<String, String> {
 }
 
 /// 打开日志文件所在的文件夹
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn open_log_folder() -> Result<(), String> {
     log::info!("打开日志文件夹");
-    
+
     // 获取日志文件路径
     let log_path = if let Some(data_dir) = dirs::data_local_dir() {
         data_dir.join("MCTier")
     } else {
-        std::env::current_dir()
-            .map_err(|e| format!("获取当前目录失败: {}", e))?
+        std::env::current_dir().map_err(|e| format!("获取当前目录失败: {}", e))?
     };
-    
+
     log::info!("日志文件夹路径: {:?}", log_path);
-    
+
     // 确保目录存在
     if !log_path.exists() {
         return Err("日志文件夹不存在".to_string());
     }
-    
+
     // 打开文件夹
     #[cfg(target_os = "windows")]
     {
         use std::process::Command;
-        match Command::new("explorer.exe")
+        match Command::new(windows_system_command("explorer.exe"))
             .arg(&log_path)
             .spawn()
         {
@@ -4217,7 +5864,7 @@ pub async fn open_log_folder() -> Result<(), String> {
             }
         }
     }
-    
+
     #[cfg(not(target_os = "windows"))]
     {
         Err("当前平台不支持此功能".to_string())
@@ -4225,34 +5872,34 @@ pub async fn open_log_folder() -> Result<(), String> {
 }
 
 /// 打开日志文件（使用默认文本编辑器）
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn open_log_file() -> Result<(), String> {
     log::info!("打开日志文件");
-    
+
     // 获取日志文件路径
     let log_path = if let Some(data_dir) = dirs::data_local_dir() {
         data_dir.join("MCTier").join("mctier.log")
     } else {
         std::path::PathBuf::from("mctier.log")
     };
-    
+
     log::info!("日志文件路径: {:?}", log_path);
-    
+
     // 确保文件存在
     if !log_path.exists() {
         return Err("日志文件不存在".to_string());
     }
-    
+
     // 打开文件
     #[cfg(target_os = "windows")]
     {
         use std::process::Command;
         // 使用notepad打开日志文件
-        match Command::new("notepad.exe")
+        match Command::new(windows_system_command("notepad.exe"))
             .arg(&log_path)
             .spawn()
         {
@@ -4266,7 +5913,7 @@ pub async fn open_log_file() -> Result<(), String> {
             }
         }
     }
-    
+
     #[cfg(not(target_os = "windows"))]
     {
         Err("当前平台不支持此功能".to_string())
@@ -4274,7 +5921,7 @@ pub async fn open_log_file() -> Result<(), String> {
 }
 
 /// 获取日志文件路径
-/// 
+///
 /// # 返回
 /// * `Ok(String)` - 日志文件路径
 /// * `Err(String)` - 错误信息
@@ -4285,7 +5932,7 @@ pub async fn get_log_file_path() -> Result<String, String> {
     } else {
         std::path::PathBuf::from("mctier.log")
     };
-    
+
     Ok(log_path.to_string_lossy().to_string())
 }
 
@@ -4318,7 +5965,7 @@ pub async fn read_log_file() -> Result<String, String> {
 /// * `lobby_name` - 大厅名称
 /// * `lobby_password` - 大厅密码
 /// 保存设置
-/// 
+///
 /// # 参数
 /// * `auto_startup` - 开机自启
 /// * `auto_lobby_enabled` - 自动大厅启用
@@ -4368,167 +6015,205 @@ pub async fn save_settings(
     log::info!("保存设置: auto_startup={}, auto_lobby_enabled={}, use_private_server={}, always_on_top={:?}, remember_window_position={:?}, voice_volume={:?}, enable_gpu_rendering={:?}, mic_hotkey={:?}, global_mute_hotkey={:?}, push_to_talk_hotkey={:?}, enable_exit_node={:?}, subnet_proxy_cidrs={:?}, virtual_domain={:?}", 
         auto_startup, auto_lobby_enabled, use_private_server, always_on_top, remember_window_position, voice_volume, enable_gpu_rendering, mic_hotkey, global_mute_hotkey, push_to_talk_hotkey, enable_exit_node, subnet_proxy_cidrs, virtual_domain);
 
+    let legacy_config_password = {
+        let core = state.core.lock().await;
+        let config_manager = core.get_config_manager();
+        let cfg_mgr = config_manager.lock().await;
+        cfg_mgr
+            .get_config()
+            .auto_lobby
+            .as_ref()
+            .and_then(|auto_lobby| auto_lobby.lobby_password.clone())
+    };
+    if let Some(password) = lobby_password.clone().or(legacy_config_password) {
+        tokio::task::spawn_blocking(move || write_auto_lobby_secret(&password))
+            .await
+            .map_err(|error| format!("保存系统凭据任务失败: {}", error))??;
+    }
+
     // 1. 保存配置到文件
     {
         let core = state.core.lock().await;
         let config_manager = core.get_config_manager();
         let mut cfg_mgr = config_manager.lock().await;
-        cfg_mgr.update_config(|config| {
-            if let Some(value) = language.as_deref() {
-                if matches!(value, "system" | "zh" | "en") {
-                    config.language = Some(value.to_string());
-                }
-            }
-            config.auto_startup = Some(auto_startup);
-            // 读取已有的auto_lobby配置，只更新非None的字段
-            let existing = config.auto_lobby.clone().unwrap_or_default();
-            
-            // 如果传入了 lobby_name、lobby_password 或 player_name，则更新这些字段
-            // 如果传入了 use_domain 或 virtual_domain，则更新这些字段（独立于其他字段）
-            let updated_use_domain = if lobby_name.is_some() || lobby_password.is_some() || player_name.is_some() || virtual_domain.is_some() {
-                use_domain
-            } else {
-                existing.use_domain
-            };
-            
-            let updated_virtual_domain = if virtual_domain.is_some() {
-                virtual_domain.clone()
-            } else {
-                existing.virtual_domain.clone()
-            };
-            
-            log::info!("更新 auto_lobby 配置: use_domain={}, virtual_domain={:?}", updated_use_domain, updated_virtual_domain);
-            
-            config.auto_lobby = Some(AutoLobbyConfig {
-                enabled: auto_lobby_enabled,
-                lobby_name: lobby_name.clone().or(existing.lobby_name),
-                lobby_password: lobby_password.clone().or(existing.lobby_password),
-                player_name: player_name.clone().or(existing.player_name),
-                use_domain: updated_use_domain,
-                virtual_domain: updated_virtual_domain,
-            });
-            // 保存私有服务器配置
-            config.use_private_server = Some(use_private_server);
-            // 【修复】仅在调用方明确传入时才更新私有服务器地址，
-            // 避免「保存节点列表」等只关心部分设置的调用传 null 时，把已保存的地址抹掉
-            if private_easytier_server.is_some() {
-                config.private_easytier_server = private_easytier_server.clone();
-            }
-            if private_signaling_server.is_some() {
-                config.private_signaling_server = private_signaling_server.clone();
-            }
-            // 保存窗口置顶配置
-            if let Some(on_top) = always_on_top {
-                config.always_on_top = Some(on_top);
-            }
-            // 保存记住窗口位置配置
-            if let Some(remember) = remember_window_position {
-                config.remember_window_position = Some(remember);
-                // 如果关闭记住位置，清除已保存的位置
-                if !remember {
-                    config.window_position = None;
-                }
-            }
-            // 保存「关闭时最小化到托盘」配置
-            if let Some(v) = close_to_tray {
-                config.close_to_tray = Some(v);
-            }
-            // 保存「启动后自动隐藏到托盘」配置
-            if let Some(v) = start_minimized {
-                config.start_minimized = Some(v);
-            }
-            // 保存自定义 EasyTier 节点
-            if let Some(nodes_json) = custom_easytier_nodes.clone() {
-                let nodes: Vec<EasyTierNode> = nodes_json.iter().filter_map(|n| {
-                    if let (Some(name), Some(address)) = (n.get("name").and_then(|v| v.as_str()), n.get("address").and_then(|v| v.as_str())) {
-                        Some(EasyTierNode {
-                            name: name.to_string(),
-                            address: address.to_string(),
-                        })
-                    } else {
-                        None
+        cfg_mgr
+            .update_config(|config| {
+                if let Some(value) = language.as_deref() {
+                    if matches!(value, "system" | "zh" | "en") {
+                        config.language = Some(value.to_string());
                     }
-                }).collect();
-                config.custom_easytier_nodes = Some(nodes);
-            }
-            // 保存语音音量
-            if let Some(volume) = voice_volume {
-                config.voice_volume = Some(volume.clamp(0.0, 1.0));
-            }
-            // 保存 GPU 渲染设置
-            if let Some(enable) = enable_gpu_rendering {
-                config.enable_gpu_rendering = Some(enable);
-            }
-            // 保存快捷键设置
-            if let Some(hotkey) = mic_hotkey {
-                config.mic_hotkey = Some(hotkey);
-            }
-            if let Some(hotkey) = global_mute_hotkey {
-                config.global_mute_hotkey = Some(hotkey);
-            }
-            if let Some(hotkey) = push_to_talk_hotkey {
-                config.push_to_talk_hotkey = Some(hotkey);
-            }
-            if let Some(hotkey) = summon_hotkey {
-                config.summon_hotkey = Some(hotkey);
-            }
-            // 保存出口节点配置
-            if let Some(enable) = enable_exit_node {
-                if config.exit_node_config.is_none() {
-                    config.exit_node_config = Some(crate::modules::config_manager::ExitNodeConfig::default());
                 }
-                if let Some(ref mut exit_config) = config.exit_node_config {
-                    exit_config.enable_exit_node = enable;
+                config.auto_startup = Some(auto_startup);
+                // 读取已有的auto_lobby配置，只更新非None的字段
+                let existing = config.auto_lobby.clone().unwrap_or_default();
+
+                // 如果传入了 lobby_name、lobby_password 或 player_name，则更新这些字段
+                // 如果传入了 use_domain 或 virtual_domain，则更新这些字段（独立于其他字段）
+                let updated_use_domain = if lobby_name.is_some()
+                    || lobby_password.is_some()
+                    || player_name.is_some()
+                    || virtual_domain.is_some()
+                {
+                    use_domain
+                } else {
+                    existing.use_domain
+                };
+
+                let updated_virtual_domain = if virtual_domain.is_some() {
+                    virtual_domain.clone()
+                } else {
+                    existing.virtual_domain.clone()
+                };
+
+                log::info!(
+                    "更新 auto_lobby 配置: use_domain={}, virtual_domain={:?}",
+                    updated_use_domain,
+                    updated_virtual_domain
+                );
+
+                config.auto_lobby = Some(AutoLobbyConfig {
+                    enabled: auto_lobby_enabled,
+                    lobby_name: lobby_name.clone().or(existing.lobby_name),
+                    lobby_password: None,
+                    player_name: player_name.clone().or(existing.player_name),
+                    use_domain: updated_use_domain,
+                    virtual_domain: updated_virtual_domain,
+                });
+                // 保存私有服务器配置
+                config.use_private_server = Some(use_private_server);
+                // 【修复】仅在调用方明确传入时才更新私有服务器地址，
+                // 避免「保存节点列表」等只关心部分设置的调用传 null 时，把已保存的地址抹掉
+                if private_easytier_server.is_some() {
+                    config.private_easytier_server = private_easytier_server.clone();
                 }
-            }
-            if let Some(enable) = enable_as_exit_node {
-                if config.exit_node_config.is_none() {
-                    config.exit_node_config = Some(crate::modules::config_manager::ExitNodeConfig::default());
+                if private_signaling_server.is_some() {
+                    config.private_signaling_server = private_signaling_server.clone();
                 }
-                if let Some(ref mut exit_config) = config.exit_node_config {
-                    exit_config.enable_as_exit_node = enable;
+                // 保存窗口置顶配置
+                if let Some(on_top) = always_on_top {
+                    config.always_on_top = Some(on_top);
                 }
-            }
-            if let Some(cidrs) = proxy_cidrs {
-                if config.exit_node_config.is_none() {
-                    config.exit_node_config = Some(crate::modules::config_manager::ExitNodeConfig::default());
+                // 保存记住窗口位置配置
+                if let Some(remember) = remember_window_position {
+                    config.remember_window_position = Some(remember);
+                    // 如果关闭记住位置，清除已保存的位置
+                    if !remember {
+                        config.window_position = None;
+                    }
                 }
-                if let Some(ref mut exit_config) = config.exit_node_config {
-                    // 将字符串按行分割成 Vec<String>
-                    exit_config.proxy_cidrs = cidrs
-                        .lines()
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty())
+                // 保存「关闭时最小化到托盘」配置
+                if let Some(v) = close_to_tray {
+                    config.close_to_tray = Some(v);
+                }
+                // 保存「启动后自动隐藏到托盘」配置
+                if let Some(v) = start_minimized {
+                    config.start_minimized = Some(v);
+                }
+                // 保存自定义 EasyTier 节点
+                if let Some(nodes_json) = custom_easytier_nodes.clone() {
+                    let nodes: Vec<EasyTierNode> = nodes_json
+                        .iter()
+                        .filter_map(|n| {
+                            if let (Some(name), Some(address)) = (
+                                n.get("name").and_then(|v| v.as_str()),
+                                n.get("address").and_then(|v| v.as_str()),
+                            ) {
+                                Some(EasyTierNode {
+                                    name: name.to_string(),
+                                    address: address.to_string(),
+                                })
+                            } else {
+                                None
+                            }
+                        })
                         .collect();
+                    config.custom_easytier_nodes = Some(nodes);
                 }
-            }
-            if let Some(nodes) = exit_nodes {
-                if config.exit_node_config.is_none() {
-                    config.exit_node_config = Some(crate::modules::config_manager::ExitNodeConfig::default());
+                // 保存语音音量
+                if let Some(volume) = voice_volume {
+                    config.voice_volume = Some(volume.clamp(0.0, 1.0));
                 }
-                if let Some(ref mut exit_config) = config.exit_node_config {
-                    // 将字符串按行分割成 Vec<String>
-                    exit_config.exit_nodes = nodes
-                        .lines()
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect();
+                // 保存 GPU 渲染设置
+                if let Some(enable) = enable_gpu_rendering {
+                    config.enable_gpu_rendering = Some(enable);
                 }
-            }
-            if let Some(subnet_cidrs) = subnet_proxy_cidrs {
-                if config.exit_node_config.is_none() {
-                    config.exit_node_config = Some(crate::modules::config_manager::ExitNodeConfig::default());
+                // 保存快捷键设置
+                if let Some(hotkey) = mic_hotkey {
+                    config.mic_hotkey = Some(hotkey);
                 }
-                if let Some(ref mut exit_config) = config.exit_node_config {
-                    // 将字符串按行分割成 Vec<String>
-                    exit_config.subnet_proxy_cidrs = subnet_cidrs
-                        .lines()
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect();
+                if let Some(hotkey) = global_mute_hotkey {
+                    config.global_mute_hotkey = Some(hotkey);
                 }
-            }
-        }).await.map_err(|e| format!("保存配置失败: {}", e))?;
+                if let Some(hotkey) = push_to_talk_hotkey {
+                    config.push_to_talk_hotkey = Some(hotkey);
+                }
+                if let Some(hotkey) = summon_hotkey {
+                    config.summon_hotkey = Some(hotkey);
+                }
+                // 保存出口节点配置
+                if let Some(enable) = enable_exit_node {
+                    if config.exit_node_config.is_none() {
+                        config.exit_node_config =
+                            Some(crate::modules::config_manager::ExitNodeConfig::default());
+                    }
+                    if let Some(ref mut exit_config) = config.exit_node_config {
+                        exit_config.enable_exit_node = enable;
+                    }
+                }
+                if let Some(enable) = enable_as_exit_node {
+                    if config.exit_node_config.is_none() {
+                        config.exit_node_config =
+                            Some(crate::modules::config_manager::ExitNodeConfig::default());
+                    }
+                    if let Some(ref mut exit_config) = config.exit_node_config {
+                        exit_config.enable_as_exit_node = enable;
+                    }
+                }
+                if let Some(cidrs) = proxy_cidrs {
+                    if config.exit_node_config.is_none() {
+                        config.exit_node_config =
+                            Some(crate::modules::config_manager::ExitNodeConfig::default());
+                    }
+                    if let Some(ref mut exit_config) = config.exit_node_config {
+                        // 将字符串按行分割成 Vec<String>
+                        exit_config.proxy_cidrs = cidrs
+                            .lines()
+                            .map(|s| s.trim().to_string())
+                            .filter(|s| !s.is_empty())
+                            .collect();
+                    }
+                }
+                if let Some(nodes) = exit_nodes {
+                    if config.exit_node_config.is_none() {
+                        config.exit_node_config =
+                            Some(crate::modules::config_manager::ExitNodeConfig::default());
+                    }
+                    if let Some(ref mut exit_config) = config.exit_node_config {
+                        // 将字符串按行分割成 Vec<String>
+                        exit_config.exit_nodes = nodes
+                            .lines()
+                            .map(|s| s.trim().to_string())
+                            .filter(|s| !s.is_empty())
+                            .collect();
+                    }
+                }
+                if let Some(subnet_cidrs) = subnet_proxy_cidrs {
+                    if config.exit_node_config.is_none() {
+                        config.exit_node_config =
+                            Some(crate::modules::config_manager::ExitNodeConfig::default());
+                    }
+                    if let Some(ref mut exit_config) = config.exit_node_config {
+                        // 将字符串按行分割成 Vec<String>
+                        exit_config.subnet_proxy_cidrs = subnet_cidrs
+                            .lines()
+                            .map(|s| s.trim().to_string())
+                            .filter(|s| !s.is_empty())
+                            .collect();
+                    }
+                }
+            })
+            .await
+            .map_err(|e| format!("保存配置失败: {}", e))?;
     }
 
     // 2. 应用窗口置顶设置到主窗口
@@ -4556,14 +6241,41 @@ pub async fn save_settings(
 #[tauri::command]
 pub async fn get_settings(state: State<'_, AppState>) -> Result<serde_json::Value, String> {
     log::info!("开始读取设置配置");
-    
-    let core = state.core.lock().await;
-    let config_manager = core.get_config_manager();
-    let cfg_mgr = config_manager.lock().await;
-    let config = cfg_mgr.get_config();
+
+    let config = {
+        let core = state.core.lock().await;
+        let config_manager = core.get_config_manager();
+        let cfg_mgr = config_manager.lock().await;
+        cfg_mgr.get_config().clone()
+    };
 
     let _auto_startup = config.auto_startup.unwrap_or(false);
     let auto_lobby = config.auto_lobby.clone().unwrap_or_default();
+    let mut lobby_password = tokio::task::spawn_blocking(read_auto_lobby_secret)
+        .await
+        .map_err(|error| format!("读取系统凭据任务失败: {}", error))?;
+    if let Some(legacy_password) = auto_lobby.lobby_password.clone() {
+        if lobby_password.is_none() {
+            let password = legacy_password.clone();
+            match tokio::task::spawn_blocking(move || write_auto_lobby_secret(&password)).await {
+                Ok(Ok(())) => lobby_password = Some(legacy_password),
+                Ok(Err(error)) => log::warn!("迁移自动大厅密码失败: {}", error),
+                Err(error) => log::warn!("迁移系统凭据任务失败: {}", error),
+            }
+        }
+
+        let core = state.core.lock().await;
+        let config_manager = core.get_config_manager();
+        let mut cfg_mgr = config_manager.lock().await;
+        cfg_mgr
+            .update_config(|config| {
+                if let Some(auto_lobby) = config.auto_lobby.as_mut() {
+                    auto_lobby.lobby_password = None;
+                }
+            })
+            .await
+            .map_err(|error| format!("清理配置中的明文密码失败: {}", error))?;
+    }
 
     // 同时读取实际的开机自启状态
     // 直接查询注册表，不通过command函数（避免嵌套async调用死锁）
@@ -4573,22 +6285,28 @@ pub async fn get_settings(state: State<'_, AppState>) -> Result<serde_json::Valu
         {
             use std::os::windows::process::CommandExt;
             use std::time::Duration;
-            
+
             log::info!("查询注册表中的开机自启状态");
-            
+
             // 使用 tokio::time::timeout 添加超时保护
             let result = tokio::time::timeout(
                 Duration::from_secs(2), // 2秒超时
                 tokio::task::spawn_blocking(|| {
-                    std::process::Command::new("reg")
-                        .args(["query", "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", "/v", "MCTier"])
+                    std::process::Command::new(windows_system_command("reg.exe"))
+                        .args([
+                            "query",
+                            "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+                            "/v",
+                            "MCTier",
+                        ])
                         .creation_flags(0x08000000)
                         .output()
                         .map(|o| o.status.success())
                         .unwrap_or(false)
-                })
-            ).await;
-            
+                }),
+            )
+            .await;
+
             match result {
                 Ok(Ok(status)) => {
                     log::info!("注册表查询成功: {}", status);
@@ -4605,7 +6323,9 @@ pub async fn get_settings(state: State<'_, AppState>) -> Result<serde_json::Valu
             }
         }
         #[cfg(not(windows))]
-        { false }
+        {
+            false
+        }
     };
 
     log::info!("设置配置读取完成");
@@ -4618,7 +6338,7 @@ pub async fn get_settings(state: State<'_, AppState>) -> Result<serde_json::Valu
         "autoStartup": actual_auto_start,
         "autoLobbyEnabled": auto_lobby.enabled,
         "lobbyName": auto_lobby.lobby_name,
-        "lobbyPassword": auto_lobby.lobby_password,
+        "lobbyPassword": lobby_password,
         "playerName": auto_lobby.player_name,
         "avatarData": config.avatar_data.clone(),
         "useDomain": auto_lobby.use_domain,
@@ -4662,9 +6382,12 @@ pub async fn set_avatar_data(
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut cfg_mgr = config_manager.lock().await;
-    cfg_mgr.update_config(|config| {
-        config.avatar_data = avatar_data.clone();
-    }).await.map_err(|e| format!("保存头像失败: {}", e))
+    cfg_mgr
+        .update_config(|config| {
+            config.avatar_data = avatar_data.clone();
+        })
+        .await
+        .map_err(|e| format!("保存头像失败: {}", e))
 }
 
 #[tauri::command]
@@ -4682,25 +6405,27 @@ pub async fn clear_avatar_cache() -> Result<(), String> {
 }
 
 /// 保存语音音量
-/// 
+///
 /// # 参数
 /// * `volume` - 音量值 (0.0-1.0)
 /// * `state` - 应用状态
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 保存成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn save_voice_volume(volume: f64, state: State<'_, AppState>) -> Result<(), String> {
     log::info!("保存语音音量: {}", volume);
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut cfg_mgr = config_manager.lock().await;
-    
-    cfg_mgr.set_voice_volume(volume).await
+
+    cfg_mgr
+        .set_voice_volume(volume)
+        .await
         .map_err(|e| format!("保存音量失败: {}", e))?;
-    
+
     log::info!("语音音量保存成功");
     Ok(())
 }
@@ -4708,18 +6433,18 @@ pub async fn save_voice_volume(volume: f64, state: State<'_, AppState>) -> Resul
 // ==================== 配置重置命令 ====================
 
 /// 重置配置为默认值
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 重置成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
 pub async fn reset_config_to_default(state: State<'_, AppState>) -> Result<(), String> {
     log::info!("收到重置配置命令");
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut cfg_mgr = config_manager.lock().await;
-    
+
     match cfg_mgr.reset_to_default().await {
         Ok(_) => {
             log::info!("配置已重置为默认值");
@@ -4735,11 +6460,11 @@ pub async fn reset_config_to_default(state: State<'_, AppState>) -> Result<(), S
 // ==================== 配置导入导出命令 ====================
 
 /// 导出配置到文件
-/// 
+///
 /// # 参数
 /// * `export_path` - 导出文件路径
 /// * `state` - 应用状态
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 导出成功
 /// * `Err(String)` - 错误信息
@@ -4747,11 +6472,22 @@ pub async fn reset_config_to_default(state: State<'_, AppState>) -> Result<(), S
 pub async fn export_config(export_path: String, state: State<'_, AppState>) -> Result<(), String> {
     log::info!("导出配置到: {}", export_path);
 
+    let export_path = require_path_grant(&export_path, PathAccess::WriteFile, true)?;
+    if export_path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_none_or(|extension| !extension.eq_ignore_ascii_case("json"))
+    {
+        return Err("配置导出路径必须使用 .json 扩展名".to_string());
+    }
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let cfg_mgr = config_manager.lock().await;
 
-    cfg_mgr.export_config(std::path::PathBuf::from(export_path)).await
+    cfg_mgr
+        .export_config(export_path)
+        .await
         .map_err(|e| format!("导出配置失败: {}", e))?;
 
     log::info!("配置导出成功");
@@ -4759,11 +6495,11 @@ pub async fn export_config(export_path: String, state: State<'_, AppState>) -> R
 }
 
 /// 从文件导入配置
-/// 
+///
 /// # 参数
 /// * `import_path` - 导入文件路径
 /// * `state` - 应用状态
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 导入成功
 /// * `Err(String)` - 错误信息
@@ -4771,11 +6507,22 @@ pub async fn export_config(export_path: String, state: State<'_, AppState>) -> R
 pub async fn import_config(import_path: String, state: State<'_, AppState>) -> Result<(), String> {
     log::info!("从文件导入配置: {}", import_path);
 
+    let import_path = require_existing_file_grant(&import_path, PathAccess::ReadFile)?;
+    if import_path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_none_or(|extension| !extension.eq_ignore_ascii_case("json"))
+    {
+        return Err("配置导入路径必须使用 .json 扩展名".to_string());
+    }
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut cfg_mgr = config_manager.lock().await;
 
-    cfg_mgr.import_config(std::path::PathBuf::from(import_path)).await
+    cfg_mgr
+        .import_config(import_path)
+        .await
         .map_err(|e| format!("导入配置失败: {}", e))?;
 
     log::info!("配置导入成功");
@@ -4785,84 +6532,71 @@ pub async fn import_config(import_path: String, state: State<'_, AppState>) -> R
 // ==================== GPU 设置命令 ====================
 
 /// 重启应用并应用 GPU 设置
-/// 
+///
 /// # 参数
 /// * `enable_gpu` - 是否启用 GPU 渲染
 /// * `app` - 应用句柄
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 重启成功
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn restart_app_with_gpu_settings(enable_gpu: bool, app: tauri::AppHandle) -> Result<(), String> {
+pub async fn restart_app_with_gpu_settings(
+    enable_gpu: bool,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
     log::info!("重启应用以应用 GPU 设置: enable_gpu={}", enable_gpu);
-    
+
     use std::process::Command;
-    
+
     // 获取当前可执行文件路径
-    let exe_path = std::env::current_exe()
-        .map_err(|e| format!("获取程序路径失败: {}", e))?;
-    
+    let exe_path = std::env::current_exe().map_err(|e| format!("获取程序路径失败: {}", e))?;
+
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        
-        // 使用 PowerShell 启动新进程，确保环境变量正确传递
-        let ps_script = if !enable_gpu {
-            // 完全禁用 GPU（包括GPU进程）
-            format!(
-                "$env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS='--disable-gpu --disable-software-rasterizer --disable-gpu-compositing --disable-gpu-process-crash-limit --in-process-gpu'; Start-Process -FilePath '{}' -WindowStyle Hidden",
-                exe_path.to_string_lossy().replace("\\", "\\\\")
-            )
+
+        let browser_arguments = if !enable_gpu {
+            "--disable-gpu --disable-software-rasterizer --disable-gpu-compositing --disable-gpu-process-crash-limit --in-process-gpu"
         } else {
-            // 启用 GPU，明确设置启用硬件加速的参数
-            format!(
-                "$env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS='--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist'; Start-Process -FilePath '{}' -WindowStyle Hidden",
-                exe_path.to_string_lossy().replace("\\", "\\\\")
-            )
+            "--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist"
         };
-        
-        log::info!("执行 PowerShell 脚本启动新进程");
-        
-        // 使用 PowerShell 启动新进程
-        Command::new("powershell")
-            .args(["-WindowStyle", "Hidden", "-Command", &ps_script])
-            .creation_flags(0x08000000) // CREATE_NO_WINDOW
+        log::info!("直接启动新进程以应用 GPU 设置");
+        Command::new(&exe_path)
+            .env("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", browser_arguments)
+            .creation_flags(0x08000000)
             .spawn()
             .map_err(|e| format!("启动新进程失败: {}", e))?;
     }
-    
+
     #[cfg(not(windows))]
     {
         // 非 Windows 平台的实现
         let mut cmd = Command::new(&exe_path);
-        
+
         if !enable_gpu {
             cmd.env("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", "--disable-gpu --disable-software-rasterizer --disable-gpu-compositing --disable-gpu-process-crash-limit --in-process-gpu");
         } else {
-            cmd.env("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", "--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist");
+            cmd.env(
+                "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
+                "--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist",
+            );
         }
-        
-        cmd.spawn()
-            .map_err(|e| format!("启动新进程失败: {}", e))?;
+
+        cmd.spawn().map_err(|e| format!("启动新进程失败: {}", e))?;
     }
-    
+
     log::info!("新进程已启动，准备退出当前进程");
-    
+
     // 延迟退出当前进程，确保新进程已启动
     tokio::time::sleep(tokio::time::Duration::from_millis(800)).await;
     app.exit(0);
-    
+
     Ok(())
 }
 
-
-
-
-
-
 /// 保存出口节点高级配置
-/// 
+///
 /// # 参数
 /// * `enable_socks5` - 是否启用 SOCKS5 代理
 /// * `socks5_port` - SOCKS5 代理端口
@@ -4876,7 +6610,7 @@ pub async fn restart_app_with_gpu_settings(enable_gpu: bool, app: tauri::AppHand
 /// * `enable_kcp_proxy` - 是否启用 KCP 代理
 /// * `enable_quic_proxy` - 是否启用 QUIC 代理
 /// * `latency_first` - 是否启用延迟优先模式
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 保存成功
 /// * `Err(String)` - 错误信息
@@ -4897,7 +6631,7 @@ pub async fn save_exit_node_advanced_config(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     use crate::modules::config_manager::PortForwardRule;
-    
+
     log::info!("保存出口节点高级配置");
     log::info!("  - enable_socks5: {:?}", enable_socks5);
     log::info!("  - socks5_port: {:?}", socks5_port);
@@ -4910,97 +6644,106 @@ pub async fn save_exit_node_advanced_config(
     log::info!("  - enable_kcp_proxy: {:?}", enable_kcp_proxy);
     log::info!("  - enable_quic_proxy: {:?}", enable_quic_proxy);
     log::info!("  - latency_first: {:?}", latency_first);
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let mut cfg_mgr = config_manager.lock().await;
-    
-    cfg_mgr.update_config(|config| {
-        // 确保 exit_node_config 存在
-        if config.exit_node_config.is_none() {
-            config.exit_node_config = Some(crate::modules::config_manager::ExitNodeConfig::default());
-        }
-        
-        if let Some(ref mut exit_config) = config.exit_node_config {
-            // 更新 SOCKS5 配置
-            if let Some(enable) = enable_socks5 {
-                exit_config.enable_socks5 = enable;
+
+    cfg_mgr
+        .update_config(|config| {
+            // 确保 exit_node_config 存在
+            if config.exit_node_config.is_none() {
+                config.exit_node_config =
+                    Some(crate::modules::config_manager::ExitNodeConfig::default());
             }
-            if let Some(port) = socks5_port {
-                exit_config.socks5_port = Some(port);
-            }
-            
-            // 更新端口转发规则
-            if let Some(rules_json) = port_forward_rules {
-                let rules: Vec<PortForwardRule> = rules_json.iter().filter_map(|r| {
-                    if let (Some(protocol), Some(bind_addr), Some(dst_addr)) = (
-                        r.get("protocol").and_then(|v| v.as_str()),
-                        r.get("bind_addr").and_then(|v| v.as_str()),
-                        r.get("dst_addr").and_then(|v| v.as_str()),
-                    ) {
-                        Some(PortForwardRule {
-                            protocol: protocol.to_string(),
-                            bind_addr: bind_addr.to_string(),
-                            dst_addr: dst_addr.to_string(),
+
+            if let Some(ref mut exit_config) = config.exit_node_config {
+                // 更新 SOCKS5 配置
+                if let Some(enable) = enable_socks5 {
+                    exit_config.enable_socks5 = enable;
+                }
+                if let Some(port) = socks5_port {
+                    exit_config.socks5_port = Some(port);
+                }
+
+                // 更新端口转发规则
+                if let Some(rules_json) = port_forward_rules {
+                    let rules: Vec<PortForwardRule> = rules_json
+                        .iter()
+                        .filter_map(|r| {
+                            if let (Some(protocol), Some(bind_addr), Some(dst_addr)) = (
+                                r.get("protocol").and_then(|v| v.as_str()),
+                                r.get("bind_addr").and_then(|v| v.as_str()),
+                                r.get("dst_addr").and_then(|v| v.as_str()),
+                            ) {
+                                Some(PortForwardRule {
+                                    protocol: protocol.to_string(),
+                                    bind_addr: bind_addr.to_string(),
+                                    dst_addr: dst_addr.to_string(),
+                                })
+                            } else {
+                                None
+                            }
                         })
-                    } else {
-                        None
-                    }
-                }).collect();
-                exit_config.port_forward_rules = rules;
+                        .collect();
+                    exit_config.port_forward_rules = rules;
+                }
+
+                // 更新其他高级配置
+                if let Some(no_tun_val) = no_tun {
+                    exit_config.no_tun = no_tun_val;
+                }
+                if let Some(proxy_forward) = proxy_forward_by_system {
+                    exit_config.proxy_forward_by_system = proxy_forward;
+                }
+                if let Some(bind_dev) = bind_device {
+                    exit_config.bind_device = bind_dev;
+                }
+                if let Some(multi_thread_val) = multi_thread {
+                    exit_config.multi_thread = multi_thread_val;
+                }
+                if let Some(thread_count) = multi_thread_count {
+                    exit_config.multi_thread_count = Some(thread_count);
+                }
+                if let Some(smoltcp) = use_smoltcp {
+                    exit_config.use_smoltcp = smoltcp;
+                }
+                if let Some(kcp) = enable_kcp_proxy {
+                    exit_config.enable_kcp_proxy = kcp;
+                }
+                if let Some(quic) = enable_quic_proxy {
+                    exit_config.enable_quic_proxy = quic;
+                }
+                if let Some(latency) = latency_first {
+                    exit_config.latency_first = latency;
+                }
             }
-            
-            // 更新其他高级配置
-            if let Some(no_tun_val) = no_tun {
-                exit_config.no_tun = no_tun_val;
-            }
-            if let Some(proxy_forward) = proxy_forward_by_system {
-                exit_config.proxy_forward_by_system = proxy_forward;
-            }
-            if let Some(bind_dev) = bind_device {
-                exit_config.bind_device = bind_dev;
-            }
-            if let Some(multi_thread_val) = multi_thread {
-                exit_config.multi_thread = multi_thread_val;
-            }
-            if let Some(thread_count) = multi_thread_count {
-                exit_config.multi_thread_count = Some(thread_count);
-            }
-            if let Some(smoltcp) = use_smoltcp {
-                exit_config.use_smoltcp = smoltcp;
-            }
-            if let Some(kcp) = enable_kcp_proxy {
-                exit_config.enable_kcp_proxy = kcp;
-            }
-            if let Some(quic) = enable_quic_proxy {
-                exit_config.enable_quic_proxy = quic;
-            }
-            if let Some(latency) = latency_first {
-                exit_config.latency_first = latency;
-            }
-        }
-    }).await.map_err(|e| format!("保存出口节点高级配置失败: {}", e))?;
-    
+        })
+        .await
+        .map_err(|e| format!("保存出口节点高级配置失败: {}", e))?;
+
     log::info!("出口节点高级配置保存成功");
     Ok(())
 }
 
 /// 获取出口节点高级配置
-/// 
+///
 /// # 返回
 /// * `Ok(serde_json::Value)` - 出口节点高级配置
 /// * `Err(String)` - 错误信息
 #[tauri::command]
-pub async fn get_exit_node_advanced_config(state: State<'_, AppState>) -> Result<serde_json::Value, String> {
+pub async fn get_exit_node_advanced_config(
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
     log::info!("获取出口节点高级配置");
-    
+
     let core = state.core.lock().await;
     let config_manager = core.get_config_manager();
     let cfg_mgr = config_manager.lock().await;
     let config = cfg_mgr.get_config();
-    
+
     let exit_config = config.exit_node_config.clone().unwrap_or_default();
-    
+
     Ok(serde_json::json!({
         "enableSocks5": exit_config.enable_socks5,
         "socks5Port": exit_config.socks5_port,

--- a/src-tauri/src/modules/tauri_events.rs
+++ b/src-tauri/src/modules/tauri_events.rs
@@ -1,11 +1,11 @@
 // Tauri Event 推送模块
 // 负责向前端推送各种事件通知
 
-use tauri::{AppHandle, Emitter};
-use serde::{Deserialize, Serialize};
 use crate::modules::lobby_manager::Player;
 use crate::modules::network_service::ConnectionStatus;
 use crate::modules::voice_service::PlayerStatus;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
 
 // ==================== 事件数据结构 ====================
 
@@ -118,11 +118,11 @@ pub const EVENT_APP_STATE_CHANGE: &str = "app-state-change";
 // ==================== 事件推送函数 ====================
 
 /// 推送玩家加入事件
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `player` - 加入的玩家信息
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 推送成功
 /// * `Err(String)` - 推送失败
@@ -131,21 +131,21 @@ pub fn emit_player_joined(app_handle: &AppHandle, player: Player) -> Result<(), 
         player: player.clone(),
         timestamp: chrono::Utc::now().timestamp(),
     };
-    
+
     log::info!("推送玩家加入事件: {} ({})", player.name, player.id);
-    
+
     app_handle
         .emit(EVENT_PLAYER_JOINED, event)
         .map_err(|e| format!("推送玩家加入事件失败: {}", e))
 }
 
 /// 推送玩家离开事件
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `player_id` - 离开的玩家 ID
 /// * `player_name` - 离开的玩家名称
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 推送成功
 /// * `Err(String)` - 推送失败
@@ -159,20 +159,20 @@ pub fn emit_player_left(
         player_name: player_name.clone(),
         timestamp: chrono::Utc::now().timestamp(),
     };
-    
+
     log::info!("推送玩家离开事件: {} ({})", player_name, player_id);
-    
+
     app_handle
         .emit(EVENT_PLAYER_LEFT, event)
         .map_err(|e| format!("推送玩家离开事件失败: {}", e))
 }
 
 /// 推送玩家状态更新事件
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `status` - 玩家状态信息
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 推送成功
 /// * `Err(String)` - 推送失败
@@ -183,24 +183,24 @@ pub fn emit_player_status_update(
     let event = PlayerStatusUpdateEvent {
         status: status.clone(),
     };
-    
+
     log::debug!(
         "推送玩家状态更新事件: {} (麦克风: {})",
         status.player_id,
         status.mic_enabled
     );
-    
+
     app_handle
         .emit(EVENT_PLAYER_STATUS_UPDATE, event)
         .map_err(|e| format!("推送玩家状态更新事件失败: {}", e))
 }
 
 /// 推送网络状态变化事件
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `status` - 网络连接状态
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 推送成功
 /// * `Err(String)` - 推送失败
@@ -212,22 +212,22 @@ pub fn emit_network_status_change(
         status: status.clone(),
         timestamp: chrono::Utc::now().timestamp(),
     };
-    
+
     log::info!("推送网络状态变化事件: {:?}", status);
-    
+
     app_handle
         .emit(EVENT_NETWORK_STATUS_CHANGE, event)
         .map_err(|e| format!("推送网络状态变化事件失败: {}", e))
 }
 
 /// 推送错误通知事件
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `message` - 错误消息
 /// * `code` - 错误代码（可选）
 /// * `recoverable` - 是否可恢复
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 推送成功
 /// * `Err(String)` - 推送失败
@@ -243,22 +243,22 @@ pub fn emit_error(
         recoverable,
         timestamp: chrono::Utc::now().timestamp(),
     };
-    
+
     log::error!("推送错误通知事件: {}", message);
-    
+
     app_handle
         .emit(EVENT_ERROR, event)
         .map_err(|e| format!("推送错误通知事件失败: {}", e))
 }
 
 /// 推送大厅信息更新事件
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `lobby_id` - 大厅 ID
 /// * `lobby_name` - 大厅名称
 /// * `player_count` - 玩家数量
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 推送成功
 /// * `Err(String)` - 推送失败
@@ -274,20 +274,24 @@ pub fn emit_lobby_update(
         player_count,
         timestamp: chrono::Utc::now().timestamp(),
     };
-    
-    log::info!("推送大厅信息更新事件: {} ({} 个玩家)", lobby_name, player_count);
-    
+
+    log::info!(
+        "推送大厅信息更新事件: {} ({} 个玩家)",
+        lobby_name,
+        player_count
+    );
+
     app_handle
         .emit(EVENT_LOBBY_UPDATE, event)
         .map_err(|e| format!("推送大厅信息更新事件失败: {}", e))
 }
 
 /// 推送麦克风状态变化事件
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `enabled` - 麦克风是否开启
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 推送成功
 /// * `Err(String)` - 推送失败
@@ -296,20 +300,23 @@ pub fn emit_mic_status_change(app_handle: &AppHandle, enabled: bool) -> Result<(
         enabled,
         timestamp: chrono::Utc::now().timestamp(),
     };
-    
-    log::info!("推送麦克风状态变化事件: {}", if enabled { "开启" } else { "关闭" });
-    
+
+    log::info!(
+        "推送麦克风状态变化事件: {}",
+        if enabled { "开启" } else { "关闭" }
+    );
+
     app_handle
         .emit(EVENT_MIC_STATUS_CHANGE, event)
         .map_err(|e| format!("推送麦克风状态变化事件失败: {}", e))
 }
 
 /// 推送应用状态变化事件
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `state` - 新的应用状态
-/// 
+///
 /// # 返回
 /// * `Ok(())` - 推送成功
 /// * `Err(String)` - 推送失败
@@ -318,9 +325,9 @@ pub fn emit_app_state_change(app_handle: &AppHandle, state: String) -> Result<()
         state: state.clone(),
         timestamp: chrono::Utc::now().timestamp(),
     };
-    
+
     log::info!("推送应用状态变化事件: {}", state);
-    
+
     app_handle
         .emit(EVENT_APP_STATE_CHANGE, event)
         .map_err(|e| format!("推送应用状态变化事件失败: {}", e))
@@ -329,32 +336,32 @@ pub fn emit_app_state_change(app_handle: &AppHandle, state: String) -> Result<()
 // ==================== 批量事件推送 ====================
 
 /// 推送多个玩家加入事件
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `players` - 玩家列表
-/// 
+///
 /// # 返回
 /// * `Ok(usize)` - 成功推送的事件数量
 /// * `Err(String)` - 推送失败
 pub fn emit_players_joined(app_handle: &AppHandle, players: Vec<Player>) -> Result<usize, String> {
     let mut success_count = 0;
-    
+
     for player in players {
         if emit_player_joined(app_handle, player).is_ok() {
             success_count += 1;
         }
     }
-    
+
     Ok(success_count)
 }
 
 /// 推送多个玩家状态更新事件
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `statuses` - 玩家状态列表
-/// 
+///
 /// # 返回
 /// * `Ok(usize)` - 成功推送的事件数量
 /// * `Err(String)` - 推送失败
@@ -363,25 +370,25 @@ pub fn emit_player_statuses_update(
     statuses: Vec<PlayerStatus>,
 ) -> Result<usize, String> {
     let mut success_count = 0;
-    
+
     for status in statuses {
         if emit_player_status_update(app_handle, status).is_ok() {
             success_count += 1;
         }
     }
-    
+
     Ok(success_count)
 }
 
 // ==================== 辅助函数 ====================
 
 /// 安全地推送事件（捕获所有错误）
-/// 
+///
 /// # 参数
 /// * `app_handle` - Tauri 应用句柄
 /// * `event_name` - 事件名称
 /// * `payload` - 事件数据
-/// 
+///
 /// # 说明
 /// 此函数会捕获所有错误并记录日志，不会向上传播错误
 pub fn emit_safe<T: Serialize + Clone>(app_handle: &AppHandle, event_name: &str, payload: T) {
@@ -407,16 +414,16 @@ mod tests {
     #[test]
     fn test_player_joined_event_serialization() {
         use crate::modules::lobby_manager::Player;
-        
+
         let player = Player::new("测试玩家".to_string(), "10.126.126.1".to_string());
         let event = PlayerJoinedEvent {
             player,
             timestamp: 1234567890,
         };
-        
+
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: PlayerJoinedEvent = serde_json::from_str(&json).unwrap();
-        
+
         assert_eq!(deserialized.timestamp, 1234567890);
         assert_eq!(deserialized.player.name, "测试玩家");
     }
@@ -428,10 +435,10 @@ mod tests {
             player_name: "测试玩家".to_string(),
             timestamp: 1234567890,
         };
-        
+
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: PlayerLeftEvent = serde_json::from_str(&json).unwrap();
-        
+
         assert_eq!(deserialized.player_id, "player_123");
         assert_eq!(deserialized.player_name, "测试玩家");
         assert_eq!(deserialized.timestamp, 1234567890);
@@ -445,10 +452,10 @@ mod tests {
             recoverable: true,
             timestamp: 1234567890,
         };
-        
+
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: ErrorEvent = serde_json::from_str(&json).unwrap();
-        
+
         assert_eq!(deserialized.message, "测试错误");
         assert_eq!(deserialized.code, Some("ERR_001".to_string()));
         assert_eq!(deserialized.recoverable, true);
@@ -461,10 +468,10 @@ mod tests {
             status: ConnectionStatus::Connected("10.144.144.1".to_string()),
             timestamp: 1234567890,
         };
-        
+
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: NetworkStatusChangeEvent = serde_json::from_str(&json).unwrap();
-        
+
         assert_eq!(
             deserialized.status,
             ConnectionStatus::Connected("10.144.144.1".to_string())
@@ -478,10 +485,10 @@ mod tests {
             enabled: true,
             timestamp: 1234567890,
         };
-        
+
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: MicStatusChangeEvent = serde_json::from_str(&json).unwrap();
-        
+
         assert_eq!(deserialized.enabled, true);
         assert_eq!(deserialized.timestamp, 1234567890);
     }
@@ -494,10 +501,10 @@ mod tests {
             player_count: 5,
             timestamp: 1234567890,
         };
-        
+
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: LobbyUpdateEvent = serde_json::from_str(&json).unwrap();
-        
+
         assert_eq!(deserialized.lobby_id, "lobby_123");
         assert_eq!(deserialized.lobby_name, "测试大厅");
         assert_eq!(deserialized.player_count, 5);
@@ -520,11 +527,11 @@ mod tests {
     fn test_timestamp_functions() {
         let ts = get_timestamp();
         let ts_ms = get_timestamp_ms();
-        
+
         // 验证时间戳在合理范围内（2020年之后）
         assert!(ts > 1577836800); // 2020-01-01
         assert!(ts_ms > 1577836800000); // 2020-01-01 in milliseconds
-        
+
         // 验证毫秒时间戳是秒时间戳的约1000倍
         assert!((ts_ms / 1000 - ts).abs() < 2); // 允许1-2秒的误差
     }

--- a/src-tauri/src/modules/voice_service.rs
+++ b/src-tauri/src/modules/voice_service.rs
@@ -1,11 +1,11 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
-use std::sync::atomic::{AtomicBool, Ordering};
-use serde::{Deserialize, Serialize};
-use chrono::{DateTime, Utc};
 
-use crate::modules::error::{AppError, log_error};
+use crate::modules::error::{log_error, AppError};
 
 /// 音频设备类型
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -46,39 +46,25 @@ pub struct PlayerStatus {
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum SignalingMessage {
     /// SDP Offer 消息
-    Offer {
-        from: String,
-        sdp: String,
-    },
+    Offer { from: String, sdp: String },
     /// SDP Answer 消息
-    Answer {
-        from: String,
-        sdp: String,
-    },
+    Answer { from: String, sdp: String },
     /// ICE Candidate 消息
-    IceCandidate {
-        from: String,
-        candidate: String,
-    },
+    IceCandidate { from: String, candidate: String },
     /// 玩家加入消息
     PlayerJoined {
         player_id: String,
         player_name: String,
     },
     /// 玩家离开消息
-    PlayerLeft {
-        player_id: String,
-    },
+    PlayerLeft { player_id: String },
     /// 状态更新消息
     StatusUpdate {
         player_id: String,
         mic_enabled: bool,
     },
     /// 心跳消息
-    Heartbeat {
-        player_id: String,
-        timestamp: i64,
-    },
+    Heartbeat { player_id: String, timestamp: i64 },
 }
 
 /// 语音服务错误类型
@@ -86,16 +72,16 @@ pub enum SignalingMessage {
 pub enum VoiceError {
     #[error("音频设备未找到")]
     DeviceNotFound,
-    
+
     #[error("初始化失败: {0}")]
     InitializationFailed(String),
-    
+
     #[error("信令失败: {0}")]
     SignalingFailed(String),
-    
+
     #[error("玩家未找到: {0}")]
     PlayerNotFound(String),
-    
+
     #[error("操作失败: {0}")]
     OperationFailed(String),
 }
@@ -107,42 +93,42 @@ impl From<VoiceError> for AppError {
 }
 
 /// 语音服务
-/// 
+///
 /// 负责管理 WebRTC 语音通信、音频设备、麦克风状态和玩家静音状态
 pub struct VoiceService {
     /// 可用的音频设备列表
     audio_devices: Arc<RwLock<Vec<AudioDevice>>>,
-    
+
     /// 当前麦克风是否开启
     mic_enabled: Arc<AtomicBool>,
-    
+
     /// 被静音的玩家集合（玩家ID）
     muted_players: Arc<RwLock<HashSet<String>>>,
-    
+
     /// 全局静音状态
     global_muted: Arc<AtomicBool>,
-    
+
     /// 玩家状态映射（玩家ID -> 状态）
     player_statuses: Arc<RwLock<HashMap<String, PlayerStatus>>>,
-    
+
     /// 信令消息队列
     signaling_queue: Arc<Mutex<Vec<SignalingMessage>>>,
-    
+
     /// 当前选择的麦克风设备ID
     selected_mic_device: Arc<RwLock<Option<String>>>,
-    
+
     /// 当前选择的扬声器设备ID
     selected_speaker_device: Arc<RwLock<Option<String>>>,
 }
 
 impl VoiceService {
     /// 创建新的语音服务实例
-    /// 
+    ///
     /// # 返回
     /// * `VoiceService` - 新的语音服务实例
     pub fn new() -> Self {
         log::info!("创建语音服务实例");
-        
+
         Self {
             audio_devices: Arc::new(RwLock::new(Vec::new())),
             mic_enabled: Arc::new(AtomicBool::new(false)),
@@ -154,48 +140,48 @@ impl VoiceService {
             selected_speaker_device: Arc::new(RwLock::new(None)),
         }
     }
-    
+
     /// 初始化语音服务
-    /// 
+    ///
     /// 枚举可用的音频设备并设置默认设备
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 初始化成功
     /// * `Err(VoiceError)` - 初始化失败
     pub async fn initialize(&self) -> Result<(), VoiceError> {
         log::info!("初始化语音服务");
-        
+
         // 枚举音频设备
         match self.enumerate_audio_devices().await {
             Ok(devices) => {
                 log::info!("成功枚举 {} 个音频设备", devices.len());
-                
+
                 // 设置默认设备
                 self.set_default_devices(&devices).await;
-                
+
                 Ok(())
             }
             Err(e) => {
                 log_error(&e.into(), "语音服务初始化");
                 Err(VoiceError::InitializationFailed(
-                    "无法枚举音频设备".to_string()
+                    "无法枚举音频设备".to_string(),
                 ))
             }
         }
     }
-    
+
     /// 枚举可用的音频设备
-    /// 
+    ///
     /// # 返回
     /// * `Ok(Vec<AudioDevice>)` - 音频设备列表
     /// * `Err(VoiceError)` - 枚举失败
     async fn enumerate_audio_devices(&self) -> Result<Vec<AudioDevice>, VoiceError> {
         log::info!("开始枚举音频设备");
-        
+
         // 注意：这里是模拟实现，实际项目中需要使用 cpal 或其他音频库
         // 来真正枚举系统音频设备
         let mut devices = Vec::new();
-        
+
         // 添加默认麦克风设备
         devices.push(AudioDevice {
             id: "default_mic".to_string(),
@@ -203,7 +189,7 @@ impl VoiceService {
             device_type: DeviceType::Microphone,
             is_default: true,
         });
-        
+
         // 添加默认扬声器设备
         devices.push(AudioDevice {
             id: "default_speaker".to_string(),
@@ -211,72 +197,76 @@ impl VoiceService {
             device_type: DeviceType::Speaker,
             is_default: true,
         });
-        
+
         // 更新内部设备列表
         let mut audio_devices = self.audio_devices.write().await;
         *audio_devices = devices.clone();
-        
+
         log::info!("音频设备枚举完成，共 {} 个设备", devices.len());
-        
+
         Ok(devices)
     }
-    
+
     /// 设置默认音频设备
     async fn set_default_devices(&self, devices: &[AudioDevice]) {
         // 查找默认麦克风
-        if let Some(default_mic) = devices.iter()
-            .find(|d| d.device_type == DeviceType::Microphone && d.is_default) {
+        if let Some(default_mic) = devices
+            .iter()
+            .find(|d| d.device_type == DeviceType::Microphone && d.is_default)
+        {
             let mut selected = self.selected_mic_device.write().await;
             *selected = Some(default_mic.id.clone());
             log::info!("设置默认麦克风: {}", default_mic.name);
         }
-        
+
         // 查找默认扬声器
-        if let Some(default_speaker) = devices.iter()
-            .find(|d| d.device_type == DeviceType::Speaker && d.is_default) {
+        if let Some(default_speaker) = devices
+            .iter()
+            .find(|d| d.device_type == DeviceType::Speaker && d.is_default)
+        {
             let mut selected = self.selected_speaker_device.write().await;
             *selected = Some(default_speaker.id.clone());
             log::info!("设置默认扬声器: {}", default_speaker.name);
         }
     }
-    
+
     /// 获取可用的音频设备列表
-    /// 
+    ///
     /// # 返回
     /// * `Vec<AudioDevice>` - 音频设备列表
     pub async fn get_audio_devices(&self) -> Vec<AudioDevice> {
         let devices = self.audio_devices.read().await;
         devices.clone()
     }
-    
+
     /// 设置麦克风状态
-    /// 
+    ///
     /// # 参数
     /// * `enabled` - true 表示开启麦克风，false 表示关闭
-    /// 
+    ///
     /// # 返回
     /// * `Ok(bool)` - 新的麦克风状态
     /// * `Err(VoiceError)` - 操作失败
     pub async fn set_mic_enabled(&self, enabled: bool) -> Result<bool, VoiceError> {
         log::info!("设置麦克风状态: {}", if enabled { "开启" } else { "关闭" });
-        
+
         // 检查是否有选择的麦克风设备
         let selected_device = self.selected_mic_device.read().await;
         if enabled && selected_device.is_none() {
             log::warn!("未选择麦克风设备");
             return Err(VoiceError::DeviceNotFound);
         }
-        
+
         // 更新麦克风状态
         self.mic_enabled.store(enabled, Ordering::SeqCst);
-        
+
         log::info!("麦克风状态已更新: {}", enabled);
-        
+
         Ok(enabled)
     }
-    
+
     /// 切换麦克风状态
-    /// 
+    ///
     /// # 返回
     /// * `Ok(bool)` - 新的麦克风状态
     /// * `Err(VoiceError)` - 操作失败
@@ -284,21 +274,21 @@ impl VoiceService {
         let current = self.mic_enabled.load(Ordering::SeqCst);
         self.set_mic_enabled(!current).await
     }
-    
+
     /// 获取当前麦克风状态
-    /// 
+    ///
     /// # 返回
     /// * `bool` - true 表示麦克风开启，false 表示关闭
     pub fn is_mic_enabled(&self) -> bool {
         self.mic_enabled.load(Ordering::SeqCst)
     }
-    
+
     /// 静音或取消静音指定玩家
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 玩家唯一标识符
     /// * `muted` - true 表示静音，false 表示取消静音
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 操作成功
     /// * `Err(VoiceError)` - 操作失败
@@ -308,99 +298,103 @@ impl VoiceService {
             if muted { "静音" } else { "取消静音" },
             player_id
         );
-        
+
         let mut muted_players = self.muted_players.write().await;
-        
+
         if muted {
             muted_players.insert(player_id.to_string());
         } else {
             muted_players.remove(player_id);
         }
-        
+
         log::info!("玩家 {} 静音状态已更新: {}", player_id, muted);
-        
+
         Ok(())
     }
-    
+
     /// 检查玩家是否被静音
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 玩家唯一标识符
-    /// 
+    ///
     /// # 返回
     /// * `bool` - true 表示玩家被静音，false 表示未被静音
     pub async fn is_player_muted(&self, player_id: &str) -> bool {
         let muted_players = self.muted_players.read().await;
         muted_players.contains(player_id)
     }
-    
+
     /// 全局静音或取消静音所有玩家
-    /// 
+    ///
     /// # 参数
     /// * `muted` - true 表示静音所有玩家，false 表示取消静音所有玩家
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 操作成功
     /// * `Err(VoiceError)` - 操作失败
     pub async fn mute_all(&self, muted: bool) -> Result<(), VoiceError> {
         log::info!("全局静音状态: {}", if muted { "开启" } else { "关闭" });
-        
+
         self.global_muted.store(muted, Ordering::SeqCst);
-        
+
         log::info!("全局静音状态已更新: {}", muted);
-        
+
         Ok(())
     }
-    
+
     /// 获取全局静音状态
-    /// 
+    ///
     /// # 返回
     /// * `bool` - true 表示全局静音，false 表示未全局静音
     pub fn is_global_muted(&self) -> bool {
         self.global_muted.load(Ordering::SeqCst)
     }
-    
+
     /// 广播玩家状态更新
-    /// 
+    ///
     /// # 参数
     /// * `status` - 玩家状态信息
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 广播成功
     /// * `Err(VoiceError)` - 广播失败
     pub async fn broadcast_status(&self, status: PlayerStatus) -> Result<(), VoiceError> {
-        log::info!("广播玩家状态: {} (麦克风: {})", status.player_id, status.mic_enabled);
-        
+        log::info!(
+            "广播玩家状态: {} (麦克风: {})",
+            status.player_id,
+            status.mic_enabled
+        );
+
         // 更新玩家状态
         let mut statuses = self.player_statuses.write().await;
         statuses.insert(status.player_id.clone(), status.clone());
-        
+
         // 创建状态更新信令消息
         let message = SignalingMessage::StatusUpdate {
             player_id: status.player_id.clone(),
             mic_enabled: status.mic_enabled,
         };
-        
+
         // 将消息加入信令队列
         let mut queue = self.signaling_queue.lock().await;
         queue.push(message);
-        
+
         log::info!("状态广播已加入队列");
-        
+
         Ok(())
     }
-    
+
     /// 处理信令消息
-    /// 
+    ///
     /// # 参数
     /// * `message` - 信令消息
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 处理成功
     /// * `Err(VoiceError)` - 处理失败
     pub async fn handle_signaling(&self, message: SignalingMessage) -> Result<(), VoiceError> {
         log::debug!("处理信令消息: {:?}", message);
-        
+
         match &message {
             SignalingMessage::Offer { from, .. } => {
                 log::info!("收到来自 {} 的 Offer", from);
@@ -411,33 +405,39 @@ impl VoiceService {
             SignalingMessage::IceCandidate { from, .. } => {
                 log::debug!("收到来自 {} 的 ICE Candidate", from);
             }
-            SignalingMessage::PlayerJoined { player_id, player_name } => {
+            SignalingMessage::PlayerJoined {
+                player_id,
+                player_name,
+            } => {
                 log::info!("玩家加入: {} ({})", player_name, player_id);
-                
+
                 // 初始化玩家状态
                 let status = PlayerStatus {
                     player_id: player_id.clone(),
                     mic_enabled: false,
                     timestamp: Utc::now(),
                 };
-                
+
                 let mut statuses = self.player_statuses.write().await;
                 statuses.insert(player_id.clone(), status);
             }
             SignalingMessage::PlayerLeft { player_id } => {
                 log::info!("玩家离开: {}", player_id);
-                
+
                 // 移除玩家状态
                 let mut statuses = self.player_statuses.write().await;
                 statuses.remove(player_id);
-                
+
                 // 移除静音状态
                 let mut muted_players = self.muted_players.write().await;
                 muted_players.remove(player_id);
             }
-            SignalingMessage::StatusUpdate { player_id, mic_enabled } => {
+            SignalingMessage::StatusUpdate {
+                player_id,
+                mic_enabled,
+            } => {
                 log::info!("玩家 {} 状态更新: 麦克风 {}", player_id, mic_enabled);
-                
+
                 // 更新玩家状态
                 let mut statuses = self.player_statuses.write().await;
                 if let Some(status) = statuses.get_mut(player_id) {
@@ -453,9 +453,12 @@ impl VoiceService {
                     statuses.insert(player_id.clone(), status);
                 }
             }
-            SignalingMessage::Heartbeat { player_id, timestamp } => {
+            SignalingMessage::Heartbeat {
+                player_id,
+                timestamp,
+            } => {
                 log::debug!("收到玩家 {} 的心跳 (时间戳: {})", player_id, timestamp);
-                
+
                 // 更新玩家最后活跃时间
                 let mut statuses = self.player_statuses.write().await;
                 if let Some(status) = statuses.get_mut(player_id) {
@@ -463,14 +466,14 @@ impl VoiceService {
                 }
             }
         }
-        
+
         Ok(())
     }
-    
+
     /// 获取信令队列中的所有消息
-    /// 
+    ///
     /// 此方法会清空队列并返回所有消息
-    /// 
+    ///
     /// # 返回
     /// * `Vec<SignalingMessage>` - 信令消息列表
     pub async fn get_signaling_messages(&self) -> Vec<SignalingMessage> {
@@ -478,21 +481,21 @@ impl VoiceService {
         let messages = queue.drain(..).collect();
         messages
     }
-    
+
     /// 获取所有玩家的状态
-    /// 
+    ///
     /// # 返回
     /// * `HashMap<String, PlayerStatus>` - 玩家ID到状态的映射
     pub async fn get_player_statuses(&self) -> HashMap<String, PlayerStatus> {
         let statuses = self.player_statuses.read().await;
         statuses.clone()
     }
-    
+
     /// 获取指定玩家的状态
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 玩家唯一标识符
-    /// 
+    ///
     /// # 返回
     /// * `Some(PlayerStatus)` - 玩家状态
     /// * `None` - 玩家不存在
@@ -500,162 +503,162 @@ impl VoiceService {
         let statuses = self.player_statuses.read().await;
         statuses.get(player_id).cloned()
     }
-    
+
     /// 移除玩家
-    /// 
+    ///
     /// 清理指定玩家的所有状态信息
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 玩家唯一标识符
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 移除成功
     /// * `Err(VoiceError)` - 移除失败
     pub async fn remove_player(&self, player_id: &str) -> Result<(), VoiceError> {
         log::info!("移除玩家: {}", player_id);
-        
+
         // 移除玩家状态
         let mut statuses = self.player_statuses.write().await;
         statuses.remove(player_id);
-        
+
         // 移除静音状态
         let mut muted_players = self.muted_players.write().await;
         muted_players.remove(player_id);
-        
+
         log::info!("玩家 {} 已移除", player_id);
-        
+
         Ok(())
     }
-    
+
     /// 清理所有状态
-    /// 
+    ///
     /// 重置语音服务到初始状态，清理所有玩家信息
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 清理成功
     /// * `Err(VoiceError)` - 清理失败
     pub async fn cleanup(&self) -> Result<(), VoiceError> {
         log::info!("清理语音服务状态");
-        
+
         // 关闭麦克风
         self.mic_enabled.store(false, Ordering::SeqCst);
-        
+
         // 清除全局静音
         self.global_muted.store(false, Ordering::SeqCst);
-        
+
         // 清除所有玩家状态
         let mut statuses = self.player_statuses.write().await;
         statuses.clear();
-        
+
         // 清除所有静音状态
         let mut muted_players = self.muted_players.write().await;
         muted_players.clear();
-        
+
         // 清空信令队列
         let mut queue = self.signaling_queue.lock().await;
         queue.clear();
-        
+
         log::info!("语音服务状态已清理");
-        
+
         Ok(())
     }
-    
+
     /// 选择麦克风设备
-    /// 
+    ///
     /// # 参数
     /// * `device_id` - 设备唯一标识符
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 选择成功
     /// * `Err(VoiceError)` - 选择失败（设备不存在）
     pub async fn select_microphone(&self, device_id: &str) -> Result<(), VoiceError> {
         log::info!("选择麦克风设备: {}", device_id);
-        
+
         // 验证设备是否存在
         let devices = self.audio_devices.read().await;
-        let device_exists = devices.iter().any(|d| {
-            d.id == device_id && d.device_type == DeviceType::Microphone
-        });
-        
+        let device_exists = devices
+            .iter()
+            .any(|d| d.id == device_id && d.device_type == DeviceType::Microphone);
+
         if !device_exists {
             log::warn!("麦克风设备不存在: {}", device_id);
             return Err(VoiceError::DeviceNotFound);
         }
-        
+
         // 更新选择的设备
         let mut selected = self.selected_mic_device.write().await;
         *selected = Some(device_id.to_string());
-        
+
         log::info!("麦克风设备已选择: {}", device_id);
-        
+
         Ok(())
     }
-    
+
     /// 选择扬声器设备
-    /// 
+    ///
     /// # 参数
     /// * `device_id` - 设备唯一标识符
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 选择成功
     /// * `Err(VoiceError)` - 选择失败（设备不存在）
     pub async fn select_speaker(&self, device_id: &str) -> Result<(), VoiceError> {
         log::info!("选择扬声器设备: {}", device_id);
-        
+
         // 验证设备是否存在
         let devices = self.audio_devices.read().await;
-        let device_exists = devices.iter().any(|d| {
-            d.id == device_id && d.device_type == DeviceType::Speaker
-        });
-        
+        let device_exists = devices
+            .iter()
+            .any(|d| d.id == device_id && d.device_type == DeviceType::Speaker);
+
         if !device_exists {
             log::warn!("扬声器设备不存在: {}", device_id);
             return Err(VoiceError::DeviceNotFound);
         }
-        
+
         // 更新选择的设备
         let mut selected = self.selected_speaker_device.write().await;
         *selected = Some(device_id.to_string());
-        
+
         log::info!("扬声器设备已选择: {}", device_id);
-        
+
         Ok(())
     }
-    
+
     /// 获取当前选择的麦克风设备ID
-    /// 
+    ///
     /// # 返回
     /// * `Option<String>` - 设备ID，如果未选择则返回 None
     pub async fn get_selected_microphone(&self) -> Option<String> {
         let selected = self.selected_mic_device.read().await;
         selected.clone()
     }
-    
+
     /// 获取当前选择的扬声器设备ID
-    /// 
+    ///
     /// # 返回
     /// * `Option<String>` - 设备ID，如果未选择则返回 None
     pub async fn get_selected_speaker(&self) -> Option<String> {
         let selected = self.selected_speaker_device.read().await;
         selected.clone()
     }
-    
+
     /// 获取被静音的玩家列表
-    /// 
+    ///
     /// # 返回
     /// * `Vec<String>` - 被静音的玩家ID列表
     pub async fn get_muted_players(&self) -> Vec<String> {
         let muted_players = self.muted_players.read().await;
         muted_players.iter().cloned().collect()
     }
-    
+
     /// 检查是否应该播放指定玩家的音频
-    /// 
+    ///
     /// 考虑全局静音和单个玩家静音状态
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 玩家唯一标识符
-    /// 
+    ///
     /// # 返回
     /// * `bool` - true 表示应该播放，false 表示不应该播放
     pub async fn should_play_audio(&self, player_id: &str) -> bool {
@@ -663,52 +666,52 @@ impl VoiceService {
         if self.is_global_muted() {
             return false;
         }
-        
+
         // 如果玩家被单独静音，不播放该玩家的音频
         if self.is_player_muted(player_id).await {
             return false;
         }
-        
+
         true
     }
-    
+
     /// 发送心跳消息
-    /// 
+    ///
     /// # 参数
     /// * `player_id` - 当前玩家的唯一标识符
-    /// 
+    ///
     /// # 返回
     /// * `Ok(())` - 发送成功
     /// * `Err(VoiceError)` - 发送失败
     pub async fn send_heartbeat(&self, player_id: &str) -> Result<(), VoiceError> {
         log::debug!("发送心跳: {}", player_id);
-        
+
         let message = SignalingMessage::Heartbeat {
             player_id: player_id.to_string(),
             timestamp: Utc::now().timestamp(),
         };
-        
+
         let mut queue = self.signaling_queue.lock().await;
         queue.push(message);
-        
+
         Ok(())
     }
-    
+
     /// 检查玩家心跳超时
-    /// 
+    ///
     /// 返回所有超时的玩家ID列表
-    /// 
+    ///
     /// # 参数
     /// * `timeout_seconds` - 超时时间（秒）
-    /// 
+    ///
     /// # 返回
     /// * `Vec<String>` - 超时的玩家ID列表
     pub async fn check_heartbeat_timeout(&self, timeout_seconds: i64) -> Vec<String> {
         let statuses = self.player_statuses.read().await;
         let now = Utc::now();
-        
+
         let mut timeout_players = Vec::new();
-        
+
         for (player_id, status) in statuses.iter() {
             let elapsed = now.signed_duration_since(status.timestamp);
             if elapsed.num_seconds() > timeout_seconds {
@@ -716,7 +719,7 @@ impl VoiceService {
                 timeout_players.push(player_id.clone());
             }
         }
-        
+
         timeout_players
     }
 }
@@ -730,307 +733,307 @@ impl Default for VoiceService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[tokio::test]
     async fn test_voice_service_creation() {
         let service = VoiceService::new();
         assert!(!service.is_mic_enabled());
         assert!(!service.is_global_muted());
     }
-    
+
     #[tokio::test]
     async fn test_initialize() {
         let service = VoiceService::new();
         let result = service.initialize().await;
         assert!(result.is_ok());
-        
+
         let devices = service.get_audio_devices().await;
         assert!(!devices.is_empty());
     }
-    
+
     #[tokio::test]
     async fn test_mic_toggle() {
         let service = VoiceService::new();
         service.initialize().await.unwrap();
-        
+
         // 初始状态应该是关闭
         assert!(!service.is_mic_enabled());
-        
+
         // 切换到开启
         let result = service.toggle_mic().await;
         assert!(result.is_ok());
         assert!(service.is_mic_enabled());
-        
+
         // 再次切换到关闭
         let result = service.toggle_mic().await;
         assert!(result.is_ok());
         assert!(!service.is_mic_enabled());
     }
-    
+
     #[tokio::test]
     async fn test_set_mic_enabled() {
         let service = VoiceService::new();
         service.initialize().await.unwrap();
-        
+
         let result = service.set_mic_enabled(true).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), true);
         assert!(service.is_mic_enabled());
-        
+
         let result = service.set_mic_enabled(false).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), false);
         assert!(!service.is_mic_enabled());
     }
-    
+
     #[tokio::test]
     async fn test_mute_player() {
         let service = VoiceService::new();
         let player_id = "player_123";
-        
+
         // 初始状态未静音
         assert!(!service.is_player_muted(player_id).await);
-        
+
         // 静音玩家
         let result = service.mute_player(player_id, true).await;
         assert!(result.is_ok());
         assert!(service.is_player_muted(player_id).await);
-        
+
         // 取消静音
         let result = service.mute_player(player_id, false).await;
         assert!(result.is_ok());
         assert!(!service.is_player_muted(player_id).await);
     }
-    
+
     #[tokio::test]
     async fn test_mute_all() {
         let service = VoiceService::new();
-        
+
         // 初始状态未全局静音
         assert!(!service.is_global_muted());
-        
+
         // 开启全局静音
         let result = service.mute_all(true).await;
         assert!(result.is_ok());
         assert!(service.is_global_muted());
-        
+
         // 关闭全局静音
         let result = service.mute_all(false).await;
         assert!(result.is_ok());
         assert!(!service.is_global_muted());
     }
-    
+
     #[tokio::test]
     async fn test_broadcast_status() {
         let service = VoiceService::new();
-        
+
         let status = PlayerStatus {
             player_id: "player_123".to_string(),
             mic_enabled: true,
             timestamp: Utc::now(),
         };
-        
+
         let result = service.broadcast_status(status.clone()).await;
         assert!(result.is_ok());
-        
+
         // 验证状态已保存
         let saved_status = service.get_player_status("player_123").await;
         assert!(saved_status.is_some());
         assert_eq!(saved_status.unwrap().mic_enabled, true);
-        
+
         // 验证信令消息已加入队列
         let messages = service.get_signaling_messages().await;
         assert_eq!(messages.len(), 1);
     }
-    
+
     #[tokio::test]
     async fn test_handle_signaling_player_joined() {
         let service = VoiceService::new();
-        
+
         let message = SignalingMessage::PlayerJoined {
             player_id: "player_123".to_string(),
             player_name: "测试玩家".to_string(),
         };
-        
+
         let result = service.handle_signaling(message).await;
         assert!(result.is_ok());
-        
+
         // 验证玩家状态已创建
         let status = service.get_player_status("player_123").await;
         assert!(status.is_some());
         assert_eq!(status.unwrap().mic_enabled, false);
     }
-    
+
     #[tokio::test]
     async fn test_handle_signaling_player_left() {
         let service = VoiceService::new();
-        
+
         // 先添加玩家
         let join_message = SignalingMessage::PlayerJoined {
             player_id: "player_123".to_string(),
             player_name: "测试玩家".to_string(),
         };
         service.handle_signaling(join_message).await.unwrap();
-        
+
         // 静音该玩家
         service.mute_player("player_123", true).await.unwrap();
-        
+
         // 玩家离开
         let leave_message = SignalingMessage::PlayerLeft {
             player_id: "player_123".to_string(),
         };
         service.handle_signaling(leave_message).await.unwrap();
-        
+
         // 验证玩家状态已移除
         let status = service.get_player_status("player_123").await;
         assert!(status.is_none());
-        
+
         // 验证静音状态已移除
         assert!(!service.is_player_muted("player_123").await);
     }
-    
+
     #[tokio::test]
     async fn test_handle_signaling_status_update() {
         let service = VoiceService::new();
-        
+
         let message = SignalingMessage::StatusUpdate {
             player_id: "player_123".to_string(),
             mic_enabled: true,
         };
-        
+
         let result = service.handle_signaling(message).await;
         assert!(result.is_ok());
-        
+
         // 验证状态已更新
         let status = service.get_player_status("player_123").await;
         assert!(status.is_some());
         assert_eq!(status.unwrap().mic_enabled, true);
     }
-    
+
     #[tokio::test]
     async fn test_remove_player() {
         let service = VoiceService::new();
-        
+
         // 添加玩家
         let message = SignalingMessage::PlayerJoined {
             player_id: "player_123".to_string(),
             player_name: "测试玩家".to_string(),
         };
         service.handle_signaling(message).await.unwrap();
-        
+
         // 静音玩家
         service.mute_player("player_123", true).await.unwrap();
-        
+
         // 移除玩家
         let result = service.remove_player("player_123").await;
         assert!(result.is_ok());
-        
+
         // 验证玩家已移除
         let status = service.get_player_status("player_123").await;
         assert!(status.is_none());
         assert!(!service.is_player_muted("player_123").await);
     }
-    
+
     #[tokio::test]
     async fn test_cleanup() {
         let service = VoiceService::new();
         service.initialize().await.unwrap();
-        
+
         // 设置一些状态
         service.set_mic_enabled(true).await.unwrap();
         service.mute_all(true).await.unwrap();
-        
+
         let message = SignalingMessage::PlayerJoined {
             player_id: "player_123".to_string(),
             player_name: "测试玩家".to_string(),
         };
         service.handle_signaling(message).await.unwrap();
-        
+
         // 清理
         let result = service.cleanup().await;
         assert!(result.is_ok());
-        
+
         // 验证所有状态已重置
         assert!(!service.is_mic_enabled());
         assert!(!service.is_global_muted());
-        
+
         let statuses = service.get_player_statuses().await;
         assert!(statuses.is_empty());
-        
+
         let muted = service.get_muted_players().await;
         assert!(muted.is_empty());
     }
-    
+
     #[tokio::test]
     async fn test_select_microphone() {
         let service = VoiceService::new();
         service.initialize().await.unwrap();
-        
+
         // 选择默认麦克风
         let result = service.select_microphone("default_mic").await;
         assert!(result.is_ok());
-        
+
         let selected = service.get_selected_microphone().await;
         assert_eq!(selected, Some("default_mic".to_string()));
-        
+
         // 选择不存在的设备
         let result = service.select_microphone("non_existent").await;
         assert!(result.is_err());
     }
-    
+
     #[tokio::test]
     async fn test_select_speaker() {
         let service = VoiceService::new();
         service.initialize().await.unwrap();
-        
+
         // 选择默认扬声器
         let result = service.select_speaker("default_speaker").await;
         assert!(result.is_ok());
-        
+
         let selected = service.get_selected_speaker().await;
         assert_eq!(selected, Some("default_speaker".to_string()));
-        
+
         // 选择不存在的设备
         let result = service.select_speaker("non_existent").await;
         assert!(result.is_err());
     }
-    
+
     #[tokio::test]
     async fn test_should_play_audio() {
         let service = VoiceService::new();
         let player_id = "player_123";
-        
+
         // 默认应该播放
         assert!(service.should_play_audio(player_id).await);
-        
+
         // 全局静音后不应该播放
         service.mute_all(true).await.unwrap();
         assert!(!service.should_play_audio(player_id).await);
-        
+
         // 取消全局静音
         service.mute_all(false).await.unwrap();
         assert!(service.should_play_audio(player_id).await);
-        
+
         // 单独静音玩家后不应该播放
         service.mute_player(player_id, true).await.unwrap();
         assert!(!service.should_play_audio(player_id).await);
-        
+
         // 取消单独静音
         service.mute_player(player_id, false).await.unwrap();
         assert!(service.should_play_audio(player_id).await);
     }
-    
+
     #[tokio::test]
     async fn test_send_heartbeat() {
         let service = VoiceService::new();
         let player_id = "player_123";
-        
+
         let result = service.send_heartbeat(player_id).await;
         assert!(result.is_ok());
-        
+
         let messages = service.get_signaling_messages().await;
         assert_eq!(messages.len(), 1);
-        
+
         match &messages[0] {
             SignalingMessage::Heartbeat { player_id: id, .. } => {
                 assert_eq!(id, player_id);
@@ -1038,47 +1041,47 @@ mod tests {
             _ => panic!("期望心跳消息"),
         }
     }
-    
+
     #[tokio::test]
     async fn test_check_heartbeat_timeout() {
         let service = VoiceService::new();
-        
+
         // 添加一个玩家
         let message = SignalingMessage::PlayerJoined {
             player_id: "player_123".to_string(),
             player_name: "测试玩家".to_string(),
         };
         service.handle_signaling(message).await.unwrap();
-        
+
         // 立即检查，不应该超时
         let timeout_players = service.check_heartbeat_timeout(30).await;
         assert!(timeout_players.is_empty());
-        
+
         // 等待2秒后检查（使用1秒的超时时间进行测试）
         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
         let timeout_players = service.check_heartbeat_timeout(1).await;
         assert_eq!(timeout_players.len(), 1);
         assert_eq!(timeout_players[0], "player_123");
     }
-    
+
     #[tokio::test]
     async fn test_get_muted_players() {
         let service = VoiceService::new();
-        
+
         // 静音多个玩家
         service.mute_player("player_1", true).await.unwrap();
         service.mute_player("player_2", true).await.unwrap();
         service.mute_player("player_3", true).await.unwrap();
-        
+
         let muted = service.get_muted_players().await;
         assert_eq!(muted.len(), 3);
         assert!(muted.contains(&"player_1".to_string()));
         assert!(muted.contains(&"player_2".to_string()));
         assert!(muted.contains(&"player_3".to_string()));
-        
+
         // 取消静音一个玩家
         service.mute_player("player_2", false).await.unwrap();
-        
+
         let muted = service.get_muted_players().await;
         assert_eq!(muted.len(), 2);
         assert!(!muted.contains(&"player_2".to_string()));

--- a/src-tauri/src/modules/websocket_signaling.rs
+++ b/src-tauri/src/modules/websocket_signaling.rs
@@ -1,13 +1,13 @@
+use crate::modules::error::AppError;
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::sync::RwLock;
-use serde::{Deserialize, Serialize};
 use tauri::Emitter;
-use crate::modules::error::AppError;
-use tokio_tungstenite::{accept_async, tungstenite::Message};
 use tokio::net::{TcpListener, TcpStream};
-use futures_util::{StreamExt, SinkExt};
+use tokio::sync::RwLock;
+use tokio_tungstenite::{accept_async, tungstenite::Message};
 
 /// WebSocket 信令消息
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,9 +21,7 @@ pub enum SignalingMessage {
         player_name: String,
     },
     /// 玩家列表
-    PlayersList {
-        players: Vec<PlayerInfo>,
-    },
+    PlayersList { players: Vec<PlayerInfo> },
     /// 玩家加入
     PlayerJoined {
         #[serde(rename = "playerId")]
@@ -94,7 +92,11 @@ pub struct CandidateData {
 struct ClientInfo {
     player_id: String,
     player_name: String,
-    sender: Arc<RwLock<futures_util::stream::SplitSink<tokio_tungstenite::WebSocketStream<TcpStream>, Message>>>,
+    sender: Arc<
+        RwLock<
+            futures_util::stream::SplitSink<tokio_tungstenite::WebSocketStream<TcpStream>, Message>,
+        >,
+    >,
 }
 
 /// WebSocket 信令服务器
@@ -118,7 +120,7 @@ impl WebSocketSignalingServer {
         log::info!("创建 WebSocket 信令服务器");
         log::info!("  监听地址: {}", listen_addr);
         log::info!("  虚拟IP: {} (用于前端连接)", virtual_ip);
-        
+
         Self {
             listen_addr,
             clients: Arc::new(RwLock::new(HashMap::new())),
@@ -126,18 +128,18 @@ impl WebSocketSignalingServer {
             app_handle: Arc::new(RwLock::new(None)),
         }
     }
-    
+
     /// 设置 Tauri 应用句柄
     pub async fn set_app_handle(&self, app_handle: tauri::AppHandle) {
         let mut handle = self.app_handle.write().await;
         *handle = Some(app_handle);
         log::info!("WebSocket 信令服务器已设置应用句柄");
     }
-    
+
     /// 启动服务器
     pub async fn start(&self) -> Result<(), AppError> {
         log::info!("启动 WebSocket 信令服务器: {}", self.listen_addr);
-        
+
         // 检查是否已经在运行
         {
             let is_running = self.is_running.read().await;
@@ -146,38 +148,45 @@ impl WebSocketSignalingServer {
                 return Ok(());
             }
         }
-        
+
         // 绑定监听地址
-        let listener = TcpListener::bind(&self.listen_addr).await
-            .map_err(|e| AppError::NetworkError(format!("无法绑定地址 {}: {}", self.listen_addr, e)))?;
-        
+        let listener = TcpListener::bind(&self.listen_addr).await.map_err(|e| {
+            AppError::NetworkError(format!("无法绑定地址 {}: {}", self.listen_addr, e))
+        })?;
+
         log::info!("✅ WebSocket 信令服务器已绑定到: {}", self.listen_addr);
-        
+
         // 标记为正在运行
         *self.is_running.write().await = true;
-        
+
         // 克隆需要的数据
         let clients = Arc::clone(&self.clients);
         let is_running = Arc::clone(&self.is_running);
         let app_handle = Arc::clone(&self.app_handle);
-        
+
         // 启动接受连接的任务
         tokio::spawn(async move {
             while *is_running.read().await {
                 // 用 1 秒超时包裹 accept，避免 accept 永久阻塞导致 stop() 后无法退出循环；
                 // 超时后回到 while 重新检查 is_running，从而能够干净停止。
-                match tokio::time::timeout(
-                    std::time::Duration::from_secs(1),
-                    listener.accept(),
-                ).await {
+                match tokio::time::timeout(std::time::Duration::from_secs(1), listener.accept())
+                    .await
+                {
                     Ok(Ok((stream, addr))) => {
                         log::info!("新客户端连接: {}", addr);
-                        
+
                         let clients_clone = Arc::clone(&clients);
                         let app_handle_clone = Arc::clone(&app_handle);
-                        
+
                         tokio::spawn(async move {
-                            if let Err(e) = Self::handle_connection(stream, addr, clients_clone, app_handle_clone).await {
+                            if let Err(e) = Self::handle_connection(
+                                stream,
+                                addr,
+                                clients_clone,
+                                app_handle_clone,
+                            )
+                            .await
+                            {
                                 log::error!("处理客户端连接失败 ({}): {}", addr, e);
                             }
                         });
@@ -191,14 +200,14 @@ impl WebSocketSignalingServer {
                     }
                 }
             }
-            
+
             log::info!("WebSocket 信令服务器已停止接受新连接");
         });
-        
+
         log::info!("✅ WebSocket 信令服务器启动成功");
         Ok(())
     }
-    
+
     /// 处理客户端连接
     async fn handle_connection(
         stream: TcpStream,
@@ -207,43 +216,49 @@ impl WebSocketSignalingServer {
         app_handle: Arc<RwLock<Option<tauri::AppHandle>>>,
     ) -> Result<(), AppError> {
         // 升级到 WebSocket
-        let ws_stream = accept_async(stream).await
+        let ws_stream = accept_async(stream)
+            .await
             .map_err(|e| AppError::NetworkError(format!("WebSocket 握手失败: {}", e)))?;
-        
+
         log::info!("✅ WebSocket 连接已建立: {}", addr);
-        
+
         let (write, mut read) = ws_stream.split();
         let write = Arc::new(RwLock::new(write));
-        
+
         let mut client_id: Option<String> = None;
-        
+
         // 处理消息
         while let Some(msg_result) = read.next().await {
             match msg_result {
                 Ok(msg) => {
                     if msg.is_text() {
                         let text = msg.to_text().unwrap();
-                        
+
                         match serde_json::from_str::<SignalingMessage>(text) {
                             Ok(message) => {
                                 match message {
-                                    SignalingMessage::Register { client_id: cid, player_name } => {
+                                    SignalingMessage::Register {
+                                        client_id: cid,
+                                        player_name,
+                                    } => {
                                         log::info!("客户端注册: {} ({})", player_name, cid);
-                                        
+
                                         // 保存客户端信息
                                         let client_info = ClientInfo {
                                             player_id: cid.clone(),
                                             player_name: player_name.clone(),
                                             sender: Arc::clone(&write),
                                         };
-                                        
+
                                         clients.write().await.insert(cid.clone(), client_info);
                                         client_id = Some(cid.clone());
-                                        
+
                                         log::info!("当前在线: {} 人", clients.read().await.len());
-                                        
+
                                         // 发送当前在线玩家列表
-                                        let players: Vec<PlayerInfo> = clients.read().await
+                                        let players: Vec<PlayerInfo> = clients
+                                            .read()
+                                            .await
                                             .iter()
                                             .filter(|(id, _)| **id != cid)
                                             .map(|(_, info)| PlayerInfo {
@@ -251,12 +266,14 @@ impl WebSocketSignalingServer {
                                                 player_name: info.player_name.clone(),
                                             })
                                             .collect();
-                                        
-                                        let players_list = SignalingMessage::PlayersList { players };
+
+                                        let players_list =
+                                            SignalingMessage::PlayersList { players };
                                         if let Ok(json) = serde_json::to_string(&players_list) {
-                                            let _ = write.write().await.send(Message::Text(json)).await;
+                                            let _ =
+                                                write.write().await.send(Message::Text(json)).await;
                                         }
-                                        
+
                                         // 通知其他客户端有新玩家加入
                                         Self::broadcast_except(
                                             &clients,
@@ -265,24 +282,32 @@ impl WebSocketSignalingServer {
                                                 player_id: cid.clone(),
                                                 player_name: player_name.clone(),
                                             },
-                                        ).await;
-                                        
+                                        )
+                                        .await;
+
                                         // 通知前端（如果是本地客户端）
                                         if let Some(app) = app_handle.read().await.as_ref() {
-                                            let _ = app.emit("player-joined", serde_json::json!({
-                                                "playerId": cid,
-                                                "playerName": player_name,
-                                            }));
+                                            let _ = app.emit(
+                                                "player-joined",
+                                                serde_json::json!({
+                                                    "playerId": cid,
+                                                    "playerName": player_name,
+                                                }),
+                                            );
                                         }
                                     }
-                                    SignalingMessage::Offer { from, to, offer, .. } => {
+                                    SignalingMessage::Offer {
+                                        from, to, offer, ..
+                                    } => {
                                         log::info!("转发 Offer from {} to {}", from, to);
-                                        
+
                                         // 获取发送者名称
-                                        let player_name = clients.read().await
+                                        let player_name = clients
+                                            .read()
+                                            .await
                                             .get(&from)
                                             .map(|info| info.player_name.clone());
-                                        
+
                                         // 转发到目标客户端
                                         if let Some(target) = clients.read().await.get(&to) {
                                             let forward_msg = SignalingMessage::Offer {
@@ -291,9 +316,14 @@ impl WebSocketSignalingServer {
                                                 offer,
                                                 player_name,
                                             };
-                                            
+
                                             if let Ok(json) = serde_json::to_string(&forward_msg) {
-                                                let _ = target.sender.write().await.send(Message::Text(json)).await;
+                                                let _ = target
+                                                    .sender
+                                                    .write()
+                                                    .await
+                                                    .send(Message::Text(json))
+                                                    .await;
                                             }
                                         } else {
                                             log::warn!("目标客户端不存在: {}", to);
@@ -301,27 +331,46 @@ impl WebSocketSignalingServer {
                                     }
                                     SignalingMessage::Answer { from, to, answer } => {
                                         log::info!("转发 Answer from {} to {}", from, to);
-                                        
+
                                         // 转发到目标客户端
                                         if let Some(target) = clients.read().await.get(&to) {
-                                            let forward_msg = SignalingMessage::Answer { from, to, answer };
-                                            
+                                            let forward_msg =
+                                                SignalingMessage::Answer { from, to, answer };
+
                                             if let Ok(json) = serde_json::to_string(&forward_msg) {
-                                                let _ = target.sender.write().await.send(Message::Text(json)).await;
+                                                let _ = target
+                                                    .sender
+                                                    .write()
+                                                    .await
+                                                    .send(Message::Text(json))
+                                                    .await;
                                             }
                                         } else {
                                             log::warn!("目标客户端不存在: {}", to);
                                         }
                                     }
-                                    SignalingMessage::IceCandidate { from, to, candidate } => {
+                                    SignalingMessage::IceCandidate {
+                                        from,
+                                        to,
+                                        candidate,
+                                    } => {
                                         log::debug!("转发 ICE Candidate from {} to {}", from, to);
-                                        
+
                                         // 转发到目标客户端
                                         if let Some(target) = clients.read().await.get(&to) {
-                                            let forward_msg = SignalingMessage::IceCandidate { from, to, candidate };
-                                            
+                                            let forward_msg = SignalingMessage::IceCandidate {
+                                                from,
+                                                to,
+                                                candidate,
+                                            };
+
                                             if let Ok(json) = serde_json::to_string(&forward_msg) {
-                                                let _ = target.sender.write().await.send(Message::Text(json)).await;
+                                                let _ = target
+                                                    .sender
+                                                    .write()
+                                                    .await
+                                                    .send(Message::Text(json))
+                                                    .await;
                                             }
                                         } else {
                                             log::warn!("目标客户端不存在: {}", to);
@@ -347,7 +396,7 @@ impl WebSocketSignalingServer {
                 }
             }
         }
-        
+
         // 客户端断开连接，清理资源
         if let Some(cid) = client_id {
             log::info!("客户端断开: {}", cid);
@@ -370,7 +419,7 @@ impl WebSocketSignalingServer {
                 log::info!("Ignoring stale signaling session close for {}", cid);
                 return Ok(());
             }
-            
+
             // 通知其他客户端
             Self::broadcast_except(
                 &clients,
@@ -378,19 +427,23 @@ impl WebSocketSignalingServer {
                 SignalingMessage::PlayerLeft {
                     player_id: cid.clone(),
                 },
-            ).await;
-            
+            )
+            .await;
+
             // 通知前端
             if let Some(app) = app_handle.read().await.as_ref() {
-                let _ = app.emit("player-left", serde_json::json!({
-                    "playerId": cid,
-                }));
+                let _ = app.emit(
+                    "player-left",
+                    serde_json::json!({
+                        "playerId": cid,
+                    }),
+                );
             }
         }
-        
+
         Ok(())
     }
-    
+
     /// 广播消息（排除指定客户端）
     async fn broadcast_except(
         clients: &Arc<RwLock<HashMap<String, ClientInfo>>>,
@@ -401,24 +454,29 @@ impl WebSocketSignalingServer {
             let clients_read = clients.read().await;
             for (id, client) in clients_read.iter() {
                 if id != exclude_id {
-                    let _ = client.sender.write().await.send(Message::Text(json.clone())).await;
+                    let _ = client
+                        .sender
+                        .write()
+                        .await
+                        .send(Message::Text(json.clone()))
+                        .await;
                 }
             }
         }
     }
-    
+
     /// 停止服务器
     pub async fn stop(&self) -> Result<(), AppError> {
         log::info!("停止 WebSocket 信令服务器");
-        
+
         *self.is_running.write().await = false;
-        
+
         // 关闭所有客户端连接
         self.clients.write().await.clear();
-        
+
         Ok(())
     }
-    
+
     /// 获取在线客户端数量
     pub async fn get_client_count(&self) -> usize {
         self.clients.read().await.len()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,6 @@
           "blob:",
           "ws:",
           "wss:",
-          "http://*:14539",
           "http://*:14540",
           "https://gitee.com"
         ],
@@ -70,7 +69,6 @@
           "blob:",
           "ws:",
           "wss:",
-          "http://*:14539",
           "http://*:14540",
           "https://gitee.com",
           "http://localhost:1420"
@@ -83,13 +81,13 @@
     "withGlobalTauri": false
   },
   "plugins": {
+    "shell": {
+      "open": "https://(?:mctier\\.pmhs\\.top|www\\.mcmod\\.cn|github\\.com|gitee\\.com|webrtc\\.googlesource\\.com|www\\.wintun\\.net|reqrypt\\.org|npcap\\.com)(?:[/?#][^\\s]*)?\\z"
+    },
     "deep-link": {
       "desktop": {
         "schemes": ["mctier"]
       }
-    },
-    "shell": {
-      "open": "https?://[a-zA-Z0-9][^\\s\"'<>]*"
     }
   },
   "bundle": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import {
   resolveTheme,
   type ThemePreference,
 } from './theme/themePreference';
+import { isSafeResourceId, sanitizeUntrustedText } from './security/trustBoundary';
 import './App.css';
 
 function App() {
@@ -107,8 +108,9 @@ function App() {
   if (isScreenViewerWindow) {
     // 从URL参数中获取shareId和playerName
     const urlParams = new URLSearchParams(window.location.search);
-    const shareId = urlParams.get('shareId') || '';
-    const playerName = urlParams.get('playerName') || tl('未知玩家', 'Unknown Player');
+    const rawShareId = urlParams.get('shareId');
+    const shareId = isSafeResourceId(rawShareId) ? rawShareId : '';
+    const playerName = sanitizeUntrustedText(urlParams.get('playerName'), 64).trim() || tl('未知玩家', 'Unknown Player');
     
     return (
       <ErrorBoundary>
@@ -411,7 +413,7 @@ function App() {
         // 从后端加载用户配置
         try {
           const userConfig = await invoke<UserConfig>('get_config');
-          console.log('已加载用户配置:', userConfig);
+          console.log('已加载用户配置');
 
           // 更新前端store中的配置
           const { updateConfig } = useAppStore.getState();
@@ -492,7 +494,7 @@ function App() {
 
           // 获取玩家名称
           const playerName = useAppStore.getState().config.playerName || tl('未知玩家', 'Unknown Player');
-          console.log('使用玩家名称:', playerName);
+           console.log('已读取玩家身份');
 
           // 在初始化之前先设置版本错误回调
           webrtcClient.onVersionError((currentVersion, minimumVersion) => {
@@ -506,12 +508,7 @@ function App() {
           // 初始化WebRTC客户端
           // 从 lobby 对象中获取信令服务器地址，如果没有则使用默认值
           const signalingServer = lobby.signalingServer || 'wss://mctier.pmhs.top/signaling';
-          console.log('使用信令服务器:', signalingServer);
-
-          console.log('WebRTC初始化参数:');
-          console.log('  - 当前玩家虚拟IP:', lobby.virtualIp);
-          console.log('  - 大厅名称:', lobby.name);
-          console.log('  - 信令服务器:', signalingServer);
+           console.log('已准备 WebRTC 连接参数');
 
           await webrtcClient.initialize(playerId, playerName, lobby.name, lobby.password || '', lobby.virtualDomain, lobby.useDomain, signalingServer);
 
@@ -572,7 +569,7 @@ function App() {
           });
 
           webrtcClient.onChatMessage((playerId, playerName, content, timestamp) => {
-            console.log(`WebRTC: 收到聊天消息 - ${playerName}: ${content}`);
+            console.log('WebRTC: 收到聊天消息');
             addChatMessage({
               id: `${playerId}-${timestamp}`,
               playerId,

--- a/src/components/AboutWindow/AboutWindow.tsx
+++ b/src/components/AboutWindow/AboutWindow.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Button, Typography, Divider, Modal } from 'antd';
 import { useTranslation } from 'react-i18next';
+import { open } from '@tauri-apps/plugin-shell';
 import { tl } from '../../i18n';
 import {
   GitHubIcon,
@@ -44,6 +45,13 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
   const [showSponsorModal, setShowSponsorModal] = useState(false);
   const [enlargedQRCode, setEnlargedQRCode] = useState<string | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
+
+  const openTrustedExternal = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    void open(event.currentTarget.href).catch((error) => {
+      console.error('打开外部链接失败:', error);
+    });
+  };
 
   // ESC键返回
   useEscapeKey(() => {
@@ -301,6 +309,7 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
                 <a
                   href="https://mctier.pmhs.top"
                   target="_blank"
+                  onClick={openTrustedExternal}
                   rel="noopener noreferrer"
                   className="repo-link"
                 >
@@ -310,6 +319,7 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
                 <a
                   href="https://github.com/pmh1314520/MCTier"
                   target="_blank"
+                  onClick={openTrustedExternal}
                   rel="noopener noreferrer"
                   className="repo-link"
                 >
@@ -319,6 +329,7 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
                 <a
                   href="https://gitee.com/peng-minghang/mctier"
                   target="_blank"
+                  onClick={openTrustedExternal}
                   rel="noopener noreferrer"
                   className="repo-link"
                 >
@@ -442,6 +453,7 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
                   <a
                     href="https://github.com/EasyTier/EasyTier"
                     target="_blank"
+                    onClick={openTrustedExternal}
                     rel="noopener noreferrer"
                     className="third-party-link"
                   >
@@ -471,6 +483,7 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
                   <a
                     href="https://webrtc.googlesource.com/src"
                     target="_blank"
+                    onClick={openTrustedExternal}
                     rel="noopener noreferrer"
                     className="third-party-link"
                   >
@@ -497,6 +510,7 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
                   <a
                     href="https://www.wintun.net"
                     target="_blank"
+                    onClick={openTrustedExternal}
                     rel="noopener noreferrer"
                     className="third-party-link"
                   >
@@ -520,6 +534,7 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
                   <a
                     href="https://reqrypt.org/windivert.html"
                     target="_blank"
+                    onClick={openTrustedExternal}
                     rel="noopener noreferrer"
                     className="third-party-link"
                   >
@@ -546,6 +561,7 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
                   <a
                     href="https://npcap.com"
                     target="_blank"
+                    onClick={openTrustedExternal}
                     rel="noopener noreferrer"
                     className="third-party-link"
                   >
@@ -575,6 +591,7 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
                   <a
                     href="https://github.com/localai-org/LocalVQE"
                     target="_blank"
+                    onClick={openTrustedExternal}
                     rel="noopener noreferrer"
                     className="third-party-link"
                   >
@@ -601,6 +618,7 @@ export const AboutWindow: React.FC<AboutWindowProps> = ({ onClose }) => {
                   <a
                     href="https://github.com/jboss-javassist/javassist"
                     target="_blank"
+                    onClick={openTrustedExternal}
                     rel="noopener noreferrer"
                     className="third-party-link"
                   >

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { isSafeImageDataUrl } from '../../security/trustBoundary';
 import './Avatar.css';
 
 const MAX_SIZE = 256;
@@ -59,6 +60,7 @@ export const Avatar: React.FC<AvatarProps> = ({
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const initial = Array.from((name || '?').trim())[0] || '?';
+  const safeAvatarData = isSafeImageDataUrl(avatarData) ? avatarData : undefined;
 
   const chooseAvatar = () => {
     if (!editable || !onChange) return;
@@ -84,7 +86,7 @@ export const Avatar: React.FC<AvatarProps> = ({
 
   return (
     <div
-      className={`mct-avatar ${avatarData ? 'has-image' : 'no-image'} ${editable ? 'mct-avatar-editable' : ''} ${className}`.trim()}
+      className={`mct-avatar ${safeAvatarData ? 'has-image' : 'no-image'} ${editable ? 'mct-avatar-editable' : ''} ${className}`.trim()}
       style={{ width: size, height: size }}
       onClick={chooseAvatar}
       onKeyDown={handleKeyDown}
@@ -92,7 +94,7 @@ export const Avatar: React.FC<AvatarProps> = ({
       tabIndex={editable ? 0 : undefined}
       aria-label={editable ? '上传头像' : `${name || '玩家'}的头像`}
     >
-      {avatarData ? <img src={avatarData} alt="" draggable={false} /> : <span>{initial.toUpperCase()}</span>}
+      {safeAvatarData ? <img src={safeAvatarData} alt="" draggable={false} /> : <span>{initial.toUpperCase()}</span>}
       {editable && <input ref={inputRef} type="file" accept="image/*" onChange={(event) => void handleFile(event)} />}
     </div>
   );

--- a/src/components/ChatRoom/ChatRoom.tsx
+++ b/src/components/ChatRoom/ChatRoom.tsx
@@ -13,6 +13,7 @@ import { Avatar } from '../Avatar/Avatar';
 import { saveAvatarData } from '../../services/avatar/avatarService';
 import { useTranslation } from 'react-i18next';
 import { tl } from '../../i18n';
+import { isSafeHttpUrl, isSafeImageDataUrl } from '../../security/trustBoundary';
 import type { ChatMessage } from '../../types';
 import './ChatRoom.css';
 
@@ -821,10 +822,11 @@ export const ChatRoom: React.FC = () => {
     const urlRegex = /(https?:\/\/[^\s]+)/g;
     const segments = text.split(urlRegex);
     return segments.map((seg, i) => {
-      if (urlRegex.test(seg)) {
+      if (/^https?:\/\//i.test(seg)) {
         // 去掉结尾常见标点，避免把句号带进链接
         const trimmed = seg.replace(/[。，、,.!?；;）)】\]]+$/, '');
         const tail = seg.slice(trimmed.length);
+        if (!isSafeHttpUrl(trimmed)) return <React.Fragment key={`u-${i}`}>{seg}</React.Fragment>;
         return (
           <React.Fragment key={`u-${i}`}>
             <a
@@ -894,6 +896,7 @@ export const ChatRoom: React.FC = () => {
             const isOwnMessage = message.playerId === currentPlayerId;
             const canRecallMessage = isOwnMessage && !message.recalled && isWithinRecallWindow(message.timestamp, recallClock);
             const showUnreadDivider = firstUnreadId && message.id === firstUnreadId;
+            const imageData = isSafeImageDataUrl(message.imageData) ? message.imageData : undefined;
             
             return (
               <React.Fragment key={message.id}>
@@ -937,23 +940,23 @@ export const ChatRoom: React.FC = () => {
                 </span>
                 
                 <div className="message-bubble-stack">
-                <div className={`message-content${message.type === 'image' && message.imageData ? ' message-content-image' : ''}${message.recalled ? ' message-content-recalled' : ''}`}>
+                <div className={`message-content${message.type === 'image' && imageData ? ' message-content-image' : ''}${message.recalled ? ' message-content-recalled' : ''}`}>
                   {message.recalled ? (
                     <span className="message-recalled-text message-text-body">{tl('此消息已撤回', 'This message was recalled')}</span>
-                  ) : message.type === 'image' && message.imageData ? (
+                  ) : message.type === 'image' && imageData ? (
                     <div className="chat-image-wrapper">
                       <img 
-                        src={message.imageData} 
+                         src={imageData}
                         alt={tl('聊天图片', 'Chat image')} 
                         className="chat-image"
-                        onClick={() => { setPreviewZoom(1); setPreviewPan({ x: 0, y: 0 }); setPreviewImage(message.imageData!); }}
+                         onClick={() => { setPreviewZoom(1); setPreviewPan({ x: 0, y: 0 }); setPreviewImage(imageData); }}
                         onLoad={() => { if (isAtBottom) { try { scrollToBottom(); } catch { /* ignore */ } } }}
                       />
                       <button
                         className="image-download-btn"
                         onClick={(e) => {
                           e.stopPropagation();
-                          handleDownloadImage(message.imageData!, message.id);
+                           handleDownloadImage(imageData, message.id);
                         }}
                         disabled={downloadingImageId === message.id}
                         title={tl('下载图片', 'Download image')}

--- a/src/components/Danmaku/DanmakuOverlay.tsx
+++ b/src/components/Danmaku/DanmakuOverlay.tsx
@@ -2,6 +2,11 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { tl } from '../../i18n';
+import {
+  MAX_CHAT_TEXT_LENGTH,
+  sanitizeImageDataUrl,
+  sanitizeUntrustedText,
+} from '../../security/trustBoundary';
 import './DanmakuOverlay.css';
 
 interface Bullet {
@@ -57,8 +62,14 @@ export const DanmakuOverlay: React.FC = () => {
   }, []);
 
   const spawn = useCallback((p: DanmakuPayload) => {
+    if (!p || typeof p !== 'object') return;
+    const text = sanitizeUntrustedText(p.text, MAX_CHAT_TEXT_LENGTH);
+    const image = sanitizeImageDataUrl(p.image);
+    const isImage = p.kind === 'image' && !!image;
+    if (!text && !isImage) return;
+
     const vw = window.innerWidth || 1920;
-    const tracks = Math.max(1, Math.min(12, p.tracks || 4));
+    const tracks = Number.isFinite(p.tracks) ? Math.max(1, Math.min(12, Math.floor(p.tracks))) : 4;
     if (trackFreeAt.current.length !== tracks) {
       trackFreeAt.current = new Array(tracks).fill(0);
     }
@@ -69,32 +80,32 @@ export const DanmakuOverlay: React.FC = () => {
       if (trackFreeAt.current[i] <= now) { track = i; break; }
       if (trackFreeAt.current[i] < earliest) { earliest = trackFreeAt.current[i]; track = i; }
     }
-    const speed = Math.max(40, p.speed || 140);
-    const isImage = p.kind === 'image' && !!p.image;
-    const imgH = p.fontSize * 1.55;
+    const speed = Number.isFinite(p.speed) ? Math.max(40, Math.min(1000, p.speed)) : 140;
+    const fontSize = Number.isFinite(p.fontSize) ? Math.max(12, Math.min(72, p.fontSize)) : 24;
+    const imgH = fontSize * 1.55;
     const estWidth = isImage
-      ? (p.text.length * p.fontSize * 0.62) + p.fontSize * 3.6 + 50
-      : p.text.length * p.fontSize * 0.62 + 40;
+      ? (text.length * fontSize * 0.62) + fontSize * 3.6 + 50
+      : text.length * fontSize * 0.62 + 40;
     const distance = vw + estWidth;
     const duration = distance / speed; // s
     const releaseDelay = (estWidth + 30) / speed * 1000;
     trackFreeAt.current[track] = now + releaseDelay;
 
-    const lineHeight = (isImage ? imgH : p.fontSize) * 1.6;
+    const lineHeight = (isImage ? imgH : fontSize) * 1.6;
     const top = 12 + track * lineHeight;
 
     const bullet: Bullet = {
       id: idRef.current++,
-      text: p.text,
-      color: p.color || '#ffffff',
-      fontSize: p.fontSize,
+      text,
+      color: typeof p.color === 'string' && p.color.length <= 32 ? p.color : '#ffffff',
+      fontSize,
       duration,
       top,
       kind: isImage ? 'image' : 'text',
-      image: p.image,
-      copyText: p.copyText,
+      image,
+      copyText: sanitizeUntrustedText(p.copyText, MAX_CHAT_TEXT_LENGTH),
     };
-    setOpacity(p.opacity ?? 0.9);
+    setOpacity(Number.isFinite(p.opacity) ? Math.max(0, Math.min(1, p.opacity)) : 0.9);
     setBullets((prev) => [...prev, bullet]);
     // 移除交由 onAnimationEnd 处理：暂停时动画不结束故不会被移除，恢复后飘出自动清理。
   }, []);
@@ -177,7 +188,7 @@ export const DanmakuOverlay: React.FC = () => {
 
     let un: (() => void) | undefined;
     listen<DanmakuPayload>('danmaku-msg', (e) => {
-      if (e.payload && (e.payload.text || e.payload.image)) spawn(e.payload);
+      if (e.payload && typeof e.payload === 'object') spawn(e.payload);
     }).then((fn) => { un = fn; });
     // 语言同步：主窗口切换语言时本窗口随之刷新
     let unLang: (() => void) | undefined;

--- a/src/components/ExitNodeAdvancedModal/ExitNodeAdvancedModal.tsx
+++ b/src/components/ExitNodeAdvancedModal/ExitNodeAdvancedModal.tsx
@@ -54,7 +54,7 @@ export const ExitNodeAdvancedModal: React.FC<ExitNodeAdvancedModalProps> = ({
     try {
       const config = await invoke<any>('get_exit_node_advanced_config');
       
-      console.log('📖 [ExitNodeAdvanced] 加载的配置:', config);
+      console.log('📖 [ExitNodeAdvanced] 已加载配置');
       
       // 设置状态
       setEnableSocks5(config.enableSocks5 || false);

--- a/src/components/FavoriteLobbyManager/FavoriteLobbyManager.tsx
+++ b/src/components/FavoriteLobbyManager/FavoriteLobbyManager.tsx
@@ -3,12 +3,12 @@ import { Modal, Button, Form, Input, Space, App, Switch } from 'antd';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { tl } from '../../i18n';
+import { isSafeServerNode, isSafeSignalingServer, sanitizeUntrustedText } from '../../security/trustBoundary';
 import './FavoriteLobbyManager.css';
 
 export interface FavoriteLobby {
   id: string;
   name: string;
-  password: string;
   playerName?: string;
   useDomain?: boolean;
   serverNode?: string;
@@ -30,6 +30,41 @@ interface FavoriteLobbyManagerProps {
 
 const STORAGE_KEY = 'mctier_favorite_lobbies';
 
+function normalizeFavorite(value: unknown): FavoriteLobby | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const item = value as Record<string, unknown>;
+  const name = sanitizeUntrustedText(item.name, 64).trim();
+  const id = sanitizeUntrustedText(item.id, 128).trim();
+  if (!name || !id) return null;
+  const playerName = sanitizeUntrustedText(item.playerName, 64).trim();
+  const serverNode = typeof item.serverNode === 'string' && isSafeServerNode(item.serverNode) && item.serverNode !== 'custom'
+    ? item.serverNode.trim()
+    : undefined;
+  const signalingServer = typeof item.signalingServer === 'string' && isSafeSignalingServer(item.signalingServer)
+    ? item.signalingServer.trim()
+    : undefined;
+  const createdAt = typeof item.createdAt === 'number' && Number.isFinite(item.createdAt)
+    ? Math.max(0, Math.min(Number.MAX_SAFE_INTEGER, Math.trunc(item.createdAt)))
+    : Date.now();
+  const useCount = typeof item.useCount === 'number' && Number.isFinite(item.useCount)
+    ? Math.max(0, Math.min(1_000_000, Math.trunc(item.useCount)))
+    : 0;
+  const lastUsedAt = typeof item.lastUsedAt === 'number' && Number.isFinite(item.lastUsedAt)
+    ? Math.max(0, Math.min(Number.MAX_SAFE_INTEGER, Math.trunc(item.lastUsedAt)))
+    : undefined;
+  return {
+    id,
+    name,
+    ...(playerName ? { playerName } : {}),
+    ...(item.useDomain === true ? { useDomain: true } : {}),
+    ...(serverNode ? { serverNode } : {}),
+    ...(signalingServer ? { signalingServer } : {}),
+    createdAt,
+    useCount,
+    ...(lastUsedAt === undefined ? {} : { lastUsedAt }),
+  };
+}
+
 /**
  * 常用大厅信息管理组件
  */
@@ -46,8 +81,7 @@ export const FavoriteLobbyManager: React.FC<FavoriteLobbyManagerProps> = ({
   const [favorites, setFavorites] = useState<FavoriteLobby[]>([]);
   const [editingFavorite, setEditingFavorite] = useState<FavoriteLobby | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
-  const [form] = Form.useForm<{ name: string; password: string; playerName?: string; useDomain?: boolean }>();
-  const [showPassword, setShowPassword] = useState(false);
+  const [form] = Form.useForm<{ name: string; playerName?: string; useDomain?: boolean }>();
 
   // 从 localStorage 加载常用大厅列表
   useEffect(() => {
@@ -56,7 +90,16 @@ export const FavoriteLobbyManager: React.FC<FavoriteLobbyManagerProps> = ({
         const saved = localStorage.getItem(STORAGE_KEY);
         if (saved) {
           const parsed = JSON.parse(saved);
-          setFavorites(Array.isArray(parsed) ? parsed : []);
+          const normalized = Array.isArray(parsed)
+            ? parsed.flatMap((item: unknown) => {
+                const favorite = normalizeFavorite(item);
+                return favorite ? [favorite] : [];
+              })
+            : [];
+          setFavorites(normalized);
+          // Rewrite legacy entries to remove persisted passwords and malformed
+          // fields immediately, even if the user never edits a favorite.
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
         }
       } catch (error) {
         console.error('加载常用大厅列表失败:', error);
@@ -71,8 +114,12 @@ export const FavoriteLobbyManager: React.FC<FavoriteLobbyManagerProps> = ({
   // 保存常用大厅列表到 localStorage
   const saveFavorites = (newFavorites: FavoriteLobby[]) => {
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(newFavorites));
-      setFavorites(newFavorites);
+      const normalized = newFavorites.flatMap((item) => {
+        const favorite = normalizeFavorite(item);
+        return favorite ? [favorite] : [];
+      });
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+      setFavorites(normalized);
     } catch (error) {
       console.error('保存常用大厅列表失败:', error);
       message.error(tl('保存失败', 'Save failed'));
@@ -88,10 +135,9 @@ export const FavoriteLobbyManager: React.FC<FavoriteLobbyManagerProps> = ({
         // 编辑现有项
         const updated = favorites.map(fav =>
           fav.id === editingFavorite.id
-            ? { 
+          ? {
                 ...fav, 
                 name: values.name, 
-                password: values.password,
                 playerName: values.playerName,
                 useDomain: values.useDomain ?? false
               }
@@ -104,7 +150,6 @@ export const FavoriteLobbyManager: React.FC<FavoriteLobbyManagerProps> = ({
         const newFavorite: FavoriteLobby = {
           id: `fav_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
           name: values.name,
-          password: values.password,
           playerName: values.playerName,
           useDomain: values.useDomain ?? false,
           serverNode: defaultServerNode,
@@ -118,7 +163,6 @@ export const FavoriteLobbyManager: React.FC<FavoriteLobbyManagerProps> = ({
       form.resetFields();
       setEditingFavorite(null);
       setShowAddForm(false);
-      setShowPassword(false);
     } catch (error) {
       console.error('保存常用大厅失败:', error);
     }
@@ -169,7 +213,6 @@ export const FavoriteLobbyManager: React.FC<FavoriteLobbyManagerProps> = ({
     setEditingFavorite(lobby);
     form.setFieldsValue({
       name: lobby.name,
-      password: lobby.password,
       playerName: lobby.playerName,
       useDomain: lobby.useDomain ?? false,
     });
@@ -181,7 +224,6 @@ export const FavoriteLobbyManager: React.FC<FavoriteLobbyManagerProps> = ({
     form.resetFields();
     setEditingFavorite(null);
     setShowAddForm(false);
-    setShowPassword(false);
   };
 
   return (
@@ -228,71 +270,6 @@ export const FavoriteLobbyManager: React.FC<FavoriteLobbyManagerProps> = ({
                       }
                     }}
                   />
-                </Form.Item>
-                <Form.Item
-                  label={tl('密码', 'Password')}
-                  name="password"
-                  rules={[
-                    { required: true, message: tl('请输入密码', 'Enter a password') },
-                    { min: 8, max: 32, message: tl('密码长度为 8-32 个字符', 'Password must be 8-32 characters') },
-                    {
-                      validator: (_, value) => {
-                        if (!value) return Promise.resolve();
-                        const hasLetter = /[a-zA-Z]/.test(value);
-                        const hasDigit = /[0-9]/.test(value);
-                        if (!hasLetter) {
-                          return Promise.reject(new Error(tl('密码必须包含至少一个字母', 'Password must contain at least one letter')));
-                        }
-                        if (!hasDigit) {
-                          return Promise.reject(new Error(tl('密码必须包含至少一个数字', 'Password must contain at least one digit')));
-                        }
-                        return Promise.resolve();
-                      },
-                    },
-                  ]}
-                >
-                  <div style={{ position: 'relative' }}>
-                    <Input
-                      type={showPassword ? 'text' : 'password'}
-                      placeholder={tl('输入密码（至少8个字符，包含字母和数字）', 'Password (min 8 chars, letters and digits)')}
-                      style={{ paddingRight: '40px' }}
-                      className="custom-password-input"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      style={{
-                        position: 'absolute',
-                        right: '8px',
-                        top: '50%',
-                        transform: 'translateY(-50%)',
-                        background: 'transparent',
-                        border: 'none',
-                        cursor: 'pointer',
-                        padding: '4px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        color: 'rgba(255, 255, 255, 0.6)',
-                        transition: 'color 0.2s',
-                        zIndex: 10,
-                      }}
-                      onMouseEnter={(e) => e.currentTarget.style.color = 'rgba(255, 255, 255, 0.9)'}
-                      onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255, 255, 255, 0.6)'}
-                    >
-                      {showPassword ? (
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-                          <circle cx="12" cy="12" r="3"></circle>
-                        </svg>
-                      ) : (
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                          <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
-                          <line x1="1" y1="1" x2="23" y2="23"></line>
-                        </svg>
-                      )}
-                    </button>
-                  </div>
                 </Form.Item>
                 <Form.Item
                   label={tl('玩家名称', 'Player Name')}
@@ -371,7 +348,7 @@ export const FavoriteLobbyManager: React.FC<FavoriteLobbyManagerProps> = ({
                         <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
                         <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
                       </svg>
-                      <span>{item.password.replace(/./g, '●')}</span>
+                      <span>{tl('加入时需要重新输入密码', 'Password required when joining')}</span>
                     </div>
                     <div className="favorite-card-meta" style={{ fontSize: 11, color: 'rgba(255,255,255,0.45)', marginTop: 4, display: 'flex', gap: 12 }}>
                       <span>{tl('使用', 'Used')} {item.useCount ?? 0} {tl('次', 'x')}</span>

--- a/src/components/FileShareManager/FileShareManagerNew.tsx
+++ b/src/components/FileShareManager/FileShareManagerNew.tsx
@@ -14,6 +14,13 @@ import type { SharedFolder, SharedFolderSummary, FileInfo } from '../../types/fi
 import { FolderIcon, DownloadIcon, ShareIcon, CloseIcon, BackIcon, TrashIcon } from '../icons';
 import { useTranslation } from 'react-i18next';
 import { tl } from '../../i18n';
+import {
+  isSafeIdentifier,
+  isSafeRelativePath,
+  isSafeResourceId,
+  isSafeVirtualIp,
+  sanitizeUntrustedText,
+} from '../../security/trustBoundary';
 import './FileShareManager.css';
 
 // 简化的远程共享类型
@@ -22,6 +29,8 @@ interface SimpleRemoteShare {
   ownerName: string;
   ownerIp: string;
 }
+
+type DownloadRetry = (password: string) => void;
 
 // 下载任务状态
 interface DownloadTask {
@@ -39,6 +48,87 @@ interface DownloadTask {
   lastUpdateTime?: number; // 上次更新时间
   lastDownloaded?: number; // 上次下载的字节数
   isBatchDownload?: boolean; // 是否为批量下载（文件夹）
+}
+
+const WINDOWS_RESERVED_NAMES = new Set([
+  'CON', 'PRN', 'AUX', 'NUL',
+  'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+  'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
+]);
+
+function safeDownloadFileName(fileName: string): string {
+  const basename = fileName.replace(/\\/g, '/').split('/').pop()?.trim() ?? '';
+  let safe = basename
+    .replace(/[<>:"/\\|?*\u0000-\u001f\u007f]/g, '_')
+    .replace(/[. ]+$/g, '');
+  if (!safe || safe === '.' || safe === '..') {
+    throw new Error(tl('文件名无效', 'Invalid file name'));
+  }
+  const stem = safe.split('.')[0]?.toUpperCase() ?? '';
+  if (WINDOWS_RESERVED_NAMES.has(stem)) safe = `_${safe}`;
+  return safe;
+}
+
+function normalizeSharedFolderSummary(value: unknown): SharedFolderSummary | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const item = value as Record<string, unknown>;
+  const id = isSafeResourceId(item.id) ? item.id : '';
+  const name = sanitizeUntrustedText(item.name, 255).trim();
+  if (!id || !name || typeof item.has_password !== 'boolean') return null;
+  const expireTime = typeof item.expire_time === 'number' && Number.isFinite(item.expire_time)
+    ? Math.max(0, Math.min(Number.MAX_SAFE_INTEGER, Math.trunc(item.expire_time)))
+    : undefined;
+  const createdAt = typeof item.created_at === 'number' && Number.isFinite(item.created_at)
+    ? Math.max(0, Math.min(Number.MAX_SAFE_INTEGER, Math.trunc(item.created_at)))
+    : 0;
+  return {
+    id,
+    name,
+    has_password: item.has_password,
+    ...(expireTime === undefined ? {} : { expire_time: expireTime }),
+    compress_before_send: item.compress_before_send === true,
+    owner_id: sanitizeUntrustedText(item.owner_id, 128).trim(),
+    created_at: createdAt,
+  };
+}
+
+function normalizeFileInfo(value: unknown): FileInfo | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const item = value as Record<string, unknown>;
+  const name = sanitizeUntrustedText(item.name, 255).trim();
+  const path = isSafeRelativePath(item.path) ? item.path : '';
+  const size = typeof item.size === 'number' && Number.isSafeInteger(item.size)
+    ? Math.max(0, Math.min(Number.MAX_SAFE_INTEGER, item.size))
+    : -1;
+  const modified = typeof item.modified === 'number' && Number.isFinite(item.modified)
+    ? Math.max(0, Math.min(Number.MAX_SAFE_INTEGER, Math.trunc(item.modified)))
+    : 0;
+  if (!name || !path || size < 0 || typeof item.is_dir !== 'boolean') return null;
+  return { name, path, size, is_dir: item.is_dir, modified };
+}
+
+function encodeRelativePath(path: string): string {
+  return path.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+}
+
+function buildDownloadUrl(ownerIp: string, shareId: string, filePath: string): string | null {
+  if (!isSafeVirtualIp(ownerIp) || !isSafeResourceId(shareId) || !isSafeRelativePath(filePath) || !filePath) return null;
+  return `http://${ownerIp}:14539/api/shares/${encodeURIComponent(shareId)}/download/${encodeRelativePath(filePath)}`;
+}
+
+function parseDownloadUrl(url: string): { peerIp: string; shareId: string; filePath: string } | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' || parsed.port !== '14539' || !isSafeVirtualIp(parsed.hostname)) return null;
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    if (segments.length < 5 || segments[0] !== 'api' || segments[1] !== 'shares' || segments[3] !== 'download') return null;
+    const shareId = decodeURIComponent(segments[2]);
+    const filePath = segments.slice(4).map((segment) => decodeURIComponent(segment)).join('/');
+    if (!isSafeResourceId(shareId) || !isSafeRelativePath(filePath) || !filePath) return null;
+    return { peerIp: parsed.hostname, shareId, filePath };
+  } catch {
+    return null;
+  }
 }
 
 // 模块级缓存：跨组件卸载/重挂(返回大厅再进文件共享视图)保留下载记录，避免记录丢失
@@ -81,6 +171,7 @@ export const FileShareManagerNew: React.FC = () => {
   const [pendingShare, setPendingShare] = useState<SimpleRemoteShare | null>(null);
   const [sharePasswordMap, setSharePasswordMap] = useState<Record<string, string>>({});
   const pendingBrowsePathRef = useRef<string>('');
+  const pendingDownloadRetryRef = useRef<DownloadRetry | null>(null);
 
   // 从Store获取数据
   const { lobby, players, config } = useAppStore();
@@ -107,6 +198,20 @@ export const FileShareManagerNew: React.FC = () => {
     };
   };
 
+  const isUnauthorizedDownloadError = (error: unknown): boolean => {
+    const text = String(error);
+    return text.includes('401') || text.includes('访问被拒绝') || text.includes('密码错误');
+  };
+
+  const requestDownloadPassword = (remoteShare: SimpleRemoteShare, retry: DownloadRetry) => {
+    pendingDownloadRetryRef.current = retry;
+    pendingBrowsePathRef.current = currentPath;
+    setPendingShare(remoteShare);
+    setPasswordInput('');
+    setShowPasswordModal(true);
+    message.error(tl('下载需要密码，请输入后重试', 'Download requires a password; enter it to retry'));
+  };
+
   // 加载远程共享 - 简化版本
   const loadRemoteShares = async () => {
     
@@ -114,11 +219,16 @@ export const FileShareManagerNew: React.FC = () => {
     const now = Math.floor(Date.now() / 1000);
     
     // 1. 加载自己的共享
-    if (lobby?.virtualIp) {
+    if (lobby?.virtualIp && isSafeVirtualIp(lobby.virtualIp)) {
       try {
-        const shares = await invoke<SharedFolderSummary[]>('get_remote_shares', { peerIp: lobby.virtualIp });
-        
-        shares.forEach(share => {
+        const shares = await invoke<unknown>('get_remote_shares', { peerIp: lobby.virtualIp });
+        const safeShares = Array.isArray(shares)
+          ? shares.flatMap((item) => {
+              const share = normalizeSharedFolderSummary(item);
+              return share ? [share] : [];
+            })
+          : [];
+        safeShares.forEach(share => {
           // 过滤掉过期的共享
           if (!share.expire_time || share.expire_time > now) {
             allShares.push({
@@ -135,11 +245,16 @@ export const FileShareManagerNew: React.FC = () => {
     
     // 2. 加载其他玩家的共享
     for (const player of players) {
-      if (player.virtualIp) {
+      if (player.virtualIp && isSafeVirtualIp(player.virtualIp)) {
         try {
-          const shares = await invoke<SharedFolderSummary[]>('get_remote_shares', { peerIp: player.virtualIp });
-          
-          shares.forEach(share => {
+          const shares = await invoke<unknown>('get_remote_shares', { peerIp: player.virtualIp });
+          const safeShares = Array.isArray(shares)
+            ? shares.flatMap((item) => {
+                const share = normalizeSharedFolderSummary(item);
+                return share ? [share] : [];
+              })
+            : [];
+          safeShares.forEach(share => {
             // 过滤掉过期的共享
             if (!share.expire_time || share.expire_time > now) {
               allShares.push({
@@ -184,13 +299,20 @@ export const FileShareManagerNew: React.FC = () => {
     console.log('📡 [FileShareManager] 设置文件共享事件监听器');
     
     // 文件共享添加事件
-    const handleFileShareAdded = (event: any) => {
-      console.log('📁 [FileShareManager] 收到文件共享添加事件:', event.detail);
-      const { shareId, shareName, playerId, playerName, hasPassword } = event.detail;
+    const handleFileShareAdded = (event: Event) => {
+      const detail = (event as CustomEvent<unknown>).detail;
+      if (!detail || typeof detail !== 'object') return;
+      const input = detail as Record<string, unknown>;
+      const shareId = isSafeResourceId(input.shareId) ? input.shareId : '';
+      const shareName = sanitizeUntrustedText(input.shareName, 255).trim();
+      const playerId = isSafeIdentifier(input.playerId) ? input.playerId : '';
+      const playerName = sanitizeUntrustedText(input.playerName, 64).trim();
+      const hasPassword = input.hasPassword === true;
+      if (!shareId || !shareName || !playerId || !playerName || typeof input.hasPassword !== 'boolean') return;
       
       // 查找玩家的虚拟IP
       const player = players.find(p => p.id === playerId);
-      if (!player || !player.virtualIp) {
+      if (!player || !player.virtualIp || !isSafeVirtualIp(player.virtualIp)) {
         console.warn('⚠️ [FileShareManager] 找不到玩家或虚拟IP:', playerId);
         return;
       }
@@ -223,13 +345,17 @@ export const FileShareManagerNew: React.FC = () => {
     };
     
     // 文件共享删除事件
-    const handleFileShareRemoved = (event: any) => {
-      console.log('🗑️ [FileShareManager] 收到文件共享删除事件:', event.detail);
-      const { shareId, playerId } = event.detail;
+    const handleFileShareRemoved = (event: Event) => {
+      const detail = (event as CustomEvent<unknown>).detail;
+      if (!detail || typeof detail !== 'object') return;
+      const input = detail as Record<string, unknown>;
+      const shareId = isSafeResourceId(input.shareId) ? input.shareId : '';
+      const playerId = isSafeIdentifier(input.playerId) ? input.playerId : '';
+      if (!shareId || !playerId) return;
       
       // 查找玩家的虚拟IP
       const player = players.find(p => p.id === playerId);
-      if (!player || !player.virtualIp) {
+      if (!player || !player.virtualIp || !isSafeVirtualIp(player.virtualIp)) {
         console.warn('⚠️ [FileShareManager] 找不到玩家或虚拟IP:', playerId);
         return;
       }
@@ -379,29 +505,79 @@ export const FileShareManagerNew: React.FC = () => {
 
       setSelectedShare(remoteShare);
       setSelectedFiles(new Set());
-      await loadFiles(remoteShare, targetPath, verifiedPassword);
+      const loaded = await loadFiles(remoteShare, targetPath, verifiedPassword);
+      if (!loaded) return;
+      const retryDownload = pendingDownloadRetryRef.current;
+      pendingDownloadRetryRef.current = null;
       setShowPasswordModal(false);
       setPasswordInput('');
       setPendingShare(null);
       pendingBrowsePathRef.current = '';
+      retryDownload?.(verifiedPassword ?? password ?? '');
     } catch (error) {
+      const errorText = String(error);
+      if (errorText.includes('410') || errorText.includes('共享已过期')) {
+        forgetRemoteShare(remoteShare, true);
+        return;
+      }
       message.error(tl('打开共享失败', 'Failed to open share'));
     }
   };
 
   // 加载文件列表
-  const loadFiles = async (remoteShare: SimpleRemoteShare, path: string, passwordOverride?: string) => {
+  const forgetRemoteShare = (remoteShare: SimpleRemoteShare, expired: boolean) => {
+    setRemoteShares(prev => prev.filter(s =>
+      !(s.ownerIp === remoteShare.ownerIp && s.share.id === remoteShare.share.id)
+    ));
+    setSelectedShare(prev => {
+      if (!prev || prev.ownerIp !== remoteShare.ownerIp || prev.share.id !== remoteShare.share.id) {
+        return prev;
+      }
+      return null;
+    });
+    setCurrentPath('');
+    setFiles([]);
+    setSelectedFiles(new Set());
+    pendingDownloadRetryRef.current = null;
+    message.warning(expired
+      ? tl('该共享文件夹已过期', 'This shared folder has expired')
+      : tl('该共享文件夹已被删除', 'This shared folder has been deleted'));
+  };
+
+  const loadFiles = async (remoteShare: SimpleRemoteShare, path: string, passwordOverride?: string): Promise<boolean> => {
+    if (
+      !isSafeVirtualIp(remoteShare.ownerIp) ||
+      !isSafeResourceId(remoteShare.share.id) ||
+      !isSafeRelativePath(path)
+    ) {
+      message.error(tl('共享路径无效', 'Invalid shared path'));
+      return false;
+    }
     setLoadingFiles(true);
     try {
-      const response = await fetch(
-        `http://${remoteShare.ownerIp}:14539/api/shares/${remoteShare.share.id}/files${path ? `?path=${encodeURIComponent(path)}` : ''}`,
-        {
-          headers: getSharePasswordHeader(remoteShare.ownerIp, remoteShare.share.id, passwordOverride),
-        }
-      );
-
-      if (!response.ok) {
-        if (response.status === 401) {
+      const password = passwordOverride
+        ?? sharePasswordMap[getShareKey(remoteShare.ownerIp, remoteShare.share.id)]
+        ?? null;
+      try {
+        const payload = await invoke<unknown>('get_remote_files', {
+          peerIp: remoteShare.ownerIp,
+          shareId: remoteShare.share.id,
+          path: path || null,
+          password,
+        });
+        const fileList = Array.isArray(payload)
+          ? payload.flatMap((item: unknown) => {
+              const file = normalizeFileInfo(item);
+              return file ? [file] : [];
+            })
+          : [];
+        setFiles(fileList);
+        setCurrentPath(path);
+        setSelectedFiles(new Set());
+        return true;
+      } catch (error) {
+        const detail = String(error);
+        if (detail.includes('401') || detail.includes('密码错误') || detail.includes('访问被拒绝')) {
           const retryPath = path;
           message.error(tl('访问被拒绝，请重新输入密码', 'Access denied, please re-enter the password'));
           setSharePasswordMap(prev => {
@@ -414,21 +590,24 @@ export const FileShareManagerNew: React.FC = () => {
           setPendingShare(remoteShare);
           setShowPasswordModal(true);
           setPasswordInput('');
-          return;
+          return false;
         }
-        throw new Error(`HTTP ${response.status}`);
+        if (detail.includes('410') || detail.includes('共享已过期')) {
+          forgetRemoteShare(remoteShare, true);
+          return false;
+        }
+        if (detail.includes('404') || detail.includes('共享不存在')) {
+          forgetRemoteShare(remoteShare, false);
+          return false;
+        }
+        throw error;
       }
-
-      const payload = await response.json();
-      const fileList = (payload?.files ?? []) as FileInfo[];
-      setFiles(fileList);
-      setCurrentPath(path);
-      setSelectedFiles(new Set());
     } catch (error) {
       const errorMessage = String(error);
       if (!errorMessage.includes('HTTP 401')) {
         message.error(tl('加载文件列表失败', 'Failed to load file list'));
       }
+      return false;
     } finally {
       setLoadingFiles(false);
     }
@@ -468,16 +647,26 @@ export const FileShareManagerNew: React.FC = () => {
     if (!selectedShare) return;
     
     try {
-      const savePath = await invoke<string>('get_file_share_download_path', { fileName: file.name });
+      if (
+        file.is_dir ||
+        !isSafeRelativePath(file.path) ||
+        !isSafeVirtualIp(selectedShare.ownerIp) ||
+        !isSafeResourceId(selectedShare.share.id)
+      ) {
+        throw new Error(tl('文件路径无效', 'Invalid file path'));
+      }
+      const safeName = safeDownloadFileName(file.name);
+      const savePath = await invoke<string>('get_file_share_download_path', { fileName: safeName });
       
-      const downloadUrl = `http://${selectedShare.ownerIp}:14539/api/shares/${selectedShare.share.id}/download/${file.path}`;
+      const downloadUrl = buildDownloadUrl(selectedShare.ownerIp, selectedShare.share.id, file.path);
+      if (!downloadUrl) throw new Error(tl('下载地址无效', 'Invalid download URL'));
       const downloadHeaders = getSharePasswordHeader(selectedShare.ownerIp, selectedShare.share.id);
       
       // 创建下载任务
       const taskId = `download_${Date.now()}_${Math.random()}`;
       const newTask: DownloadTask = {
         id: taskId,
-        fileName: file.name,
+        fileName: safeName,
         fileSize: file.size,
         downloaded: 0,
         status: 'downloading',
@@ -501,17 +690,9 @@ export const FileShareManagerNew: React.FC = () => {
   // 实际执行下载（流式：由后端边下边写盘，避免大文件占满内存导致卡死/崩溃）
   const startDownload = async (taskId: string, url: string, savePath: string, fileSize: number, headers?: HeadersInit) => {
     try {
-      // 从下载 URL 解析 peerIp / shareId / filePath（URL 由本组件构造，格式固定）
-      // 形如 http://10.x.x.x:14539/api/shares/{shareId}/download/{filePath}
-      const afterScheme = url.replace(/^https?:\/\//, '');
-      const peerIp = afterScheme.split(':')[0];
-      const sharesIdx = url.indexOf('/api/shares/');
-      const rest = url.substring(sharesIdx + '/api/shares/'.length); // {shareId}/download/{filePath}
-      const dlIdx = rest.indexOf('/download/');
-      const shareId = rest.substring(0, dlIdx);
-      const filePathEncoded = rest.substring(dlIdx + '/download/'.length);
-      let filePath = filePathEncoded;
-      try { filePath = decodeURIComponent(filePathEncoded); } catch { /* 保持原值 */ }
+      const parsedDownload = parseDownloadUrl(url);
+      if (!parsedDownload) throw new Error('下载地址无效');
+      const { peerIp, shareId, filePath } = parsedDownload;
 
       // 从 headers 取共享密码
       let password: string | null = null;
@@ -533,6 +714,7 @@ export const FileShareManagerNew: React.FC = () => {
         filePath,
         savePath,
         password,
+        expectedSize: fileSize,
       });
 
       // 完成
@@ -545,6 +727,22 @@ export const FileShareManagerNew: React.FC = () => {
       // 用户主动取消不视为失败
       if (errStr.includes('已取消')) {
         console.log('❌ [FileShareManager] 下载被取消:', taskId);
+        return;
+      }
+      if (errStr.includes('410') || errStr.includes('共享已过期')) {
+        if (selectedShare) forgetRemoteShare(selectedShare, true);
+      }
+      if (isUnauthorizedDownloadError(error) && selectedShare) {
+        setDownloads(prev => prev.map(task =>
+          task.id === taskId ? { ...task, status: 'failed' as const, error: tl('等待重新输入密码', 'Waiting for password'), speed: 0 } : task
+        ));
+        requestDownloadPassword(selectedShare, (password) => {
+          const retryHeaders: HeadersInit = { 'x-share-password': password };
+          setDownloads(prev => prev.map(task =>
+            task.id === taskId ? { ...task, status: 'downloading' as const, error: undefined, downloaded: 0 } : task
+          ));
+          void startDownload(taskId, url, savePath, fileSize, retryHeaders);
+        });
         return;
       }
       setDownloads(prev => prev.map(task =>
@@ -563,7 +761,7 @@ export const FileShareManagerNew: React.FC = () => {
       return;
     }
 
-    const selectedFileList = files.filter(f => !f.is_dir && selectedFiles.has(f.path));
+    const selectedFileList = files.filter(f => !f.is_dir && selectedFiles.has(f.path) && isSafeRelativePath(f.path));
     
     if (selectedFileList.length === 0) {
       message.warning(tl('没有选中任何文件', 'No files selected'));
@@ -595,13 +793,17 @@ export const FileShareManagerNew: React.FC = () => {
         
         // 异步下载，不阻塞UI
         (async () => {
+          let zipCommitted = false;
           try {
             // 【流式】调用后端批量打包下载命令，边收边写盘到临时ZIP，避免大包占满内存
-            const filePaths = selectedFileList.map(f => f.path);
+            const filePaths = selectedFileList.map(f => f.path).filter((path) => isSafeRelativePath(path));
             const batchPassword = sharePasswordMap[getShareKey(selectedShare.ownerIp, selectedShare.share.id)] ?? null;
             console.log('📦 [FileShareManager] 请求批量打包(流式):', selectedShare.ownerIp, selectedShare.share.id);
             console.log('📦 [FileShareManager] 文件列表:', filePaths);
 
+            if (filePaths.length !== selectedFileList.length || !isSafeVirtualIp(selectedShare.ownerIp) || !isSafeResourceId(selectedShare.share.id)) {
+              throw new Error('文件路径无效');
+            }
             await invoke('download_remote_batch', {
               taskId,
               peerIp: selectedShare.ownerIp,
@@ -610,6 +812,7 @@ export const FileShareManagerNew: React.FC = () => {
               savePath: tempZipPath,
               password: batchPassword,
             });
+            zipCommitted = true;
 
             console.log('✅ [FileShareManager] 压缩包已保存:', tempZipPath);
             
@@ -619,7 +822,8 @@ export const FileShareManagerNew: React.FC = () => {
             
             const extractedFiles = await invoke<string[]>('extract_zip', {
               zipPath: tempZipPath,
-              extractDir: saveDir
+              extractDir: saveDir,
+              maxTotalBytes: selectedFileList.reduce((total, item) => total + Math.max(0, item.size), 0),
             });
             
             message.destroy('extracting');
@@ -647,6 +851,13 @@ export const FileShareManagerNew: React.FC = () => {
             setSelectedFiles(new Set());
           } catch (error) {
             console.error('❌ [FileShareManager] 批量下载失败:', error);
+
+            if (zipCommitted) {
+              await invoke('delete_file', { path: tempZipPath }).catch(() => {});
+            }
+            if (String(error).includes('410') || String(error).includes('共享已过期')) {
+              forgetRemoteShare(selectedShare, true);
+            }
             
             // 更新任务状态为失败
             setDownloads(prev => prev.map(task =>
@@ -665,14 +876,19 @@ export const FileShareManagerNew: React.FC = () => {
       
       // 逐个下载
       for (const file of selectedFileList) {
-        const savePath = await invoke<string>('get_file_share_download_path', { fileName: file.name });
-        const downloadUrl = `http://${selectedShare.ownerIp}:14539/api/shares/${selectedShare.share.id}/download/${file.path}`;
-      const downloadHeaders = getSharePasswordHeader(selectedShare.ownerIp, selectedShare.share.id);
+        const safeName = safeDownloadFileName(file.name);
+        const savePath = await invoke<string>('get_file_share_download_path', { fileName: safeName });
+        const downloadUrl = buildDownloadUrl(selectedShare.ownerIp, selectedShare.share.id, file.path);
+        if (!downloadUrl) {
+          message.error(tl('下载路径无效', 'Invalid download path'));
+          continue;
+        }
+        const downloadHeaders = getSharePasswordHeader(selectedShare.ownerIp, selectedShare.share.id);
         
         const taskId = `download_${Date.now()}_${Math.random()}`;
         const newTask: DownloadTask = {
           id: taskId,
-          fileName: file.name,
+          fileName: safeName,
           fileSize: file.size,
           downloaded: 0,
           status: 'downloading',
@@ -692,14 +908,19 @@ export const FileShareManagerNew: React.FC = () => {
     } else {
       // 只选中了一个文件，直接下载
       const file = selectedFileList[0];
-      const savePath = await invoke<string>('get_file_share_download_path', { fileName: file.name });
-      const downloadUrl = `http://${selectedShare.ownerIp}:14539/api/shares/${selectedShare.share.id}/download/${file.path}`;
+      const safeName = safeDownloadFileName(file.name);
+      const savePath = await invoke<string>('get_file_share_download_path', { fileName: safeName });
+      const downloadUrl = buildDownloadUrl(selectedShare.ownerIp, selectedShare.share.id, file.path);
+      if (!downloadUrl) {
+        message.error(tl('下载路径无效', 'Invalid download path'));
+        return;
+      }
       const downloadHeaders = getSharePasswordHeader(selectedShare.ownerIp, selectedShare.share.id);
       
       const taskId = `download_${Date.now()}_${Math.random()}`;
       const newTask: DownloadTask = {
         id: taskId,
-        fileName: file.name,
+        fileName: safeName,
         fileSize: file.size,
         downloaded: 0,
         status: 'downloading',
@@ -805,25 +1026,9 @@ export const FileShareManagerNew: React.FC = () => {
         : t
     ));
     
-    // 删除已下载的残留文件
-    if (task?.savePath) {
-      try {
-        console.log('🗑️ [FileShareManager] 删除残留文件:', task.savePath);
-        await invoke('delete_file', { path: task.savePath });
-        console.log('✅ [FileShareManager] 残留文件已删除');
-      } catch (error) {
-        console.error('❌ [FileShareManager] 删除残留文件失败:', error);
-      }
-      
-      // 删除临时文件
-      try {
-        await invoke('delete_file', { path: `${task.savePath}.part` });
-        console.log('✅ [FileShareManager] 临时文件已删除');
-      } catch (error) {
-        // 临时文件可能不存在，忽略错误
-      }
-    }
-    
+    // The backend owns the random .part file and removes it on cancellation.
+    // Never delete savePath here: it may be an existing user file that the
+    // no-replace backend deliberately preserved.
     setDownloads(prev => prev.filter(t => t.id !== taskId));
     message.success(tl('已取消下载', 'Download canceled'));
   };
@@ -1222,7 +1427,7 @@ const AddShareDialog: React.FC<AddShareDialogProps> = ({ visible, onClose, onSuc
       message.error(tl('请选择要共享的文件夹', 'Please select a folder to share'));
       return;
     }
-    if (hasPassword && !password) {
+    if (hasPassword && !password.trim()) {
       message.error(tl('请输入密码', 'Please enter a password'));
       return;
     }
@@ -1260,7 +1465,7 @@ const AddShareDialog: React.FC<AddShareDialogProps> = ({ visible, onClose, onSuc
             shareId: share.id,
             shareName: share.name,
             playerName: config.playerName || tl('未知玩家', 'Unknown Player'),
-            hasPassword: !!share.password,
+            hasPassword: Boolean(share.password?.trim()),
           });
         }
       } catch (error) {

--- a/src/components/GameHud/GameHudOverlay.tsx
+++ b/src/components/GameHud/GameHudOverlay.tsx
@@ -3,6 +3,7 @@ import { listen, emit } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { tl } from '../../i18n';
+import { sanitizeIdentifier, sanitizeUntrustedText } from '../../security/trustBoundary';
 import './GameHudOverlay.css';
 
 interface HudPeer {
@@ -21,6 +22,29 @@ interface HudPayload {
   peers: HudPeer[];
   opacity?: number;
   scale?: number;
+}
+
+function normalizeHudPeers(value: unknown): HudPeer[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((candidate) => {
+    if (!candidate || typeof candidate !== 'object') return [];
+    const peer = candidate as Record<string, unknown>;
+    const playerId = sanitizeIdentifier(peer.playerId);
+    if (!playerId) return [];
+    const numberOrNull = (input: unknown): number | null =>
+      typeof input === 'number' && Number.isFinite(input) ? input : null;
+    return [{
+      playerId,
+      name: sanitizeUntrustedText(peer.name, 64).trim() || tl('未知玩家', 'Unknown player'),
+      ping: numberOrNull(peer.ping),
+      loss: Math.max(0, Math.min(100, numberOrNull(peer.loss) ?? 0)),
+      speaking: peer.speaking === true,
+      self: peer.self === true,
+      muted: peer.muted === true,
+      down: Math.max(0, Math.min(1_000_000, numberOrNull(peer.down) ?? 0)),
+      up: Math.max(0, Math.min(1_000_000, numberOrNull(peer.up) ?? 0)),
+    }];
+  });
 }
 
 /**
@@ -49,15 +73,23 @@ export const GameHudOverlay: React.FC = () => {
 
     let un: (() => void) | undefined;
     listen<HudPayload>('hud-update', (e) => {
-      if (e.payload && Array.isArray(e.payload.peers)) setPeers(e.payload.peers);
-      if (e.payload && typeof e.payload.opacity === 'number') setOpacity(e.payload.opacity);
-      if (e.payload && typeof e.payload.scale === 'number') setScale(e.payload.scale);
+      if (e.payload && Array.isArray(e.payload.peers)) setPeers(normalizeHudPeers(e.payload.peers));
+      if (e.payload && typeof e.payload.opacity === 'number' && Number.isFinite(e.payload.opacity)) {
+        setOpacity(Math.max(0, Math.min(1, e.payload.opacity)));
+      }
+      if (e.payload && typeof e.payload.scale === 'number' && Number.isFinite(e.payload.scale)) {
+        setScale(Math.max(0.5, Math.min(2, e.payload.scale)));
+      }
     }).then((fn) => { un = fn; });
     // 透明度/尺寸实时变更（设置界面拖动滑块时）
     let unCfg: (() => void) | undefined;
     listen<{ opacity?: number; scale?: number }>('hud-config', (e) => {
-      if (e.payload && typeof e.payload.opacity === 'number') setOpacity(e.payload.opacity);
-      if (e.payload && typeof e.payload.scale === 'number') setScale(e.payload.scale);
+      if (e.payload && typeof e.payload.opacity === 'number' && Number.isFinite(e.payload.opacity)) {
+        setOpacity(Math.max(0, Math.min(1, e.payload.opacity)));
+      }
+      if (e.payload && typeof e.payload.scale === 'number' && Number.isFinite(e.payload.scale)) {
+        setScale(Math.max(0.5, Math.min(2, e.payload.scale)));
+      }
     }).then((fn) => { unCfg = fn; });
     let unLang: (() => void) | undefined;
     listen<string>('mctier-lang-changed', (e) => {

--- a/src/components/GlobalAdvancedConfigPanel/GlobalAdvancedConfigPanel.tsx
+++ b/src/components/GlobalAdvancedConfigPanel/GlobalAdvancedConfigPanel.tsx
@@ -20,7 +20,7 @@ export const GlobalAdvancedConfigPanel: React.FC = () => {
     setLoading(true);
     try {
       const config = await invoke<any>('get_global_easytier_advanced_config');
-      console.log('加载的全局高级配置:', config);
+      console.log('已加载全局高级配置');
       form.setFieldsValue(config);
     } catch (error) {
       console.error('加载全局高级配置失败:', error);

--- a/src/components/HistoryInput/HistoryPasswordInput.tsx
+++ b/src/components/HistoryInput/HistoryPasswordInput.tsx
@@ -25,7 +25,6 @@ export const HistoryPasswordInput: React.FC<HistoryPasswordInputProps> = ({
   value,
   onChange,
   historyKey,
-  maxHistory = 10,
   placeholder,
   size = 'large',
   disabled = false,
@@ -38,17 +37,12 @@ export const HistoryPasswordInput: React.FC<HistoryPasswordInputProps> = ({
   const inputRef = useRef<InputRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // 从 localStorage 加载历史记录
+  // Password history is intentionally disabled. Remove legacy entries during
+  // migration so a shared webview/local profile does not retain secrets.
   useEffect(() => {
-    const savedHistory = localStorage.getItem(`mctier_history_${historyKey}`);
-    if (savedHistory) {
-      try {
-        const parsed = JSON.parse(savedHistory);
-        setHistory(Array.isArray(parsed) ? parsed : []);
-      } catch (e) {
-        console.error('加载历史记录失败:', e);
-      }
-    }
+    setHistory([]);
+    setFilteredHistory([]);
+    localStorage.removeItem(`mctier_history_${historyKey}`);
   }, [historyKey]);
 
   // 根据当前输入值过滤历史记录
@@ -98,16 +92,8 @@ export const HistoryPasswordInput: React.FC<HistoryPasswordInputProps> = ({
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const currentValue = e.target.value?.trim();
     
-    // 保存到历史记录
-    if (currentValue && currentValue.length > 0) {
-      const newHistory = [
-        currentValue,
-        ...history.filter(item => item !== currentValue)
-      ].slice(0, maxHistory);
-      
-      setHistory(newHistory);
-      localStorage.setItem(`mctier_history_${historyKey}`, JSON.stringify(newHistory));
-    }
+    // Do not persist password values or maintain a password history.
+    void currentValue;
 
     // 延迟关闭，以便点击历史记录项时能够触发
     setTimeout(() => {

--- a/src/components/HostPanel/HostPanel.tsx
+++ b/src/components/HostPanel/HostPanel.tsx
@@ -50,7 +50,7 @@ export const HostPanel: React.FC<HostPanelProps> = ({ visible, onClose }) => {
   const currentCount = players.length + 1;
 
   const applyMax = () => {
-    const v = Math.max(0, Math.min(100, maxValue || 0));
+    const v = Math.max(0, Math.min(64, maxValue || 0));
     if (v !== 0 && v < currentCount) {
       message.warning(tl('人数上限不能小于当前在线人数（', 'Max players cannot be less than current online count (') + currentCount + '）');
       return;
@@ -60,13 +60,16 @@ export const HostPanel: React.FC<HostPanelProps> = ({ visible, onClose }) => {
   };
 
   const applyPublic = (checked: boolean) => {
+    if (checked && lobby?.password) {
+      setPub(false);
+      message.error(tl('公开大厅必须不设密码', 'Public lobbies must not have a password'));
+      return;
+    }
     setPub(checked);
     if (descStorageKey) localStorage.setItem(descStorageKey, desc);
     webrtcClient.setLobbyOptions({
       isPublic: checked,
       description: desc,
-      // 公开时附带明文密码，供广场内一键加入
-      password: checked ? (lobby?.password || '') : undefined,
       // 公开时附带房主当前使用的节点地址，供广场加入者自动同步（保证节点一致可互通）
       serverNode: checked ? (localStorage.getItem('mctier_current_node') || undefined) : undefined,
     });
@@ -91,7 +94,7 @@ export const HostPanel: React.FC<HostPanelProps> = ({ visible, onClose }) => {
             {tl('0 表示不限制。当前在线 ', '0 = unlimited. Online now: ')}{currentCount}{tl(' 人。', '')}
           </Paragraph>
           <Space>
-            <InputNumber min={0} max={100} value={maxValue} onChange={(v) => setMaxValue(v ?? 0)} />
+            <InputNumber min={0} max={64} value={maxValue} onChange={(v) => setMaxValue(v ?? 0)} />
             <Button type="primary" onClick={applyMax}>{tl('应用', 'Apply')}</Button>
           </Space>
         </div>
@@ -102,7 +105,7 @@ export const HostPanel: React.FC<HostPanelProps> = ({ visible, onClose }) => {
             <Switch checked={pub} onChange={applyPublic} />
           </Space>
           <Paragraph type="secondary" style={{ fontSize: 12, marginTop: 8 }}>
-            {tl('公开后，陌生人可在「公开广场」看到该大厅并一键加入（会公开大厅密码用于加入）。适合开服自由联机。', 'Once public, anyone can see and join this lobby from the Public Plaza (the lobby password is exposed for joining).')}
+            {tl('公开大厅不使用密码，陌生人可从公开广场直接加入。', 'Public lobbies have no password and can be joined directly from the plaza.')}
           </Paragraph>
           <TextArea
             value={desc}
@@ -112,7 +115,7 @@ export const HostPanel: React.FC<HostPanelProps> = ({ visible, onClose }) => {
             }}
             onBlur={() => {
               if (descStorageKey) localStorage.setItem(descStorageKey, desc);
-              if (pub) webrtcClient.setLobbyOptions({ isPublic: true, description: desc, password: lobby?.password || '' });
+              if (pub) webrtcClient.setLobbyOptions({ isPublic: true, description: desc });
             }}
             placeholder={tl('可选：填写大厅描述（如玩法、版本），展示在广场上', 'Optional: lobby description (mode, version) shown in the plaza')}
             autoSize={{ minRows: 2, maxRows: 4 }}

--- a/src/components/LobbyAdvancedConfigModal/LobbyAdvancedConfigModal.tsx
+++ b/src/components/LobbyAdvancedConfigModal/LobbyAdvancedConfigModal.tsx
@@ -34,7 +34,7 @@ export const LobbyAdvancedConfigModal: React.FC<LobbyAdvancedConfigModalProps> =
     setLoading(true);
     try {
       const config = await invoke<any>('get_lobby_easytier_advanced_config');
-      console.log('加载的大厅高级配置:', config);
+      console.log('已加载大厅高级配置');
       setUseGlobalConfig(config.use_global_config ?? true);
       form.setFieldsValue(config);
     } catch (error) {

--- a/src/components/LobbyForm/LobbyForm.tsx
+++ b/src/components/LobbyForm/LobbyForm.tsx
@@ -16,6 +16,7 @@ import type { PublicLobby } from '../../services/lobby/publicLobbies';
 import { parseLobbyInviteText, type LobbyInvite } from '../../services/lobby/lobbyInvite';
 import { useTranslation } from 'react-i18next';
 import { tl, getLanguage } from '../../i18n';
+import { isSafeServerNode, isSafeSignalingServer } from '../../security/trustBoundary';
 import './LobbyForm.css';
 
 const { Title } = Typography;
@@ -230,7 +231,7 @@ const getServerNodes = (customNodes: CustomEasyTierNode[]) => {
   customNodes.forEach((node) => {
     const name = typeof node?.name === 'string' ? node.name.trim() : '';
     const address = typeof node?.address === 'string' ? node.address.trim() : '';
-    if (!name || !address || knownAddresses.has(address) || address === 'custom') return;
+    if (!name || !address || !isSafeServerNode(address) || knownAddresses.has(address) || address === 'custom') return;
     knownAddresses.add(address);
     nodes.push({
       value: address,
@@ -457,8 +458,15 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
   const applyImportedLobby = (invite: LobbyInvite & { playerName?: string; useDomain?: boolean }) => {
     const rawServerNode = invite.serverNode?.trim() || undefined;
     const legacyCustomSentinel = rawServerNode === 'custom';
-    const serverNode = legacyCustomSentinel ? undefined : rawServerNode;
-    const signalingServer = invite.signalingServer?.trim() || undefined;
+    const serverNode = legacyCustomSentinel
+      ? undefined
+      : rawServerNode && isSafeServerNode(rawServerNode)
+        ? rawServerNode
+        : undefined;
+    const rawSignalingServer = invite.signalingServer?.trim() || undefined;
+    const signalingServer = rawSignalingServer && isSafeSignalingServer(rawSignalingServer)
+      ? rawSignalingServer
+      : undefined;
     setTemporaryServerNode(serverNode);
     setTemporarySignalingServer(serverNode ? signalingServer : undefined);
     setShowCustomServer(legacyCustomSentinel ? true : false);
@@ -475,7 +483,7 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
   const handleSelectFavorite = (lobby: FavoriteLobby) => {
     applyImportedLobby({
       name: lobby.name,
-      password: lobby.password,
+      password: '',
       playerName: lobby.playerName,
       useDomain: lobby.useDomain,
       serverNode: lobby.serverNode,
@@ -487,7 +495,7 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
   const handleSelectRecent = (lobby: RecentLobby) => {
     applyImportedLobby({
       name: lobby.name,
-      password: lobby.password,
+      password: '',
       playerName: lobby.playerName,
       useDomain: lobby.useDomain,
       serverNode: lobby.serverNode,
@@ -495,12 +503,12 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
     });
   };
 
-  // 从公开广场加入：填入大厅名与密码（公开大厅自带密码），并自动同步房主使用的节点
+  // 从公开广场加入：公开大厅必须无密码，直接填入空密码。
   const handleSelectPublic = (lobby: PublicLobby) => {
     const hostNode = (lobby.serverNode || '').trim();
     applyImportedLobby({
       name: lobby.lobbyName,
-      password: lobby.password,
+      password: '',
       serverNode: hostNode || undefined,
       signalingServer: hostNode ? 'wss://mctier.pmhs.top/signaling' : undefined,
     });
@@ -519,7 +527,7 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
     // 旧版官方节点地址自动迁移到当前官方节点
     if (isLegacyOfficialServer(pref) || pref === REMOVED_QINGYUN_NODE) return DEFAULT_EASYTIER_SERVER;
     // 直接使用上次成功连上的节点地址（官方/备用/自定义节点）
-    return pref;
+    return isSafeServerNode(pref) ? pref : DEFAULT_EASYTIER_SERVER;
   })();
 
   const initialValues: Partial<LobbyFormValues> = {
@@ -568,8 +576,12 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
         setPrivateServerConfig({
           usePrivateServer: settings.usePrivateServer || false,
           // 使用 ?? 运算符，只在 null/undefined 时使用默认值
-          privateEasytierServer: settings.privateEasytierServer ?? 'udp://us01.225284.xyz:11010',
-          privateSignalingServer: settings.privateSignalingServer ?? 'wss://mctier.pmhs.top/signaling',
+          privateEasytierServer: isSafeServerNode(settings.privateEasytierServer)
+            ? settings.privateEasytierServer
+            : 'udp://us01.225284.xyz:11010',
+          privateSignalingServer: isSafeSignalingServer(settings.privateSignalingServer)
+            ? settings.privateSignalingServer
+            : 'wss://mctier.pmhs.top/signaling',
         });
         
         // 加载自定义节点
@@ -583,8 +595,7 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
         setCustomNodes(nodes);
         setServerNodes(getServerNodes(nodes));
         
-        console.log('已加载私有服务器配置:', settings);
-        console.log('已加载自定义节点:', nodes);
+        console.log('已加载私有服务器配置和自定义节点');
       } catch (error) {
         console.error('加载私有服务器配置失败:', error);
       }
@@ -645,7 +656,7 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
       }
 
       const invite = parseLobbyInviteText(clipboardText);
-      if (invite && invite.name.length >= 4 && invite.password.length >= 8) {
+      if (invite && invite.name.length >= 4 && (invite.password.length === 0 || invite.password.length >= 8)) {
         applyImportedLobby(invite);
         message.success(
           invite.serverNode
@@ -733,10 +744,6 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
         message.error(tl('大厅名称不能为空', 'Lobby name cannot be empty'));
         return;
       }
-      if (!values.password?.trim()) {
-        message.error(tl('密码不能为空', 'Password cannot be empty'));
-        return;
-      }
       if (!values.playerName?.trim()) {
         message.error(tl('玩家名称不能为空', 'Player name cannot be empty'));
         return;
@@ -796,6 +803,11 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
         console.log('========================================');
       }
 
+      if (!isSafeServerNode(serverNode) || serverNode === 'custom' || !isSafeSignalingServer(signalingServer)) {
+        message.error(tl('服务器地址无效，请检查后重试', 'Invalid server address. Check it and retry.'));
+        return;
+      }
+
       const commandName = mode === 'create' ? 'create_lobby' : 'join_lobby';
 
       // 记录本次实际使用的节点地址，供公开广场发布时同步给加入者
@@ -839,15 +851,7 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
       }
       
       console.log('准备调用后端命令:', commandName);
-      console.log('参数:', {
-        name: values.lobbyName.trim(),
-        playerName: values.playerName.trim(),
-        playerId: currentPlayerId,
-        serverNode: serverNode,
-        signalingServer: signalingServer,
-        useDomain: values.useDomain === true,
-        virtualDomain: virtualDomain,
-      });
+      console.log('连接参数已通过前端校验');
       
       // 调用后端命令
       const lobby = await invoke<Lobby>(commandName, {
@@ -861,7 +865,11 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
         virtualDomain: virtualDomain, // 传递虚拟域名
       });
       
-      console.log('✅ 后端命令调用成功，返回的大厅信息:', lobby);
+      console.log('✅ 后端命令调用成功，已收到大厅信息:', {
+        hasLobby: !!lobby,
+        lobbyName: lobby?.name,
+        hasPassword: !!lobby?.password,
+      });
 
       // 保存玩家名称到前端store
       const { updateConfig } = useAppStore.getState();
@@ -905,7 +913,6 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
       try {
         recentService.recordLobby({
           name: values.lobbyName.trim(),
-          password: values.password.trim(),
           playerName: values.playerName.trim(),
           useDomain: values.useDomain === true,
           serverNode,
@@ -1275,12 +1282,12 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
               label={tl('密码', 'Password')}
               name="password"
               rules={[
-                { required: true, message: tl('请输入密码', 'Please enter a password') },
-                { whitespace: true, message: tl('密码不能为空白字符', 'Password cannot be only whitespace') },
-                { min: 8, max: 32, message: tl('密码长度为 8-32 个字符', 'Password must be 8-32 characters') },
                 {
                   validator: (_, value) => {
                     if (!value) return Promise.resolve();
+                    if (value.trim() !== value || value.length < 8 || value.length > 32) {
+                      return Promise.reject(new Error(tl('密码留空表示无密码，否则必须为 8-32 个字符', 'Leave blank for no password; otherwise use 8-32 characters')));
+                    }
                     const hasLetter = /[a-zA-Z]/.test(value);
                     const hasDigit = /[0-9]/.test(value);
                     if (!hasLetter) {
@@ -1295,7 +1302,7 @@ export const LobbyForm: React.FC<LobbyFormProps> = ({ mode, onClose }) => {
               ]}
             >
               <Input.Password
-                placeholder={tl('输入密码（至少8个字符，包含字母和数字）', 'Password (min 8 chars, letters and digits)')}
+                placeholder={tl('留空创建无密码大厅，或输入 8-32 位密码', 'Leave blank for no password, or enter 8-32 characters')}
                 size="large"
                 disabled={loading}
                 autoComplete="new-password"

--- a/src/components/LobbySettingsModal/LobbySettingsModal.tsx
+++ b/src/components/LobbySettingsModal/LobbySettingsModal.tsx
@@ -61,7 +61,7 @@ export const LobbySettingsModal: React.FC<LobbySettingsModalProps> = ({
     setLoading(true);
     try {
       const config = await invoke<any>('get_lobby_easytier_advanced_config');
-      console.log('📖 [LobbySettings] 加载的大厅高级配置:', JSON.stringify(config, null, 2));
+      console.log('📖 [LobbySettings] 已加载大厅高级配置');
       console.log('📖 [LobbySettings] use_global_config 字段值:', config.use_global_config);
       console.log('📖 [LobbySettings] dev_name 字段值:', config.dev_name);
       

--- a/src/components/MiniWindow/MiniWindow.tsx
+++ b/src/components/MiniWindow/MiniWindow.tsx
@@ -21,7 +21,6 @@ import { ChatRoom } from '../ChatRoom/ChatRoom';
 import { Avatar } from '../Avatar/Avatar';
 import { saveAvatarData } from '../../services/avatar/avatarService';
 import { FileShareManagerNew } from '../FileShareManager/FileShareManagerNew';
-import { fileShareService } from '../../services/fileShare/FileShareService';
 import { ScreenShareManager } from '../ScreenShareManager/ScreenShareManager';
 import { LobbySettingsModal } from '../LobbySettingsModal/LobbySettingsModal';
 import { MinecraftWorldsModal } from '../MinecraftWorlds/MinecraftWorldsModal';
@@ -312,9 +311,11 @@ export const MiniWindow: React.FC = () => {
   useEffect(() => {
     let un: (() => void) | undefined;
     void listen<{ action: string; playerId: string }>('hud-action', (e) => {
-      const { action, playerId } = e.payload || ({} as any);
-      if (!playerId) return;
+      const action = typeof e.payload?.action === 'string' ? e.payload.action : '';
+      const playerId = typeof e.payload?.playerId === 'string' ? e.payload.playerId.trim() : '';
+      if (!playerId || !['toggle-mute', 'vol-up', 'vol-down'].includes(action)) return;
       const st = useAppStore.getState();
+      if (!st.players.some((player) => player.id === playerId)) return;
       if (action === 'toggle-mute') {
         st.togglePlayerMute(playerId);
       } else if (action === 'vol-up') {
@@ -485,12 +486,11 @@ export const MiniWindow: React.FC = () => {
     }
 
     console.log('🚀 [MiniWindow] 初始化P2P聊天服务（仅初始化一次）');
-    console.log('  - 当前玩家ID:', currentPlayerId);
-    console.log('  - 自己的虚拟IP:', lobby.virtualIp);
+    console.log('  - 已准备本机聊天连接');
 
     // 设置消息接收回调（只设置一次）
     p2pChatService.onMessage((message) => {
-      console.log('📨 [MiniWindow] 收到P2P消息:', message);
+      console.log('📨 [MiniWindow] 收到P2P消息');
       
       // 查找发送者名称
       let senderName = tl('未知玩家', 'Unknown player');
@@ -574,16 +574,13 @@ export const MiniWindow: React.FC = () => {
     };
   }, [lobby, currentPlayerId, config.playerName, addChatMessage]);
 
-  // 玩家名册指纹：仅用 players.length 作依赖无法反映"虚拟IP异步补齐"（补齐时人数不变），
-  // 而共享浏览/聊天记录读取的成员校验依赖"每个成员虚拟IP均已就绪"才会启用。
-  // 若只看人数，IP 补齐后本效应不会重跑，rosterComplete 会长期停留在 false，
-  // 校验将一直处于放行状态；把 id:ip 指纹纳入依赖后，IP 一旦补齐即可重新下发名单。
+  // 玩家名册指纹：虚拟 IP 是异步补齐的，不能只以人数作为依赖。
   const playerRosterKey = players
     .map((p) => p.id + ':' + (p.virtualIp ?? ''))
     .sort()
     .join(',');
 
-  // 【新增】单独监听玩家列表变化，动态更新SSE连接
+  // 玩家列表变化时更新本窗口的聊天目标和相关 UI 状态。
   useEffect(() => {
     if (!lobby || !currentPlayerId || players.length === 0) {
       return;
@@ -595,45 +592,8 @@ export const MiniWindow: React.FC = () => {
     console.log('🔄 [MiniWindow] 玩家列表变化，更新P2P聊天连接');
     console.log('  - 其他玩家IPs:', playerIPs);
 
-    // 大厅身份名册：playerId -> 虚拟IP，供后端校验消息发送者身份，
-    // 防止同大厅成员冒用他人 playerId 发言。
-    //
-    // 注意 players 不含自己（见 WebRTCClient 中 players-list 的自身过滤），
-    // 因此需要显式补上本机条目，名册才是完整的大厅成员表。
-    //
-    // 后端对"名册中不存在的 playerId"是放行的（新玩家刚加入属正常现象），
-    // 因此这里即使名册暂时不完整也不会误伤合法成员，可以直接下发。
-    const roster: Array<[string, string]> = players
-      .filter((p) => p.id && p.virtualIp)
-      .map((p) => [p.id, p.virtualIp as string] as [string, string]);
-    if (currentPlayerId && lobby.virtualIp) {
-      roster.push([currentPlayerId, lobby.virtualIp]);
-    }
-
-    // 允许读取本机聊天记录/订阅消息流的成员IP。读取类接口不携带 playerId，
-    // 只能按来源IP判断，因此与共享一样，仅在所有成员虚拟IP均已就绪时才启用校验。
-    // 必须含本机：前端自订阅 SSE 走的是 http://{本机虚拟IP}:14540/api/chat/stream。
-    const peerIps = players.map((p) => p.virtualIp).filter(Boolean) as string[];
-    const rosterComplete = peerIps.length === players.length && !!lobby.virtualIp;
-    const chatReaders = rosterComplete ? [...peerIps, lobby.virtualIp] : undefined;
-
-    // 初始化P2P聊天服务（传入自己的虚拟IP用于过滤）
-    p2pChatService.initialize(playerIPs, currentPlayerId, lobby.virtualIp, roster, chatReaders);
-
-    // 同步文件共享的可访问成员：被移出大厅的玩家仍可能留在 EasyTier 虚拟网内，
-    // 后端据此拒绝非成员浏览与下载共享内容。
-    //
-    // 必须包含本机虚拟IP：查看"我的共享"同样是走 HTTP 请求本机的 14539
-    // （见 FileShareManagerNew 的 loadRemoteShares），而 players 不含自己，
-    // 漏掉本机会导致客户端把自己也拒掉。
-    //
-    // 仅在"每个成员的虚拟IP都已就绪"时才下发名单并启用校验：玩家的虚拟IP是
-    // 异步补齐的（这也是 backfillRemoteShareIps 存在的原因），名单不完整时
-    // 无法区分"非成员"与"IP 尚未同步的合法成员"，此时下发空名单以放行，
-    // 避免把共享重新退化成"有时有有时无"。
-    void fileShareService.updateAllowedPeers(
-      rosterComplete ? [...peerIps, lobby.virtualIp] : []
-    );
+    // 后端身份表与聊天/文件 token 由 WebRTCClient 从已认证信令快照统一配置。
+    p2pChatService.initialize(playerIPs, currentPlayerId, lobby.virtualIp);
     void p2pChatService.sendAvatar(config.avatarData).catch((error) => {
       console.warn('发送大厅头像同步消息失败:', error);
     });
@@ -822,9 +782,6 @@ export const MiniWindow: React.FC = () => {
       p2pChatService.reset();
       console.log('✅ P2P聊天服务已重置');
 
-      // 清空文件共享的可访问成员，避免旧大厅名单影响下一个大厅
-      await fileShareService.clearAllowedPeers();
-      
       // 等待一小段时间，确保WebSocket完全关闭
       await new Promise(resolve => setTimeout(resolve, 300));
       
@@ -958,7 +915,11 @@ export const MiniWindow: React.FC = () => {
   // 处理动态设置保存后重新加入大厅
   const handleLobbySettingsSaved = async () => {
     console.log('🎯 [MiniWindow] handleLobbySettingsSaved 被调用了！');
-    console.log('🎯 [MiniWindow] lobby:', lobby);
+    console.log('🎯 [MiniWindow] 当前大厅已就绪:', {
+      lobbyName: lobby?.name,
+      hasPassword: !!lobby?.password,
+      playerCount: players.length,
+    });
     console.log('🎯 [MiniWindow] currentPlayerId:', currentPlayerId);
     
     if (!lobby || !currentPlayerId) {
@@ -1027,7 +988,11 @@ export const MiniWindow: React.FC = () => {
         virtualDomain: virtualDomain,
       });
 
-      console.log('✅ [MiniWindow] 重新加入大厅成功:', newLobby);
+      console.log('✅ [MiniWindow] 重新加入大厅成功:', {
+        hasLobby: !!newLobby,
+        lobbyName: newLobby?.name,
+        hasPassword: !!newLobby?.password,
+      });
 
       // 4. 更新前端状态
       const { setLobby } = useAppStore.getState();
@@ -1219,7 +1184,7 @@ export const MiniWindow: React.FC = () => {
         duration: 3,
       });
       
-      console.log('已复制大厅信息:', lobbyInfo);
+      console.log('已复制大厅信息');
     } catch (error) {
       console.error('复制大厅信息失败:', error);
       message.error(tl('复制失败，请重试', 'Copy failed, please retry'));

--- a/src/components/PublicPlaza/PublicPlaza.tsx
+++ b/src/components/PublicPlaza/PublicPlaza.tsx
@@ -15,7 +15,7 @@ const { Text } = Typography;
 interface PublicPlazaProps {
   visible: boolean;
   onClose: () => void;
-  /** 选择一个公开大厅加入（带出大厅名与密码） */
+  /** 选择一个无密码公开大厅直接加入。 */
   onJoin: (lobby: PublicLobby) => void;
   /** 可选自定义信令服务器 */
   signalingServer?: string;

--- a/src/components/RecentManager/RecentManager.tsx
+++ b/src/components/RecentManager/RecentManager.tsx
@@ -60,7 +60,7 @@ export const RecentManager: React.FC<RecentManagerProps> = ({ visible, onClose, 
       okButtonProps: { danger: true },
       centered: true,
       onOk: () => {
-        recentService.removeLobby(l.name, l.password);
+        recentService.removeLobby(l.name, l.lastJoined);
         refresh();
         message.success(tl('已移除', 'Removed'));
       },
@@ -75,7 +75,7 @@ export const RecentManager: React.FC<RecentManagerProps> = ({ visible, onClose, 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           {lobbies.map((l) => (
             <div
-              key={`${l.name}|${l.password}`}
+              key={`${l.name}|${l.lastJoined}`}
               className="recent-lobby-item"
               onClick={() => handleSelect(l)}
               style={{

--- a/src/components/ScreenViewer/ScreenViewer.tsx
+++ b/src/components/ScreenViewer/ScreenViewer.tsx
@@ -4,6 +4,7 @@ import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { useTranslation } from 'react-i18next';
 import { tl } from '../../i18n';
 import { screenShareService } from '../../services/screenShare/ScreenShareService';
+import { isSafeResourceId, sanitizeUntrustedText } from '../../security/trustBoundary';
 import './ScreenViewer.css';
 
 interface ScreenViewerProps {
@@ -16,10 +17,16 @@ export const ScreenViewer: React.FC<ScreenViewerProps> = ({ shareId, playerName 
   const videoRef = useRef<HTMLVideoElement>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const safeShareId = isSafeResourceId(shareId) ? shareId : '';
+  const safePlayerName = sanitizeUntrustedText(playerName, 64).trim() || tl('未知玩家', 'Unknown Player');
 
   useEffect(() => {
-    console.log('🎬 [ScreenViewer] 组件已挂载，shareId:', shareId);
-    
+    if (!safeShareId) {
+      setError(tl('屏幕共享标识无效', 'Invalid screen share identifier'));
+      setIsLoading(false);
+      return;
+    }
+
     let checkInterval: ReturnType<typeof setInterval> | undefined;
     let attempts = 0;
     const maxAttempts = 100; // 10秒超时
@@ -31,7 +38,7 @@ export const ScreenViewer: React.FC<ScreenViewerProps> = ({ shareId, playerName 
         console.log(`⏳ [ScreenViewer] 尝试从服务获取流... (${attempts}/${maxAttempts})`);
         
         // 从screenShareService获取流
-        const stream = screenShareService.getRemoteStream(shareId);
+        const stream = screenShareService.getRemoteStream(safeShareId);
         
         if (stream && stream.active) {
           console.log('✅ [ScreenViewer] 从服务获取到屏幕流');
@@ -85,7 +92,7 @@ export const ScreenViewer: React.FC<ScreenViewerProps> = ({ shareId, playerName 
         videoRef.current.srcObject = null;
       }
     };
-  }, [shareId]);
+  }, [safeShareId]);
 
   // 添加关闭窗口的处理
   const handleClose = async () => {
@@ -108,7 +115,7 @@ export const ScreenViewer: React.FC<ScreenViewerProps> = ({ shareId, playerName 
             <line x1="8" y1="21" x2="16" y2="21" />
             <line x1="12" y1="17" x2="12" y2="21" />
           </svg>
-          <span>{playerName} {tl('的屏幕', '\'s Screen')}</span>
+          <span>{safePlayerName} {tl('的屏幕', '\'s Screen')}</span>
         </div>
         
         <button className="close-viewer-btn" onClick={handleClose} title={tl('关闭', 'Close')}>
@@ -153,5 +160,4 @@ export const ScreenViewer: React.FC<ScreenViewerProps> = ({ shareId, playerName 
     </div>
   );
 };
-
 

--- a/src/components/SettingsAvatar/SettingsAvatarPicker.tsx
+++ b/src/components/SettingsAvatar/SettingsAvatarPicker.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { tl } from '../../i18n';
+import { isSafeImageDataUrl } from '../../security/trustBoundary';
 import './SettingsAvatarPicker.css';
 
 const MAX_SIZE = 256;
@@ -55,7 +56,7 @@ export const SettingsAvatarPicker: React.FC<SettingsAvatarPickerProps> = ({
   onError,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const hasAvatar = typeof avatarData === 'string' && avatarData.startsWith('data:image/');
+  const hasAvatar = isSafeImageDataUrl(avatarData);
 
   const chooseAvatar = () => inputRef.current?.click();
 

--- a/src/components/SettingsWindow/SettingsWindow.tsx
+++ b/src/components/SettingsWindow/SettingsWindow.tsx
@@ -93,7 +93,7 @@ export const SettingsWindow: React.FC<{ onClose: () => void }> = ({ onClose }) =
     try {
       console.log('开始加载设置...');
       const settings = await invoke<any>('get_settings');
-      console.log('设置加载成功:', settings);
+      console.log('设置加载成功');
       
       clearTimeout(timeoutId); // 清除超时定时器
       
@@ -337,7 +337,7 @@ export const SettingsWindow: React.FC<{ onClose: () => void }> = ({ onClose }) =
         exitNodes: merged.exitNodes?.trim() || null,
         subnetProxyCidrs: merged.subnetProxyCidrs?.trim() || null,
       });
-      console.log('设置已保存:', merged);
+      console.log('设置已保存');
       message.success(tl('已保存', 'Saved'), 1);
     } catch (e) {
       console.error('保存设置失败:', e);

--- a/src/components/VoiceSettings/VoiceSettings.tsx
+++ b/src/components/VoiceSettings/VoiceSettings.tsx
@@ -54,12 +54,7 @@ export const VoiceDevicePanel: React.FC<VoiceDevicePanelProps> = ({ active = tru
 
   const loadDevices = async () => {
     try {
-      // 触发一次权限请求，否则设备 label 为空
-      try {
-        const tmp = await navigator.mediaDevices.getUserMedia({ audio: true });
-        tmp.getTracks().forEach((t) => t.stop());
-      } catch { /* 用户可能拒绝，仍尝试枚举 */ }
-
+      // 仅枚举设备；麦克风权限只在用户明确点击「开始试音」时申请。
       const devices = await navigator.mediaDevices.enumerateDevices();
       const ins: DeviceOption[] = [{ value: '', label: tl('系统默认麦克风', 'System Default Microphone') }];
       const outs: DeviceOption[] = [{ value: '', label: tl('系统默认扬声器', 'System Default Speaker') }];

--- a/src/security/trustBoundary.ts
+++ b/src/security/trustBoundary.ts
@@ -1,0 +1,205 @@
+/**
+ * Frontend trust-boundary helpers.
+ *
+ * Values received from signaling, P2P chat, Tauri events, deep links, or
+ * persisted storage are data, not trusted application state. Keep the
+ * checks here dependency-free so they can also be covered by node tests.
+ */
+
+export const MAX_PLAYER_NAME_LENGTH = 64;
+export const MAX_CHAT_TEXT_LENGTH = 10_000;
+export const MAX_ANNOUNCEMENT_LENGTH = 200;
+export const MAX_TODO_ITEMS = 200;
+export const MAX_TODO_TEXT_LENGTH = 200;
+export const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+export const MAX_IMAGE_DATA_URL_LENGTH = 14 * 1024 * 1024;
+export const CHAT_TOKEN_LENGTH = 64;
+export const MAX_RESOURCE_ID_LENGTH = 128;
+export const MAX_SESSION_ID_LENGTH = 192;
+export const MAX_RELATIVE_PATH_LENGTH = 4096;
+export const MAX_PATH_SEGMENT_LENGTH = 255;
+
+const DISALLOWED_CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+const ENDPOINT_CONTROL_OR_SPACE = /[\u0000-\u0020\u007F]/;
+const IMAGE_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png|gif|webp);base64,[A-Za-z0-9+/]+={0,2}$/i;
+const CHAT_TOKEN_PATTERN = /^[A-Fa-f0-9]{64}$/;
+const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const SAFE_RESOURCE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const SERVER_NODE_PROTOCOLS = new Set(['tcp:', 'udp:', 'ws:', 'wss:', 'txt:']);
+
+export function sanitizeUntrustedText(value: unknown, maxLength: number): string {
+  if (typeof value !== 'string' || maxLength <= 0) return '';
+  return value.replace(DISALLOWED_CONTROL_CHARS, '').slice(0, maxLength);
+}
+
+export function sanitizeIdentifier(value: unknown, maxLength = 128): string {
+  return sanitizeUntrustedText(value, maxLength).trim();
+}
+
+/**
+ * IDs cross a trust boundary before they are used as map keys, URL path
+ * segments, or Tauri command arguments. Keep them to a small ASCII grammar
+ * so separators and control characters cannot change the resource being
+ * addressed. `sanitizeIdentifier` remains intentionally looser for display
+ * and diagnostics.
+ */
+export function isSafeIdentifier(value: unknown, maxLength = MAX_RESOURCE_ID_LENGTH): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= maxLength &&
+    SAFE_IDENTIFIER_PATTERN.test(value)
+  );
+}
+
+export function isSafeResourceId(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= MAX_RESOURCE_ID_LENGTH && SAFE_RESOURCE_ID_PATTERN.test(value);
+}
+
+export function isSafeSessionId(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= MAX_SESSION_ID_LENGTH && SAFE_IDENTIFIER_PATTERN.test(value);
+}
+
+export function isSafePathSegment(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= MAX_PATH_SEGMENT_LENGTH &&
+    value !== '.' &&
+    value !== '..' &&
+    !/[\\/\u0000-\u001F\u007F]/.test(value)
+  );
+}
+
+/** Empty string denotes the share root. All other paths are relative and
+ * contain only ordinary path segments; callers should still URL-encode each
+ * segment before placing it in an HTTP URL. */
+export function isSafeRelativePath(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length > MAX_RELATIVE_PATH_LENGTH) return false;
+  if (value === '') return true;
+  if (value.startsWith('/') || value.includes('\\') || /[\u0000-\u001F\u007F]/.test(value)) return false;
+  return value.split('/').every((segment) => isSafePathSegment(segment));
+}
+
+export function isSafeChatToken(value: unknown): value is string {
+  return typeof value === 'string' && value.length === CHAT_TOKEN_LENGTH && CHAT_TOKEN_PATTERN.test(value);
+}
+
+export function isSafeImageDataUrl(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length <= MAX_IMAGE_DATA_URL_LENGTH &&
+    IMAGE_DATA_URL_PATTERN.test(value)
+  );
+}
+
+export function sanitizeImageDataUrl(value: unknown): string | undefined {
+  return isSafeImageDataUrl(value) ? value : undefined;
+}
+
+function hasSafeEndpointCharacters(value: string): boolean {
+  return value.length > 0 && !ENDPOINT_CONTROL_OR_SPACE.test(value);
+}
+
+export function isSafeSignalingServer(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!hasSafeEndpointCharacters(trimmed)) return false;
+  try {
+    const parsed = new URL(trimmed);
+    return (
+      (parsed.protocol === 'ws:' || parsed.protocol === 'wss:') &&
+      parsed.hostname.length > 0 &&
+      !parsed.username &&
+      !parsed.password &&
+      !parsed.hash
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeServerNode(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (trimmed === 'custom') return true;
+  if (!hasSafeEndpointCharacters(trimmed)) return false;
+  try {
+    const parsed = new URL(trimmed);
+    return (
+      SERVER_NODE_PROTOCOLS.has(parsed.protocol) &&
+      parsed.hostname.length > 0 &&
+      !parsed.username &&
+      !parsed.password &&
+      !parsed.hash
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeHttpUrl(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!hasSafeEndpointCharacters(trimmed)) return false;
+  try {
+    const parsed = new URL(trimmed);
+    return (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+      parsed.hostname.length > 0 &&
+      !parsed.username &&
+      !parsed.password
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeVirtualIp(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const parts = value.trim().split('.');
+  if (
+    parts.length !== 4 ||
+    !parts.every((part) => /^(?:0|[1-9]\d{0,2})$/.test(part) && Number(part) >= 0 && Number(part) <= 255)
+  ) {
+    return false;
+  }
+  const [first, second, third, host] = parts.map(Number);
+  // MCTier uses EasyTier's fixed 10.126.126.0/24 overlay. Accepting an
+  // arbitrary self-reported unicast address would turn the native HTTP
+  // clients into an SSRF primitive against the user's physical LAN.
+  return first === 10 && second === 126 && third === 126 && host >= 1 && host <= 254;
+}
+
+export function isSafeVirtualDomain(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const domain = value.trim();
+  if (domain.length === 0 || domain.length > 253 || domain.includes('..')) return false;
+  return domain.split('.').every((label) =>
+    /^(?=.{1,63}$)[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(label),
+  );
+}
+
+export interface TrustedTodoItem {
+  id: string;
+  text: string;
+  done: boolean;
+  assignee: string;
+  creator: string;
+  ts: number;
+}
+
+export function sanitizeTodoItems(value: unknown): TrustedTodoItem[] {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, MAX_TODO_ITEMS).flatMap((candidate) => {
+    if (!candidate || typeof candidate !== 'object') return [];
+    const item = candidate as Record<string, unknown>;
+    const id = sanitizeIdentifier(item.id, 128);
+    const text = sanitizeUntrustedText(item.text, MAX_TODO_TEXT_LENGTH).trim();
+    const assignee = sanitizeUntrustedText(item.assignee, MAX_PLAYER_NAME_LENGTH).trim();
+    const creator = sanitizeUntrustedText(item.creator, MAX_PLAYER_NAME_LENGTH).trim();
+    const ts = typeof item.ts === 'number' && Number.isFinite(item.ts) ? item.ts : Date.now();
+    if (!id || !text || typeof item.done !== 'boolean') return [];
+    return [{ id, text, done: item.done, assignee, creator, ts }];
+  });
+}

--- a/src/services/chat/P2PChatService.ts
+++ b/src/services/chat/P2PChatService.ts
@@ -8,6 +8,19 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { ChatMessage } from '../../types';
 import { isWithinRecallWindow } from './recallPolicy';
+import {
+  isSafeChatToken,
+  isSafeVirtualIp,
+  MAX_ANNOUNCEMENT_LENGTH,
+  MAX_CHAT_TEXT_LENGTH,
+  MAX_IMAGE_BYTES,
+  MAX_TODO_ITEMS,
+  MAX_TODO_TEXT_LENGTH,
+  sanitizeIdentifier,
+  sanitizeImageDataUrl,
+  sanitizeTodoItems,
+  sanitizeUntrustedText,
+} from '../../security/trustBoundary';
 
 interface BackendChatMessage {
   id: string;
@@ -24,60 +37,61 @@ interface BackendChatMessage {
 const CHAT_SERVER_PORT = 14540;
 
 class P2PChatService {
-  private selfEventSource: EventSource | null = null; // 仅订阅“自己”的消息流
+  private selfStreamAbortController: AbortController | null = null;
   private selfReconnectTimer: number | null = null;
   private isListening: boolean = false;
   private onMessageCallback?: (message: ChatMessage) => void;
   private peerIps: string[] = [];
   private currentPlayerId: string = '';
   private myVirtualIp: string = ''; // 本机虚拟IP，用于连接本机聊天服务器
+  private chatToken: string = '';
   private seenMessageIds: Set<string> = new Set(); // 基于消息ID去重，避免重复回调
   private seenMessageOrder: string[] = []; // 维护去重集合的插入顺序，便于裁剪
   private pendingRecalls: Map<string, string> = new Map();
   private onAvatarCallback?: (playerId: string, avatarData?: string) => void;
 
-  /**
-   * 初始化服务
-   *
-   * `roster` 为大厅成员的 [playerId, virtualIp] 列表（含自己），下发给后端后，
-   * `/api/chat/send` 会校验消息里自称的 player_id 是否来自其登记的虚拟 IP，
-   * 避免同大厅成员伪造他人身份发言（含公告、撤回、头像等控制消息）。
-   */
-  initialize(
-    peerIps: string[],
-    currentPlayerId: string,
-    myVirtualIp: string,
-    roster?: Array<[string, string]>,
-    readers?: string[]
-  ): void {
-    // 更新玩家IPs和ID（发送消息时仍需要 peerIps）
-    this.peerIps = peerIps;
-    this.currentPlayerId = currentPlayerId;
-    this.myVirtualIp = myVirtualIp;
-
-    console.log('✅ [P2PChatService] 初始化完成');
-    console.log('  - 当前玩家ID:', currentPlayerId);
-    console.log('  - 自己的虚拟IP:', myVirtualIp);
-    console.log('  - 其他玩家IPs:', peerIps);
-
-    if (roster) {
-      void this.updatePeerRoster(roster, readers);
-    }
+  private isSafeImageBytes(value: unknown): value is number[] {
+    return (
+      Array.isArray(value) &&
+      value.length > 0 &&
+      value.length <= MAX_IMAGE_BYTES &&
+      value.every((byte) => Number.isInteger(byte) && byte >= 0 && byte <= 255)
+    );
   }
 
   /**
-   * 下发大厅身份名册，供后端校验聊天消息发送者身份
-   *
-   * `readers` 为允许读取本机聊天记录的成员IP（含本机，本机需自订阅 SSE 流）。
-   * 仅在所有成员虚拟IP均已就绪时传入；未就绪时省略，后端会放行以避免误拒
-   * IP 尚未同步的合法成员。
+   * 初始化服务
    */
-  async updatePeerRoster(roster: Array<[string, string]>, readers?: string[]): Promise<void> {
-    try {
-      await invoke('set_chat_peer_roster', { entries: roster, readers: readers ?? null });
-      console.log(`🪪 [P2PChatService] 已下发身份名册（${roster.length} 人）`);
-    } catch (error) {
-      console.warn('⚠️ [P2PChatService] 下发身份名册失败:', error);
+  initialize(peerIps: string[], currentPlayerId: string, myVirtualIp: string): void {
+    // 更新玩家IPs和ID（发送消息时仍需要 peerIps）
+    const localIp = isSafeVirtualIp(myVirtualIp) ? myVirtualIp.trim() : '';
+    this.peerIps = Array.from(new Set(
+      (Array.isArray(peerIps) ? peerIps : [])
+        .filter((ip): ip is string => isSafeVirtualIp(ip))
+        .map((ip) => ip.trim())
+        .filter((ip) => ip !== localIp),
+    ));
+    this.currentPlayerId = sanitizeIdentifier(currentPlayerId);
+    this.myVirtualIp = localIp;
+
+    console.log('✅ [P2PChatService] 初始化完成');
+  }
+
+  /**
+   * Set the per-lobby credential received from signaling. It is intentionally
+   * kept out of URLs and logs; the authenticated SSE stream sends it only as
+   * a request header.
+   */
+  setChatToken(token: unknown): void {
+    const nextToken = isSafeChatToken(token) ? token : '';
+    if (nextToken === this.chatToken) return;
+
+    const wasListening = this.isListening;
+    this.stopListening();
+    this.chatToken = nextToken;
+    if (wasListening && nextToken) {
+      this.isListening = true;
+      void this.connectToSelfStream();
     }
   }
   
@@ -89,14 +103,12 @@ class P2PChatService {
     this.peerIps = [];
     this.currentPlayerId = '';
     this.myVirtualIp = '';
+    this.chatToken = '';
     this.onMessageCallback = undefined;
     this.onAvatarCallback = undefined;
     this.seenMessageIds.clear();
     this.seenMessageOrder = [];
     this.pendingRecalls.clear();
-    void invoke('clear_chat_peer_roster').catch((error) => {
-      console.warn('⚠️ [P2PChatService] 清空身份名册失败:', error);
-    });
     console.log('🔄 [P2PChatService] 服务已重置');
   }
 
@@ -112,77 +124,89 @@ class P2PChatService {
   }
 
   startPolling(): void {
-    if (
-      this.isListening &&
-      this.selfEventSource &&
-      this.selfEventSource.readyState !== EventSource.CLOSED
-    ) {
-      return;
-    }
+    if (this.selfStreamAbortController) return;
     this.isListening = true;
-    this.connectToSelfStream();
+    void this.connectToSelfStream();
   }
 
   /**
    * 连接到本机聊天服务器的 SSE 流
    */
-  private connectToSelfStream(): void {
-    // 清理可能存在的旧连接
-    if (this.selfEventSource) {
-      try {
-        this.selfEventSource.close();
-      } catch {
-        // 忽略关闭异常
-      }
-      this.selfEventSource = null;
+  private async connectToSelfStream(): Promise<void> {
+    if (this.selfStreamAbortController || !this.isListening) return;
+    if (!this.myVirtualIp || !isSafeVirtualIp(this.myVirtualIp)) {
+      console.warn('⚠️ [P2PChatService] 虚拟IP未就绪，等待后续初始化');
+      return;
     }
-
-    if (!this.myVirtualIp) {
-      console.warn('⚠️ [P2PChatService] 虚拟IP未就绪，稍后重试连接本机消息流');
-      this.scheduleSelfReconnect();
+    // EventSource cannot set a custom header. Refuse an unauthenticated
+    // connection instead of falling back to a token-bearing query string.
+    if (!isSafeChatToken(this.chatToken)) {
+      console.warn('⚠️ [P2PChatService] 聊天认证令牌未就绪，等待信令下发');
       return;
     }
 
     const streamUrl = `http://${this.myVirtualIp}:${CHAT_SERVER_PORT}/api/chat/stream`;
-    console.log(`📡 [P2PChatService] 连接到本机消息流: ${streamUrl}`);
+    const controller = new AbortController();
+    this.selfStreamAbortController = controller;
+    console.log('📡 [P2PChatService] 连接到本机认证消息流');
 
     try {
-      const eventSource = new EventSource(streamUrl);
+      const response = await fetch(streamUrl, {
+        method: 'GET',
+        headers: {
+          Accept: 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'x-mctier-chat-token': this.chatToken,
+        },
+        cache: 'no-store',
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`聊天消息流返回 HTTP ${response.status}`);
+      }
+      if (!response.body) throw new Error('聊天消息流缺少响应体');
 
-      eventSource.onopen = () => {
-        console.log('✅ [P2PChatService] 本机消息流已连接');
-      };
-
-      eventSource.onmessage = (event) => {
-        // 跳过keep-alive消息
-        if (event.data === 'keep-alive') {
-          return;
-        }
-
-        try {
-          const message: BackendChatMessage = JSON.parse(event.data);
-          this.handleMessage(message);
-        } catch (error) {
-          console.error('❌ [P2PChatService] 解析消息失败:', error);
-        }
-      };
-
-      eventSource.onerror = (error) => {
-        console.warn('⚠️ [P2PChatService] 本机消息流连接错误，将重连', error);
-        try {
-          eventSource.close();
-        } catch {
-          // 忽略关闭异常
-        }
-        this.selfEventSource = null;
-        this.scheduleSelfReconnect();
-      };
-
-      this.selfEventSource = eventSource;
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      while (this.isListening && this.selfStreamAbortController === controller) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        buffer = this.consumeSseFrames(buffer);
+      }
+      buffer += decoder.decode();
+      this.consumeSseFrames(buffer);
     } catch (error) {
-      console.error('❌ [P2PChatService] 创建本机消息流连接失败:', error);
-      this.scheduleSelfReconnect();
+      if (!controller.signal.aborted && this.isListening) {
+        const detail = error instanceof Error ? error.message : '连接失败';
+        console.warn(`⚠️ [P2PChatService] 本机消息流连接错误，将重连: ${detail}`);
+      }
+    } finally {
+      if (this.selfStreamAbortController === controller) {
+        this.selfStreamAbortController = null;
+        if (this.isListening) this.scheduleSelfReconnect();
+      }
     }
+  }
+
+  private consumeSseFrames(buffer: string): string {
+    const frames = buffer.split(/\r?\n\r?\n/);
+    const remainder = frames.pop() ?? '';
+    for (const frame of frames) {
+      const data = frame
+        .split(/\r?\n/)
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.slice(5).replace(/^ /, ''))
+        .join('\n');
+      if (!data || data === 'keep-alive') continue;
+      try {
+        this.handleMessage(JSON.parse(data) as BackendChatMessage);
+      } catch (error) {
+        console.warn('⚠️ [P2PChatService] 忽略无效消息流帧:', error instanceof Error ? error.message : '解析失败');
+      }
+    }
+    return remainder;
   }
 
   /**
@@ -205,9 +229,34 @@ class P2PChatService {
    * 处理接收到的消息
    */
   private handleMessage(msg: BackendChatMessage): void {
+    if (!msg || typeof msg !== 'object') return;
+
+    const messageId = sanitizeIdentifier(msg.id);
+    const playerId = sanitizeIdentifier(msg.player_id);
+    const messageType = sanitizeIdentifier(msg.message_type, 32).toLowerCase();
+    const playerName = sanitizeUntrustedText(msg.player_name, 64).trim();
+    const contentLimit = messageType === 'todo' ? MAX_TODO_ITEMS * (MAX_TODO_TEXT_LENGTH + 128) : MAX_CHAT_TEXT_LENGTH;
+    const content = sanitizeUntrustedText(msg.content, contentLimit);
+    const timestamp = typeof msg.timestamp === 'number' ? msg.timestamp : Number.NaN;
+
+    if (!messageId || !playerId || !Number.isFinite(timestamp) || timestamp < 0) return;
+    if (!['text', 'image', 'announce', 'voicegroup', 'todo', 'recall', 'avatar'].includes(messageType)) return;
+    if (messageType !== 'announce' && messageType !== 'voicegroup' && messageType !== 'todo' && messageType !== 'recall' && messageType !== 'avatar' && !playerName) return;
+    if (messageType === 'image' && !this.isSafeImageBytes(msg.image_data)) return;
+
+    const safeMessage: BackendChatMessage = {
+      ...msg,
+      id: messageId,
+      player_id: playerId,
+      player_name: playerName,
+      content,
+      message_type: messageType,
+      timestamp,
+      image_data: messageType === 'image' ? msg.image_data : undefined,
+    };
 
     // 控制消息（公告 / 语音小队 / 待办）：不计入聊天，分发到状态后返回
-    const mtype = (msg as { message_type: string }).message_type;
+    const mtype = safeMessage.message_type;
     if (
       mtype === 'announce' ||
       mtype === 'voicegroup' ||
@@ -215,33 +264,33 @@ class P2PChatService {
       mtype === 'recall' ||
       mtype === 'avatar'
     ) {
-      if (msg.player_id === this.currentPlayerId) return;
+      if (safeMessage.player_id === this.currentPlayerId) return;
       // 按消息 ID 去重：避免对账/SSE 重复投递导致控制消息反复触发（如剪贴板反复弹窗、白板重复笔画）
-      if (this.seenMessageIds.has(msg.id)) return;
-      this.seenMessageIds.add(msg.id);
-      this.seenMessageOrder.push(msg.id);
+      if (this.seenMessageIds.has(safeMessage.id)) return;
+      this.seenMessageIds.add(safeMessage.id);
+      this.seenMessageOrder.push(safeMessage.id);
       if (this.seenMessageOrder.length > 1000) {
         const oldest = this.seenMessageOrder.shift();
         if (oldest) this.seenMessageIds.delete(oldest);
       }
-      void this.handleControlMessage(mtype, msg);
+      void this.handleControlMessage(mtype, safeMessage);
       return;
     }
 
     // 跳过自己发送的消息
-    if (msg.player_id === this.currentPlayerId) {
-      console.log('🚫 [P2PChatService] 跳过自己发送的消息:', msg.id);
+    if (safeMessage.player_id === this.currentPlayerId) {
+      console.log('🚫 [P2PChatService] 跳过自己发送的消息');
       return;
     }
 
     // 【修复】基于消息ID去重（每条消息ID唯一），避免重复回调；
     // 旧逻辑用“内容相同”去重，会误杀用户连续发送的相同文本（如连续两条“哈哈”）。
-    if (this.seenMessageIds.has(msg.id)) {
-      console.log('🚫 [P2PChatService] 跳过重复消息（ID相同）:', msg.id);
+    if (this.seenMessageIds.has(safeMessage.id)) {
+      console.log('🚫 [P2PChatService] 跳过重复消息（ID相同）');
       return;
     }
-    this.seenMessageIds.add(msg.id);
-    this.seenMessageOrder.push(msg.id);
+    this.seenMessageIds.add(safeMessage.id);
+    this.seenMessageOrder.push(safeMessage.id);
     // 限制去重集合大小，避免长时间运行内存增长
     if (this.seenMessageOrder.length > 1000) {
       const oldest = this.seenMessageOrder.shift();
@@ -250,24 +299,24 @@ class P2PChatService {
       }
     }
 
-    console.log('✅ [P2PChatService] 接收新消息:', `${msg.player_name}: ${msg.message_type === 'text' ? msg.content.substring(0, 20) + '...' : '[图片]'}`);
+    console.log('✅ [P2PChatService] 接收新消息:', safeMessage.message_type);
 
     // 转换为前端消息格式
     const chatMessage: ChatMessage = {
-      id: msg.id,
-      playerId: msg.player_id,
-      playerName: msg.player_name,
-      content: msg.content,
-      timestamp: msg.timestamp * 1000, // 转换为毫秒
-      type: msg.message_type === 'image' ? 'image' : 'text',
-      imageData: msg.image_data ? this.arrayToBase64(msg.image_data) : undefined,
+      id: safeMessage.id,
+      playerId: safeMessage.player_id,
+      playerName: safeMessage.player_name,
+      content: safeMessage.content,
+      timestamp: safeMessage.timestamp * 1000, // 转换为毫秒
+      type: safeMessage.message_type === 'image' ? 'image' : 'text',
+      imageData: safeMessage.image_data ? this.arrayToBase64(safeMessage.image_data) : undefined,
     };
-    if (this.pendingRecalls.get(msg.id) === msg.player_id && isWithinRecallWindow(chatMessage.timestamp)) {
+    if (this.pendingRecalls.get(safeMessage.id) === safeMessage.player_id && isWithinRecallWindow(chatMessage.timestamp)) {
       chatMessage.content = '';
       chatMessage.imageData = undefined;
       chatMessage.type = 'text';
       chatMessage.recalled = true;
-      this.pendingRecalls.delete(msg.id);
+      this.pendingRecalls.delete(safeMessage.id);
     }
 
     // 回调通知新消息
@@ -292,27 +341,32 @@ class P2PChatService {
       const { useAppStore } = await import('../../stores/appStore');
       const store = useAppStore.getState();
       if (type === 'announce') {
-        store.setAnnouncement(msg.content ?? '');
+        if (store.hostId && msg.player_id !== store.hostId) return;
+        store.setAnnouncement(sanitizeUntrustedText(msg.content, MAX_ANNOUNCEMENT_LENGTH).trim());
       } else if (type === 'voicegroup') {
-        const g = parseInt((msg.content ?? '0').trim(), 10);
-        store.setPlayerVoiceGroup(msg.player_id, Number.isFinite(g) ? g : 0);
+        const g = Number.parseInt((msg.content ?? '0').trim(), 10);
+        store.setPlayerVoiceGroup(msg.player_id, Number.isFinite(g) ? Math.max(0, Math.min(4, g)) : 0);
       } else if (type === 'todo') {
         // 多人协同待办：内容为待办列表 JSON，收到后覆盖本地（后写覆盖），实现全队同步
         try {
           const parsed = JSON.parse(msg.content ?? '[]');
-          if (Array.isArray(parsed)) {
-            store.setTodos(parsed);
+          if (Array.isArray(parsed) && parsed.length <= MAX_TODO_ITEMS) {
+            const safeTodos = sanitizeTodoItems(parsed);
+            if (safeTodos.length === parsed.length) store.setTodos(safeTodos);
           }
         } catch (e) {
           console.warn('⚠️ [P2PChatService] 解析待办同步内容失败:', e);
         }
       } else if (type === 'recall') {
-        const targetExists = store.chatMessages.some((message) => message.id === msg.content);
-        if (!store.recallChatMessage(msg.content, msg.player_id) && !targetExists) {
-          this.pendingRecalls.set(msg.content, msg.player_id);
+        const targetId = sanitizeIdentifier(msg.content);
+        if (!targetId) return;
+        const targetExists = store.chatMessages.some((message) => message.id === targetId);
+        if (!store.recallChatMessage(targetId, msg.player_id) && !targetExists) {
+          this.pendingRecalls.set(targetId, msg.player_id);
         }
       } else if (type === 'avatar') {
-        this.onAvatarCallback?.(msg.player_id, msg.content || undefined);
+        const avatarData = sanitizeImageDataUrl(msg.content);
+        if (avatarData) this.onAvatarCallback?.(msg.player_id, avatarData);
       }
     } catch (error) {
       console.warn('⚠️ [P2PChatService] 处理控制消息失败:', error);
@@ -383,13 +437,9 @@ class P2PChatService {
       clearTimeout(this.selfReconnectTimer);
       this.selfReconnectTimer = null;
     }
-    if (this.selfEventSource) {
-      try {
-        this.selfEventSource.close();
-      } catch {
-        // 忽略关闭异常
-      }
-      this.selfEventSource = null;
+    if (this.selfStreamAbortController) {
+      this.selfStreamAbortController.abort();
+      this.selfStreamAbortController = null;
       console.log('🛑 [P2PChatService] 已关闭本机消息流连接');
     }
   }
@@ -402,14 +452,19 @@ class P2PChatService {
       throw new Error('未初始化：缺少玩家ID');
     }
 
+    const safeContent = sanitizeUntrustedText(content, MAX_CHAT_TEXT_LENGTH);
+    const safeMessageId = messageId ? sanitizeIdentifier(messageId) : undefined;
+    if (!safeContent.trim()) throw new Error('消息内容不能为空');
+    if (messageId && !safeMessageId) throw new Error('消息ID无效');
+
     try {
       const res = await invoke<{ delivered: number; total: number }>('send_p2p_chat_message', {
         playerId: this.currentPlayerId,
         playerName: '', // 后端会自动填充
-        content,
+        content: safeContent,
         messageType: 'text',
         imageData: null,
-        messageId,
+        messageId: safeMessageId,
         peerIps: this.peerIps,
       });
       console.log('✅ [P2PChatService] 文本消息已发送', res);
@@ -429,13 +484,22 @@ class P2PChatService {
       throw new Error('未初始化：缺少玩家ID');
     }
 
+    const safeImageDataUrl = sanitizeImageDataUrl(imageDataUrl);
+    const safeContent = sanitizeUntrustedText(content, 256).trim() || '[图片]';
+    const safeMessageId = messageId ? sanitizeIdentifier(messageId) : undefined;
+    if (!safeImageDataUrl) throw new Error('图片数据格式无效');
+    if (messageId && !safeMessageId) throw new Error('消息ID无效');
+
     try {
       // 从Data URL中提取Base64数据
-      const base64Data = imageDataUrl.split(',')[1];
+      const base64Data = safeImageDataUrl.split(',')[1];
       
       // 【优化】使用Uint8Array直接转换，避免中间字符串
       const binaryString = atob(base64Data);
       const bytes = new Uint8Array(binaryString.length);
+      if (bytes.length === 0 || bytes.length > MAX_IMAGE_BYTES) {
+        throw new Error('图片大小超出限制');
+      }
       
       // 分块处理，提高性能
       const chunkSize = 8192;
@@ -451,10 +515,10 @@ class P2PChatService {
       await invoke('send_p2p_chat_message', {
         playerId: this.currentPlayerId,
         playerName: '', // 后端会自动填充
-        content,
+        content: safeContent,
         messageType: 'image',
         imageData: Array.from(bytes),
-        messageId,
+        messageId: safeMessageId,
         peerIps: this.peerIps,
       });
       
@@ -469,13 +533,15 @@ class P2PChatService {
   /** 广播撤回控制消息。接收方会校验撤回者是否为原发送者。 */
   async recallMessage(messageId: string): Promise<void> {
     if (!this.currentPlayerId) throw new Error('未初始化：缺少玩家ID');
+    const targetId = sanitizeIdentifier(messageId);
+    if (!targetId) throw new Error('消息ID无效');
     await invoke('send_p2p_chat_message', {
       playerId: this.currentPlayerId,
       playerName: '',
-      content: messageId,
+      content: targetId,
       messageType: 'recall',
       imageData: null,
-      messageId: 'recall-' + this.currentPlayerId + '-' + Date.now(),
+      messageId: `recall-${this.currentPlayerId}-${Date.now()}`,
       peerIps: this.peerIps,
     });
   }

--- a/src/services/fileShare/FileShareService.ts
+++ b/src/services/fileShare/FileShareService.ts
@@ -40,32 +40,6 @@ class FileShareService {
   }
 
   /**
-   * 下发允许访问共享的大厅成员虚拟IP（含自己）
-   *
-   * EasyTier 的网络名与密钥在大厅存续期间不变，被房主移出大厅的玩家仍可能
-   * 留在虚拟网内。后端据此拒绝非成员浏览共享列表、文件列表与下载。
-   */
-  async updateAllowedPeers(ips: string[]): Promise<void> {
-    try {
-      await invoke('set_share_allowed_peers', { ips });
-      console.log(`🪪 [FileShareService] 已下发可访问成员（${ips.length} 个）`);
-    } catch (error) {
-      console.warn('⚠️ [FileShareService] 下发可访问成员失败:', error);
-    }
-  }
-
-  /**
-   * 清空允许访问共享的成员列表（退出大厅时调用）
-   */
-  async clearAllowedPeers(): Promise<void> {
-    try {
-      await invoke('clear_share_allowed_peers');
-    } catch (error) {
-      console.warn('⚠️ [FileShareService] 清空可访问成员失败:', error);
-    }
-  }
-
-  /**
    * 添加共享文件夹
    */
   async addShare(share: SharedFolder): Promise<void> {

--- a/src/services/lobby/lobbyInvite.ts
+++ b/src/services/lobby/lobbyInvite.ts
@@ -1,3 +1,9 @@
+import {
+  isSafeServerNode,
+  isSafeSignalingServer,
+  sanitizeUntrustedText,
+} from '../../security/trustBoundary.ts';
+
 export interface LobbyInvite {
   name: string;
   password: string;
@@ -13,13 +19,13 @@ const cleanOptional = (value?: string | null): string | undefined => {
 export const buildLobbyInviteLink = (invite: LobbyInvite): string => {
   const params = new URLSearchParams({
     v: '2',
-    name: invite.name,
-    pwd: invite.password,
+    name: sanitizeUntrustedText(invite.name, 64),
+    pwd: sanitizeUntrustedText(invite.password, 128),
   });
   const serverNode = cleanOptional(invite.serverNode);
   const signalingServer = cleanOptional(invite.signalingServer);
-  if (serverNode) params.set('node', serverNode);
-  if (signalingServer) params.set('signal', signalingServer);
+  if (serverNode && isSafeServerNode(serverNode) && serverNode !== 'custom') params.set('node', serverNode);
+  if (signalingServer && isSafeSignalingServer(signalingServer)) params.set('signal', signalingServer);
   return `mctier://join?${params.toString()}`;
 };
 
@@ -28,14 +34,21 @@ export const parseLobbyInviteLink = (raw: string): LobbyInvite | null => {
   if (!match) return null;
 
   const params = new URLSearchParams(match[1]);
-  const name = params.get('name')?.trim() || '';
+  const name = sanitizeUntrustedText(params.get('name'), 64).trim();
   if (!name) return null;
+
+  const rawServerNode = cleanOptional(params.get('node'));
+  const rawSignalingServer = cleanOptional(params.get('signal'));
+  // Deep links can arrive from another application. Reject an invite rather
+  // than allowing an unvalidated endpoint to reach the join command.
+  if (rawServerNode && !isSafeServerNode(rawServerNode)) return null;
+  if (rawSignalingServer && !isSafeSignalingServer(rawSignalingServer)) return null;
 
   return {
     name,
-    password: params.get('pwd') || '',
-    serverNode: cleanOptional(params.get('node')),
-    signalingServer: cleanOptional(params.get('signal')),
+    password: sanitizeUntrustedText(params.get('pwd'), 128),
+    serverNode: rawServerNode,
+    signalingServer: rawSignalingServer,
   };
 };
 
@@ -55,31 +68,44 @@ export const parseLobbyInviteText = (text: string): LobbyInvite | null => {
 
   const name = extractField(text, ['大厅名称', 'Lobby Name']);
   if (name) {
+    const serverNode = cleanOptional(extractField(text, ['服务器节点', 'Server Node']));
+    const signalingServer = cleanOptional(extractField(text, ['信令服务器', 'Signaling Server']));
+    if (serverNode && !isSafeServerNode(serverNode)) return null;
+    if (signalingServer && !isSafeSignalingServer(signalingServer)) return null;
     return {
-      name,
-      password: extractField(text, ['密码', 'Password'], true) || '',
-      serverNode: extractField(text, ['服务器节点', 'Server Node']),
-      signalingServer: extractField(text, ['信令服务器', 'Signaling Server']),
+      name: sanitizeUntrustedText(name, 64),
+      password: sanitizeUntrustedText(extractField(text, ['密码', 'Password'], true), 128),
+      serverNode,
+      signalingServer,
     };
   }
 
   const legacyParts = text.trim().split('|');
   if (legacyParts.length === 2 && legacyParts[0].trim()) {
-    return { name: legacyParts[0].trim(), password: legacyParts[1].trim() };
+    return {
+      name: sanitizeUntrustedText(legacyParts[0], 64).trim(),
+      password: sanitizeUntrustedText(legacyParts[1], 128).trim(),
+    };
   }
   return null;
 };
 
 export const formatLobbyInviteText = (invite: LobbyInvite, language: 'zh' | 'en'): string => {
   const link = buildLobbyInviteLink(invite);
+  const serverNode = cleanOptional(invite.serverNode);
+  const signalingServer = cleanOptional(invite.signalingServer);
+  const safeServerNode = serverNode && isSafeServerNode(serverNode) ? serverNode : undefined;
+  const safeSignalingServer = signalingServer && isSafeSignalingServer(signalingServer) ? signalingServer : undefined;
+  const name = sanitizeUntrustedText(invite.name, 64);
+  const password = sanitizeUntrustedText(invite.password, 128);
   if (language === 'en') {
     return [
       '——————— Invitation to Join Lobby ———————',
       'Copy everything, then open MCTier - Join Lobby (auto-detected)',
-      `Lobby Name: ${invite.name}`,
-      `Password: ${invite.password}`,
-      ...(invite.serverNode ? [`Server Node: ${invite.serverNode}`] : []),
-      ...(invite.signalingServer ? [`Signaling Server: ${invite.signalingServer}`] : []),
+      `Lobby Name: ${name}`,
+      `Password: ${password}`,
+      ...(safeServerNode ? [`Server Node: ${safeServerNode}`] : []),
+      ...(safeSignalingServer ? [`Signaling Server: ${safeSignalingServer}`] : []),
       `Invite Link: ${link}`,
       '————— https://mctier.pmhs.top —————',
     ].join('\n');
@@ -88,10 +114,10 @@ export const formatLobbyInviteText = (invite: LobbyInvite, language: 'zh' | 'en'
   return [
     '——————— 邀请您加入大厅 ———————',
     '完整复制后打开 MCTier-加入大厅 界面（自动识别）',
-    `大厅名称：${invite.name}`,
-    `密码：${invite.password}`,
-    ...(invite.serverNode ? [`服务器节点：${invite.serverNode}`] : []),
-    ...(invite.signalingServer ? [`信令服务器：${invite.signalingServer}`] : []),
+    `大厅名称：${name}`,
+    `密码：${password}`,
+    ...(safeServerNode ? [`服务器节点：${safeServerNode}`] : []),
+    ...(safeSignalingServer ? [`信令服务器：${safeSignalingServer}`] : []),
     `邀请链接：${link}`,
     '————— https://mctier.pmhs.top —————',
   ].join('\n');

--- a/src/services/lobby/publicLobbies.ts
+++ b/src/services/lobby/publicLobbies.ts
@@ -4,14 +4,19 @@
  * - 不依赖已加入的大厅会话，可在大厅外（主界面/加入表单）直接调用
  */
 
+import {
+  isSafeServerNode,
+  isSafeSignalingServer,
+  sanitizeUntrustedText,
+} from '../../security/trustBoundary';
+
 export interface PublicLobby {
   lobbyName: string;
   playerCount: number;
   maxPlayers?: number | null;
   hostName: string;
   description: string;
-  /** 加入用的明文密码（公开大厅由房主主动公开） */
-  password: string;
+  /** Public lobbies are passwordless; the listing never carries a password. */
   /** 房主使用的 EasyTier 节点地址，加入时自动同步（空=未知，回退加入者默认节点） */
   serverNode?: string;
 }
@@ -24,7 +29,10 @@ const DEFAULT_SIGNALING = 'wss://mctier.pmhs.top/signaling';
  * @param timeoutMs 超时时间（毫秒）
  */
 export function fetchPublicLobbies(signalingServer?: string, timeoutMs = 8000): Promise<PublicLobby[]> {
-  const url = signalingServer || DEFAULT_SIGNALING;
+  const url = signalingServer?.trim() || DEFAULT_SIGNALING;
+  if (!isSafeSignalingServer(url)) {
+    return Promise.reject(new Error('信令服务器地址无效'));
+  }
   return new Promise((resolve, reject) => {
     let settled = false;
     let ws: WebSocket;
@@ -69,11 +77,32 @@ export function fetchPublicLobbies(signalingServer?: string, timeoutMs = 8000): 
             window.clearTimeout(timer);
             cleanup();
             const lobbies = Array.isArray(msg.lobbies) ? msg.lobbies : [];
-            resolve(lobbies.map((lobby: any) => ({
-              ...lobby,
-              description: String(lobby.description ?? lobby.desc ?? ''),
-              serverNode: lobby.serverNode ? String(lobby.serverNode) : undefined,
-            })));
+            resolve(lobbies.flatMap((lobby: unknown) => {
+              if (!lobby || typeof lobby !== 'object') return [];
+              const item = lobby as Record<string, unknown>;
+              const lobbyName = sanitizeUntrustedText(item.lobbyName, 64).trim();
+              const hostName = sanitizeUntrustedText(item.hostName, 64).trim();
+              if (!lobbyName || !hostName) return [];
+
+              const playerCount = typeof item.playerCount === 'number' && Number.isFinite(item.playerCount)
+                ? Math.max(0, Math.min(100_000, Math.floor(item.playerCount)))
+                : 0;
+              const maxPlayers = typeof item.maxPlayers === 'number' && Number.isFinite(item.maxPlayers)
+                ? Math.max(1, Math.min(100_000, Math.floor(item.maxPlayers)))
+                : null;
+              const rawServerNode = typeof item.serverNode === 'string' ? item.serverNode.trim() : '';
+
+              return [{
+                lobbyName,
+                hostName,
+                playerCount,
+                maxPlayers,
+                description: sanitizeUntrustedText(item.description ?? item.desc, 200).trim(),
+                serverNode: rawServerNode && isSafeServerNode(rawServerNode) && rawServerNode !== 'custom'
+                  ? rawServerNode
+                  : undefined,
+              }];
+            }));
           }
         }
       } catch {

--- a/src/services/recent/recentService.ts
+++ b/src/services/recent/recentService.ts
@@ -4,9 +4,12 @@
  * - 记录最近一起联机过的玩家
  */
 
+import { isSafeServerNode, isSafeSignalingServer, sanitizeUntrustedText } from '../../security/trustBoundary';
+
 export interface RecentLobby {
   name: string;
-  password: string;
+  /** Passwords are intentionally never persisted. A selected record requires re-entry. */
+  password?: string;
   playerName?: string;
   useDomain?: boolean;
   serverNode?: string;
@@ -45,27 +48,103 @@ function writeJson<T>(key: string, value: T[]): void {
   }
 }
 
+function normalizeRecentLobby(value: unknown): RecentLobby | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const item = value as Record<string, unknown>;
+  const name = sanitizeUntrustedText(item.name, 64).trim();
+  const lastJoined = typeof item.lastJoined === 'number' && Number.isFinite(item.lastJoined)
+    ? Math.max(0, Math.min(Number.MAX_SAFE_INTEGER, Math.trunc(item.lastJoined)))
+    : 0;
+  if (!name || !lastJoined) return null;
+  const playerName = sanitizeUntrustedText(item.playerName, 64).trim();
+  const serverNode = typeof item.serverNode === 'string' && isSafeServerNode(item.serverNode) && item.serverNode !== 'custom'
+    ? item.serverNode.trim()
+    : undefined;
+  const signalingServer = typeof item.signalingServer === 'string' && isSafeSignalingServer(item.signalingServer)
+    ? item.signalingServer.trim()
+    : undefined;
+  return {
+    name,
+    ...(playerName ? { playerName } : {}),
+    ...(item.useDomain === true ? { useDomain: true } : {}),
+    ...(serverNode ? { serverNode } : {}),
+    ...(signalingServer ? { signalingServer } : {}),
+    lastJoined,
+  };
+}
+
+function readRecentLobbies(): RecentLobby[] {
+  return readJson<unknown>(LOBBIES_KEY).flatMap((item) => {
+    const lobby = normalizeRecentLobby(item);
+    return lobby ? [lobby] : [];
+  });
+}
+
+function writeRecentLobbies(value: RecentLobby[]): void {
+  // Explicitly rebuild each object so legacy `password` properties cannot be
+  // copied back into localStorage during migration.
+  writeJson(LOBBIES_KEY, value.map(({ password: _password, ...lobby }) => lobby));
+}
+
+function normalizeRecentPlayers(value: unknown): RecentPlayer[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((candidate) => {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return [];
+    const item = candidate as Record<string, unknown>;
+    const name = sanitizeUntrustedText(item.name, 64).trim();
+    const lastSeen = typeof item.lastSeen === 'number' && Number.isFinite(item.lastSeen)
+      ? Math.max(0, Math.min(Number.MAX_SAFE_INTEGER, Math.trunc(item.lastSeen)))
+      : 0;
+    const count = typeof item.count === 'number' && Number.isFinite(item.count)
+      ? Math.max(0, Math.min(1_000_000, Math.trunc(item.count)))
+      : 0;
+    return name && lastSeen ? [{ name, lastSeen, count }] : [];
+  });
+}
+
 export const recentService = {
   /** 记录一次成功进入的大厅 */
   recordLobby(lobby: Omit<RecentLobby, 'lastJoined'>): void {
-    if (!lobby.name) return;
-    let list = readJson<RecentLobby>(LOBBIES_KEY);
-    // 以"大厅名+密码"去重，保留最新
-    list = list.filter(l => !(l.name === lobby.name && l.password === lobby.password));
-    list.unshift({ ...lobby, lastJoined: Date.now() });
+    const name = sanitizeUntrustedText(lobby.name, 64).trim();
+    if (!name) return;
+    let list = readRecentLobbies();
+    // Passwords are not a stable local identifier and must never be written.
+    list = list.filter((item) => !(
+      item.name === name &&
+      item.serverNode === lobby.serverNode &&
+      item.signalingServer === lobby.signalingServer
+    ));
+    const playerName = sanitizeUntrustedText(lobby.playerName, 64).trim();
+    const serverNode = typeof lobby.serverNode === 'string' && isSafeServerNode(lobby.serverNode) && lobby.serverNode !== 'custom'
+      ? lobby.serverNode.trim()
+      : undefined;
+    const signalingServer = typeof lobby.signalingServer === 'string' && isSafeSignalingServer(lobby.signalingServer)
+      ? lobby.signalingServer.trim()
+      : undefined;
+    list.unshift({
+      name,
+      ...(playerName ? { playerName } : {}),
+      ...(lobby.useDomain === true ? { useDomain: true } : {}),
+      ...(serverNode ? { serverNode } : {}),
+      ...(signalingServer ? { signalingServer } : {}),
+      lastJoined: Date.now(),
+    });
     if (list.length > MAX_LOBBIES) list = list.slice(0, MAX_LOBBIES);
-    writeJson(LOBBIES_KEY, list);
+    writeRecentLobbies(list);
   },
 
   getRecentLobbies(): RecentLobby[] {
-    return readJson<RecentLobby>(LOBBIES_KEY).sort((a, b) => b.lastJoined - a.lastJoined);
+    const list = readRecentLobbies().sort((a, b) => b.lastJoined - a.lastJoined);
+    writeRecentLobbies(list.slice(0, MAX_LOBBIES));
+    return list;
   },
 
-  removeLobby(name: string, password: string): void {
-    const list = readJson<RecentLobby>(LOBBIES_KEY).filter(
-      l => !(l.name === name && l.password === password)
+  removeLobby(name: string, lastJoined?: number): void {
+    const safeName = sanitizeUntrustedText(name, 64).trim();
+    const list = readRecentLobbies().filter((lobby) =>
+      !(lobby.name === safeName && (lastJoined === undefined || lobby.lastJoined === lastJoined))
     );
-    writeJson(LOBBIES_KEY, list);
+    writeRecentLobbies(list);
   },
 
   clearLobbies(): void {
@@ -75,26 +154,31 @@ export const recentService = {
   /** 记录一起联机过的玩家（传入当前大厅其他玩家名） */
   recordPlayers(names: string[]): void {
     if (!names || names.length === 0) return;
-    const list = readJson<RecentPlayer>(PLAYERS_KEY);
+    const list = normalizeRecentPlayers(readJson<unknown>(PLAYERS_KEY));
     const map = new Map<string, RecentPlayer>();
     list.forEach(p => map.set(p.name, p));
     const now = Date.now();
-    names.filter(Boolean).forEach(name => {
-      const existing = map.get(name);
-      if (existing) {
-        existing.lastSeen = now;
-        existing.count += 1;
-      } else {
-        map.set(name, { name, lastSeen: now, count: 1 });
-      }
-    });
+    names
+      .map((name) => sanitizeUntrustedText(name, 64).trim())
+      .filter(Boolean)
+      .forEach(name => {
+        const existing = map.get(name);
+        if (existing) {
+          existing.lastSeen = now;
+          existing.count += 1;
+        } else {
+          map.set(name, { name, lastSeen: now, count: 1 });
+        }
+      });
     let merged = Array.from(map.values()).sort((a, b) => b.lastSeen - a.lastSeen);
     if (merged.length > MAX_PLAYERS) merged = merged.slice(0, MAX_PLAYERS);
     writeJson(PLAYERS_KEY, merged);
   },
 
   getRecentPlayers(): RecentPlayer[] {
-    return readJson<RecentPlayer>(PLAYERS_KEY).sort((a, b) => b.lastSeen - a.lastSeen);
+    const list = normalizeRecentPlayers(readJson<unknown>(PLAYERS_KEY)).sort((a, b) => b.lastSeen - a.lastSeen);
+    writeJson(PLAYERS_KEY, list.slice(0, MAX_PLAYERS));
+    return list;
   },
 
   clearPlayers(): void {
@@ -104,20 +188,28 @@ export const recentService = {
   // ==================== 收藏队友 ====================
   /** 获取收藏的队友名字列表 */
   getFavoritePlayers(): string[] {
-    return readJson<string>(FAV_PLAYERS_KEY);
+    const list = readJson<unknown>(FAV_PLAYERS_KEY)
+      .map((name) => sanitizeUntrustedText(name, 64).trim())
+      .filter(Boolean)
+      .slice(0, MAX_PLAYERS);
+    const unique = Array.from(new Set(list));
+    writeJson(FAV_PLAYERS_KEY, unique);
+    return unique;
   },
 
   isFavoritePlayer(name: string): boolean {
-    return readJson<string>(FAV_PLAYERS_KEY).includes(name);
+    const safeName = sanitizeUntrustedText(name, 64).trim();
+    return !!safeName && this.getFavoritePlayers().includes(safeName);
   },
 
   /** 切换收藏/取消收藏某队友，返回切换后的是否已收藏 */
   toggleFavoritePlayer(name: string): boolean {
-    if (!name) return false;
-    let list = readJson<string>(FAV_PLAYERS_KEY);
+    const safeName = sanitizeUntrustedText(name, 64).trim();
+    if (!safeName) return false;
+    let list = this.getFavoritePlayers();
     let fav: boolean;
-    if (list.includes(name)) { list = list.filter(n => n !== name); fav = false; }
-    else { list = [...list, name]; fav = true; }
+    if (list.includes(safeName)) { list = list.filter(n => n !== safeName); fav = false; }
+    else { list = [...list, safeName].slice(0, MAX_PLAYERS); fav = true; }
     writeJson(FAV_PLAYERS_KEY, list);
     return fav;
   },

--- a/src/services/remoteControl/RemoteControlService.ts
+++ b/src/services/remoteControl/RemoteControlService.ts
@@ -8,6 +8,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import { isSafeIdentifier, isSafeSessionId, sanitizeUntrustedText } from '../../security/trustBoundary';
 
 export type RemoteInputEvent =
   | { kind: 'move'; x: number; y: number }
@@ -68,6 +69,11 @@ class RemoteControlService {
     return this.peerName;
   }
 
+  /** Whether a signaling message belongs to the currently negotiated peer session. */
+  isSessionForPeer(sessionId: string, peerId: string): boolean {
+    return this.role !== 'idle' && this.sessionId === sessionId && this.peerId === peerId;
+  }
+
   private send(message: any): void {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(message));
@@ -97,14 +103,16 @@ class RemoteControlService {
     if (this.role !== 'idle') {
       throw new Error('已有进行中的远程控制会话');
     }
-    if (!targetId || targetId === this.playerId) {
-      throw new Error('无效的远程控制目标');
+    if (!isSafeIdentifier(targetId) || targetId === this.playerId) {
+      throw new Error('远程控制目标无效');
     }
+    const safeTargetName = sanitizeUntrustedText(targetName, 64).trim();
+    if (!safeTargetName) throw new Error('远程控制目标名称无效');
     const nextSessionId = this.createSessionId();
     this.role = 'controller';
     this.sessionId = nextSessionId;
     this.peerId = targetId;
-    this.peerName = targetName;
+    this.peerName = safeTargetName;
     this.send({
       type: 'remote-control-request',
       from: this.playerId,
@@ -128,6 +136,11 @@ class RemoteControlService {
 
   // ==================== 被控端：接受/拒绝 ====================
   async acceptControl(sessionId: string, controllerId: string, controllerName: string): Promise<void> {
+    if (!isSafeSessionId(sessionId) || !isSafeIdentifier(controllerId) || controllerId === this.playerId) {
+      throw new Error('远程控制会话无效');
+    }
+    const safeControllerName = sanitizeUntrustedText(controllerName, 64).trim();
+    if (!safeControllerName) throw new Error('远程控制者名称无效');
     const pending = this.pendingRequest;
     if (!pending || pending.sessionId !== sessionId || pending.from !== controllerId || this.role !== 'idle') {
       throw new Error('远程控制请求已失效');
@@ -135,7 +148,7 @@ class RemoteControlService {
     this.role = 'controlled';
     this.sessionId = sessionId;
     this.peerId = controllerId;
-    this.peerName = controllerName;
+    this.peerName = safeControllerName;
     this.pendingRequest = null;
     try {
       // 在用户手势内采集屏幕（getDisplayMedia 需要用户激活）。
@@ -186,6 +199,7 @@ class RemoteControlService {
   }
 
   rejectControl(sessionId: string, controllerId: string): void {
+    if (!isSafeSessionId(sessionId) || !isSafeIdentifier(controllerId) || controllerId === this.playerId) return;
     const pending = this.pendingRequest;
     if (!pending || pending.sessionId !== sessionId || pending.from !== controllerId) return;
     this.send({
@@ -252,7 +266,9 @@ class RemoteControlService {
 
   /** 被控端收到控制请求 */
   handleRequest(sessionId: string, from: string, fromName: string, to: string): void {
-    if (!sessionId || !from || from === this.playerId || to !== this.playerId) return;
+    if (!isSafeSessionId(sessionId) || !isSafeIdentifier(from) || from === this.playerId || to !== this.playerId) return;
+    const safeFromName = sanitizeUntrustedText(fromName, 64).trim();
+    if (!safeFromName) return;
     if (this.role !== 'idle') {
       // 忙：自动拒绝
       this.send({ type: 'remote-control-reject', from: this.playerId, to: from, sessionId, reason: 'busy' });
@@ -262,12 +278,13 @@ class RemoteControlService {
       this.send({ type: 'remote-control-reject', from: this.playerId, to: from, sessionId, reason: 'busy' });
       return;
     }
-    this.pendingRequest = { sessionId, from, fromName };
-    window.dispatchEvent(new CustomEvent('rc-incoming-request', { detail: { sessionId, from, fromName } }));
+    this.pendingRequest = { sessionId, from, fromName: safeFromName };
+    window.dispatchEvent(new CustomEvent('rc-incoming-request', { detail: { sessionId, from, fromName: safeFromName } }));
   }
 
   /** 控制端收到被控端接受 -> 建立连接并发 offer */
   async handleAccept(sessionId: string, from: string, to: string): Promise<void> {
+    if (!isSafeSessionId(sessionId) || !isSafeIdentifier(from) || from === this.playerId || to !== this.playerId) return;
     if (this.role !== 'controller' || !this.isCurrentPeerMessage(sessionId, from, to) || this.pc) return;
     const expectedSessionId = sessionId;
     const expectedPeerId = from;
@@ -317,7 +334,9 @@ class RemoteControlService {
 
   /** 被控端收到 offer -> 加屏幕轨、建数据通道、应答 */
   async handleOffer(sessionId: string, from: string, to: string, sdp: string): Promise<void> {
-    if (this.role !== 'controlled' || !this.isCurrentPeerMessage(sessionId, from, to) || this.pc) return;
+    if (!isSafeSessionId(sessionId) || !isSafeIdentifier(from) || from === this.playerId || to !== this.playerId ||
+        typeof sdp !== 'string' || sdp.length === 0 || sdp.length > 256 * 1024 ||
+        this.role !== 'controlled' || !this.isCurrentPeerMessage(sessionId, from, to) || this.pc) return;
     const expectedSessionId = sessionId;
     const expectedPeerId = from;
     try {
@@ -382,7 +401,9 @@ class RemoteControlService {
 
   /** 控制端收到 answer */
   async handleAnswer(sessionId: string, from: string, to: string, sdp: string): Promise<void> {
-    if (this.role !== 'controller' || !this.isCurrentPeerMessage(sessionId, from, to) || !this.pc) return;
+    if (!isSafeSessionId(sessionId) || !isSafeIdentifier(from) || from === this.playerId || to !== this.playerId ||
+        typeof sdp !== 'string' || sdp.length === 0 || sdp.length > 256 * 1024 ||
+        this.role !== 'controller' || !this.isCurrentPeerMessage(sessionId, from, to) || !this.pc) return;
     const pc = this.pc;
     if (pc.signalingState !== 'have-local-offer' || !this.isCurrentPeerSession(sessionId, from, pc)) return;
     try {
@@ -397,7 +418,15 @@ class RemoteControlService {
 
   /** 双方：收到对端 ICE */
   async handleIce(sessionId: string, from: string, to: string, candidate: RTCIceCandidateInit): Promise<void> {
-    if (!this.isCurrentPeerMessage(sessionId, from, to)) return;
+    if (!isSafeSessionId(sessionId) || !isSafeIdentifier(from) || from === this.playerId || to !== this.playerId ||
+        !candidate || typeof candidate.candidate !== 'string' || candidate.candidate.length === 0 ||
+        candidate.candidate.length > 16 * 1024 ||
+        (candidate.sdpMLineIndex != null &&
+          (typeof candidate.sdpMLineIndex !== 'number' || !Number.isSafeInteger(candidate.sdpMLineIndex) ||
+            candidate.sdpMLineIndex < 0 || candidate.sdpMLineIndex > 256)) ||
+        (candidate.sdpMid != null && (typeof candidate.sdpMid !== 'string' || candidate.sdpMid.length > 128)) ||
+        !this.isCurrentPeerMessage(sessionId, from, to)) return;
+    if (this.pendingIce.length >= 256) return;
     const pc = this.pc;
     if (!pc || !pc.remoteDescription) {
       this.pendingIce.push({ sessionId, peerId: from, candidate });
@@ -418,12 +447,15 @@ class RemoteControlService {
   }
 
   handleReject(sessionId: string, from: string, to: string, reason: string): void {
-    if (this.role !== 'controller' || !this.isCurrentPeerMessage(sessionId, from, to)) return;
-    this.finishReject(reason);
+    if (!isSafeSessionId(sessionId) || !isSafeIdentifier(from) || from === this.playerId || to !== this.playerId ||
+        this.role !== 'controller' || !this.isCurrentPeerMessage(sessionId, from, to)) return;
+    const safeReason = sanitizeUntrustedText(reason, 200).trim();
+    this.finishReject(safeReason || 'rejected');
   }
 
   /** 对端停止 */
   handleStop(sessionId: string, from: string, to: string): void {
+    if (!isSafeSessionId(sessionId) || !isSafeIdentifier(from) || from === this.playerId || to !== this.playerId) return;
     if (this.role === 'idle') {
       const pending = this.pendingRequest;
       if (pending && pending.sessionId === sessionId && pending.from === from && to === this.playerId) {

--- a/src/services/screenShare/ScreenShareService.ts
+++ b/src/services/screenShare/ScreenShareService.ts
@@ -1147,7 +1147,13 @@ class ScreenShareService {
    */
   async handleOffer(offer: ScreenShareOffer): Promise<void> {
     try {
-      console.log('📨 [ScreenShareService] 收到查看请求:', offer);
+      console.log('📨 [ScreenShareService] 收到查看请求:', {
+        shareId: offer.shareId,
+        playerId: offer.playerId,
+        routeVersion: offer.routeVersion,
+        hasPassword: !!offer.password,
+        hasSdp: !!offer.sdp,
+      });
       const share = this.activeShares.get(offer.shareId);
       if (!share) {
         console.error('❌ [ScreenShareService] 找不到对应的共享');

--- a/src/services/version/VersionCheckService.ts
+++ b/src/services/version/VersionCheckService.ts
@@ -3,20 +3,14 @@
  * 从 Gitee API 获取最新版本信息并与当前版本对比
  */
 
-import { compareVersions, newestVersionTag } from './versionPolicy';
+import { compareVersions, isReleaseVersion, newestVersionTag, normalizeReleaseVersion } from './versionPolicy';
 import { getVersion } from '@tauri-apps/api/app';
 
 interface GiteeTag {
   name: string;
-  message: string;
+  message?: string;
   commit: {
     sha: string;
-    date: string;
-  };
-  tagger: {
-    name: string;
-    email: string;
-    date: string;
   };
 }
 
@@ -27,8 +21,64 @@ interface VersionInfo {
   updateMessage?: string;
 }
 
+const MAX_VERSION_RESPONSE_BYTES = 256 * 1024;
+const MAX_TAGS = 100;
+const MAX_RELEASE_NOTES_BYTES = 8 * 1024;
+const MAX_RELEASE_NOTE_LINES = 64;
+const MAX_RELEASE_NOTE_LINE_LENGTH = 512;
+const VERSION_CHECK_TIMEOUT_MS = 10_000;
+
+function isTrustedGiteeTag(value: unknown): value is GiteeTag {
+  if (!value || typeof value !== 'object') return false;
+  const tag = value as Partial<GiteeTag>;
+  return (
+    isReleaseVersion(tag.name) &&
+    typeof tag.commit?.sha === 'string' &&
+    /^[0-9a-f]{40}$/i.test(tag.commit.sha) &&
+    (tag.message === undefined || (typeof tag.message === 'string' && new TextEncoder().encode(tag.message).length <= MAX_RELEASE_NOTES_BYTES))
+  );
+}
+
+async function readLimitedResponse(response: Response, maxBytes: number): Promise<string> {
+  const contentLength = response.headers.get('content-length');
+  if (contentLength !== null) {
+    if (!/^\d+$/.test(contentLength)) throw new Error('版本响应长度无效');
+    const declaredLength = Number(contentLength);
+    if (!Number.isSafeInteger(declaredLength) || declaredLength > maxBytes) {
+      throw new Error('版本响应过大');
+    }
+  }
+
+  if (!response.body) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).length > maxBytes) throw new Error('版本响应过大');
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let totalBytes = 0;
+  let text = '';
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel();
+        throw new Error('版本响应过大');
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
 class VersionCheckService {
-  private readonly GITEE_API_URL = 'https://gitee.com/api/v5/repos/peng-minghang/mctier/tags';
+  // Keep the source fixed to the official repository; update packages are never downloaded from this response.
+  private readonly GITEE_API_URL = 'https://gitee.com/api/v5/repos/peng-minghang/mctier/tags?per_page=100&page=1';
   private readonly VERSION_CHECK_KEY = 'mctier_version_check_shown';
 
   /**
@@ -76,6 +126,8 @@ class VersionCheckService {
    * 从 Gitee API 获取最新版本信息
    */
   async fetchLatestVersion(): Promise<VersionInfo | null> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), VERSION_CHECK_TIMEOUT_MS);
     try {
       console.log('🔍 [VersionCheckService] 开始检查版本更新...');
       console.log('📡 [VersionCheckService] 请求 Gitee API:', this.GITEE_API_URL);
@@ -85,6 +137,8 @@ class VersionCheckService {
         headers: {
           'Accept': 'application/json',
         },
+        redirect: 'error',
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -92,8 +146,20 @@ class VersionCheckService {
         return null;
       }
 
-      const tags: GiteeTag[] = await response.json();
-      console.log('✅ [VersionCheckService] 成功获取标签列表，共', tags.length, '个标签');
+      const contentType = response.headers.get('content-type')?.toLowerCase();
+      if (contentType && !contentType.startsWith('application/json')) {
+        console.error('❌ [VersionCheckService] API 返回了非 JSON 内容');
+        return null;
+      }
+
+      const responseText = await readLimitedResponse(response, MAX_VERSION_RESPONSE_BYTES);
+      const parsed: unknown = JSON.parse(responseText);
+      if (!Array.isArray(parsed) || parsed.length > MAX_TAGS) {
+        console.error('❌ [VersionCheckService] API 返回的标签清单无效或过大');
+        return null;
+      }
+      const tags = parsed.filter(isTrustedGiteeTag);
+      console.log('✅ [VersionCheckService] 成功获取标签列表，共', tags.length, '个有效标签');
 
       if (!tags || tags.length === 0) {
         console.warn('⚠️ [VersionCheckService] 未找到任何版本标签');
@@ -104,8 +170,13 @@ class VersionCheckService {
       // 否则可能把旧 tag 当成"最新版"误报更新。这里遍历全部 tag，按语义版本取最大值。
       const latestTag = newestVersionTag(tags);
       if (!latestTag) return null;
-      const latestVersion = latestTag.name.replace(/^v/, ''); // 移除 'v' 前缀
+      const latestVersion = normalizeReleaseVersion(latestTag.name);
+      if (!latestVersion) return null;
       const currentVersion = await getVersion();
+      if (!normalizeReleaseVersion(currentVersion)) {
+        console.error('❌ [VersionCheckService] 当前版本号无效，停止更新提示');
+        return null;
+      }
       
       console.log('📦 [VersionCheckService] 最新版本:', latestVersion);
       console.log('📦 [VersionCheckService] 当前版本:', currentVersion);
@@ -124,6 +195,8 @@ class VersionCheckService {
     } catch (error) {
       console.error('❌ [VersionCheckService] 检查版本更新失败:', error);
       return null;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 
@@ -135,15 +208,17 @@ class VersionCheckService {
     try {
       // 按行分割，过滤空行，并去掉"- "前缀
       return message
+        .slice(0, MAX_RELEASE_NOTES_BYTES)
         .split(/\r?\n/)
         .map(line => line.trim())
         .filter(line => line.length > 0)
+        .slice(0, MAX_RELEASE_NOTE_LINES)
         .map(line => {
           // 如果行以"- "开头，去掉这个前缀
           if (line.startsWith('- ')) {
-            return line.substring(2);
+            return line.substring(2).slice(0, MAX_RELEASE_NOTE_LINE_LENGTH);
           }
-          return line;
+          return line.slice(0, MAX_RELEASE_NOTE_LINE_LENGTH);
         });
     } catch (error) {
       console.error('❌ [VersionCheckService] 格式化更新日志失败:', error);

--- a/src/services/version/versionPolicy.ts
+++ b/src/services/version/versionPolicy.ts
@@ -1,16 +1,41 @@
 export const DOWNLOAD_WEBSITE = 'https://mctier.pmhs.top';
 
+const MAX_VERSION_LENGTH = 64;
+const RELEASE_VERSION_PATTERN = /^v?(0|[1-9]\d{0,8})\.(0|[1-9]\d{0,8})\.(0|[1-9]\d{0,8})$/;
+
+/**
+ * Normalize a release tag only when it is an exact, bounded x.y.z version.
+ * Update metadata is untrusted input, so tags such as `2.8.0.exe` or
+ * `999999999999999999999.0.0` must never become a candidate update.
+ */
+export function normalizeReleaseVersion(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0 || value.length > MAX_VERSION_LENGTH) {
+    return null;
+  }
+  const match = RELEASE_VERSION_PATTERN.exec(value);
+  if (!match) return null;
+  return `${match[1]}.${match[2]}.${match[3]}`;
+}
+
+export function isReleaseVersion(value: unknown): value is string {
+  return normalizeReleaseVersion(value) !== null;
+}
+
 export function compareVersions(left: string, right: string): number {
-  const toParts = (version: string) => {
-    const parts = version
-      .replace(/^v/i, '')
-      .split('.')
-      .map((part) => Number.parseInt(part, 10) || 0);
-    while (parts.length < 3) parts.push(0);
-    return parts;
+  const toParts = (version: string): number[] | null => {
+    if (typeof version !== 'string' || version.length === 0 || version.length > MAX_VERSION_LENGTH) {
+      return null;
+    }
+    const parts = version.replace(/^v/i, '').split('.');
+    if (parts.some((part) => !/^\d{1,9}$/.test(part))) return null;
+    const numbers = parts.map((part) => Number(part));
+    if (numbers.some((part) => !Number.isSafeInteger(part))) return null;
+    while (numbers.length < 3) numbers.push(0);
+    return numbers;
   };
   const leftParts = toParts(left);
   const rightParts = toParts(right);
+  if (!leftParts || !rightParts) return 0;
   const length = Math.max(leftParts.length, rightParts.length);
   for (let index = 0; index < length; index += 1) {
     const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
@@ -20,6 +45,7 @@ export function compareVersions(left: string, right: string): number {
 }
 export function newestVersionTag<T extends { name: string }>(tags: readonly T[]): T | undefined {
   return tags.reduce<T | undefined>((newest, tag) => {
+    if (!isReleaseVersion(tag.name)) return newest;
     if (!newest || compareVersions(tag.name, newest.name) > 0) return tag;
     return newest;
   }, undefined);

--- a/src/services/webrtc/WebRTCClient.ts
+++ b/src/services/webrtc/WebRTCClient.ts
@@ -12,6 +12,23 @@ import { tl } from '../../i18n';
 import { voiceChangerService } from '../voice/voiceChangerService';
 import { localVqeService } from '../voice/localVqeService';
 import { appVersion, loadAppVersion } from '../version/appVersion';
+import { p2pChatService } from '../chat/P2PChatService';
+import {
+  isSafeChatToken,
+  isSafeIdentifier,
+  isSafeResourceId,
+  isSafeSessionId,
+  isSafeServerNode,
+  isSafeSignalingServer,
+  isSafeVirtualDomain,
+  isSafeVirtualIp,
+  MAX_ANNOUNCEMENT_LENGTH,
+  MAX_CHAT_TEXT_LENGTH,
+  MAX_PLAYER_NAME_LENGTH,
+  MAX_PATH_SEGMENT_LENGTH,
+  sanitizeIdentifier,
+  sanitizeUntrustedText,
+} from '../../security/trustBoundary';
 
 export interface SignalingMessage {
   type: 'offer' | 'answer' | 'ice-candidate' | 'player-joined' | 'player-left' | 'status-update' | 'heartbeat' | 'chat-message';
@@ -39,6 +56,12 @@ export interface PeerConnection {
   connectionTimeout?: number; // 连接超时定时器
   isNegotiating: boolean; // 是否正在协商中
   createdAt: number; // 连接创建时间
+}
+
+interface ChatPeerPayload {
+  player_id: string;
+  player_name: string;
+  virtual_ip: string;
 }
 
 /**
@@ -106,6 +129,10 @@ export class WebRTCClient {
   
   // 信令服务器地址（创建者的虚拟IP）
   private signalingServerUrl: string = '';
+  private chatToken: string = '';
+  private chatTokenEpoch: number = 0;
+  private chatHostId: string | undefined;
+  private chatPeers: Map<string, ChatPeerPayload> = new Map();
 
   // 事件回调
   private onPlayerJoinedCallback?: (playerId: string, playerName: string, virtualIp?: string, virtualDomain?: string, useDomain?: boolean) => void;
@@ -134,14 +161,27 @@ export class WebRTCClient {
    */
   async initialize(playerId: string, playerName: string, lobbyName: string, lobbyPassword: string, virtualDomain?: string, useDomain?: boolean, signalingServer?: string): Promise<void> {
     try {
+      const safePlayerId = isSafeIdentifier(playerId) ? playerId : '';
+      const safePlayerName = sanitizeUntrustedText(playerName, MAX_PLAYER_NAME_LENGTH).trim();
+      const safeLobbyName = sanitizeUntrustedText(lobbyName, 128).trim();
+      const safeLobbyPassword = sanitizeUntrustedText(lobbyPassword, 256);
+      const safeVirtualDomain = isSafeVirtualDomain(virtualDomain) ? virtualDomain.trim() : undefined;
+      const safeSignalingServer = signalingServer?.trim() || 'wss://mctier.pmhs.top/signaling';
+      if (!safePlayerId || !safePlayerName || !safeLobbyName || !isSafeSignalingServer(safeSignalingServer)) {
+        throw new Error('WebRTC 初始化参数无效');
+      }
+
       console.log('🚀 开始初始化 WebRTC 客户端...');
-      console.log('玩家ID:', playerId);
-      console.log('玩家名称:', playerName);
-      console.log('大厅名称:', lobbyName);
+      console.log('已读取 WebRTC 身份参数');
       
       // 重置麦克风的期望/实际状态，避免上一次大厅的残留状态导致本次关麦被误判为"无需操作"
       this.desiredMicEnabled = false;
       this.micActuallyEnabled = false;
+      this.chatToken = '';
+      this.chatTokenEpoch = 0;
+      this.chatHostId = undefined;
+      this.chatPeers.clear();
+      p2pChatService.setChatToken(undefined);
 
       // 重置 Store 的语音状态为默认值
       try {
@@ -164,12 +204,12 @@ export class WebRTCClient {
         await new Promise(resolve => setTimeout(resolve, 500));
       }
       
-      this.localPlayerId = playerId;
-      this.localPlayerName = playerName;
-      this.lobbyName = lobbyName;
-      this.lobbyPassword = lobbyPassword;
-      this.virtualDomain = virtualDomain || null;
-      this.useDomain = useDomain || false;
+      this.localPlayerId = safePlayerId;
+      this.localPlayerName = safePlayerName;
+      this.lobbyName = safeLobbyName;
+      this.lobbyPassword = safeLobbyPassword;
+      this.virtualDomain = safeVirtualDomain || null;
+      this.useDomain = useDomain === true && !!safeVirtualDomain;
       
       // 重置断开标志和重连相关状态
       this.isIntentionalDisconnect = false;
@@ -194,7 +234,10 @@ export class WebRTCClient {
       try {
         const virtualIp = await invoke<string | null>('get_virtual_ip');
         if (virtualIp) {
-          this.virtualIp = virtualIp;
+          if (!isSafeVirtualIp(virtualIp)) {
+            throw new Error('虚拟IP无效');
+          }
+          this.virtualIp = virtualIp.trim();
           console.log('✅ 虚拟IP:', this.virtualIp);
         } else {
           console.warn('⚠️ 未获取到虚拟IP，WebRTC可能无法正常工作');
@@ -207,7 +250,7 @@ export class WebRTCClient {
       // 预取版本号：注册消息在 onopen 同步回调中发送，无法 await（见 src/services/version/appVersion.ts）
       await loadAppVersion();
 
-      this.signalingServerUrl = signalingServer || 'wss://mctier.pmhs.top/signaling';
+      this.signalingServerUrl = safeSignalingServer;
       console.log('📡 连接到信令服务器:', this.signalingServerUrl);
 
       // 不再在初始化时获取麦克风，只有在用户开启麦克风时才获取
@@ -239,7 +282,7 @@ export class WebRTCClient {
       try {
         const { screenShareService } = await import('../screenShare/ScreenShareService');
         if (this.websocket) {
-          screenShareService.initialize(playerId, playerName, this.websocket);
+          screenShareService.initialize(this.localPlayerId, this.localPlayerName, this.websocket);
           console.log('✅ 屏幕共享服务初始化成功');
         }
       } catch (error) {
@@ -250,7 +293,7 @@ export class WebRTCClient {
       try {
         const { remoteControlService } = await import('../remoteControl/RemoteControlService');
         if (this.websocket) {
-          remoteControlService.initialize(playerId, playerName, this.websocket);
+          remoteControlService.initialize(this.localPlayerId, this.localPlayerName, this.websocket);
           console.log('✅ 远程控制服务初始化成功');
         }
       } catch (error) {
@@ -305,7 +348,7 @@ export class WebRTCClient {
   private async connectToSignalingServer(): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
-        console.log(`正在连接到信令服务器: ${this.signalingServerUrl}`);
+        console.log('正在连接到信令服务器');
         
         const socket = new WebSocket(this.signalingServerUrl);
         let hasOpened = false;
@@ -329,7 +372,7 @@ export class WebRTCClient {
               lobbyPassword: this.lobbyPassword,
               clientVersion: appVersion(),
             }));
-            console.log('📤 已发送注册消息，玩家名称:', this.localPlayerName, '大厅:', this.lobbyName, '虚拟域名:', this.virtualDomain, '使用域名:', this.useDomain);
+            console.log('📤 已发送注册消息');
           }
           
           // 启动 WebSocket 心跳保活
@@ -346,6 +389,7 @@ export class WebRTCClient {
         this.websocket.onmessage = (event) => {
           if (this.websocket !== socket) return;
           try {
+            if (typeof event.data !== 'string' || event.data.length > 512 * 1024) return;
             const message = JSON.parse(event.data);
             this.websocketMessageQueue = this.websocketMessageQueue
               .then(() => this.handleWebSocketMessage(message))
@@ -601,39 +645,256 @@ export class WebRTCClient {
       .catch((error) => console.error(`清理离线玩家 ${peerId} 的远程控制会话失败:`, error));
   }
 
+  private isKnownPlayer(playerId: unknown, includeLocal = true): playerId is string {
+    if (!isSafeIdentifier(playerId)) return false;
+    const normalized = playerId;
+    if (includeLocal && normalized === this.localPlayerId) return true;
+    return this.knownPlayers.has(normalized);
+  }
+
+  private authenticatedPeerId(message: unknown, requireTarget = true): string | null {
+    if (!message || typeof message !== 'object') return null;
+    const input = message as Record<string, unknown>;
+    const from = input.from;
+    const to = input.to;
+    if (!isSafeIdentifier(from) || from === this.localPlayerId || !this.knownPlayers.has(from)) {
+      return null;
+    }
+    if (requireTarget && to !== this.localPlayerId) return null;
+    if (!requireTarget && input.to !== undefined && to !== this.localPlayerId) {
+      return null;
+    }
+    return from;
+  }
+
+  private safeRouteVersion(value: unknown): number | undefined {
+    if (value === undefined || value === null) return undefined;
+    return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 && value <= 1_000_000_000
+      ? value
+      : undefined;
+  }
+
+  private safeViewerCount(value: unknown): number {
+    return typeof value === 'number' && Number.isSafeInteger(value)
+      ? Math.max(0, Math.min(100_000, value))
+      : 0;
+  }
+
+  private safeScreenShareId(value: unknown): string | null {
+    return isSafeResourceId(value) ? value : null;
+  }
+
+  private safeFileShareId(value: unknown): string | null {
+    return isSafeResourceId(value) ? value : null;
+  }
+
+  private authenticatedSession(message: unknown): { peerId: string; sessionId: string } | null {
+    const peerId = this.authenticatedPeerId(message);
+    if (!peerId || !message || typeof message !== 'object') return null;
+    const sessionId = (message as Record<string, unknown>).sessionId;
+    return isSafeSessionId(sessionId) ? { peerId, sessionId } : null;
+  }
+
+  private isSafeSessionDescription(value: unknown, expectedType: 'offer' | 'answer'): value is RTCSessionDescriptionInit {
+    if (!value || typeof value !== 'object') return false;
+    const input = value as Record<string, unknown>;
+    return input.type === expectedType && typeof input.sdp === 'string' && input.sdp.length > 0 && input.sdp.length <= 256 * 1024;
+  }
+
+  private isSafeIceCandidate(value: unknown): boolean {
+    if (!value || typeof value !== 'object') return false;
+    const input = value as Record<string, unknown>;
+    if (typeof input.candidate !== 'string' || input.candidate.length === 0 || input.candidate.length > 16 * 1024) return false;
+    if (
+      input.sdpMLineIndex != null &&
+      (typeof input.sdpMLineIndex !== 'number' ||
+        !Number.isSafeInteger(input.sdpMLineIndex) ||
+        input.sdpMLineIndex < 0 ||
+        input.sdpMLineIndex > 256)
+    ) return false;
+    return input.sdpMid == null || (typeof input.sdpMid === 'string' && input.sdpMid.length <= 128);
+  }
+
+  private parseChatPeer(raw: unknown): ChatPeerPayload | null {
+    if (!raw || typeof raw !== 'object') return null;
+    const input = raw as Record<string, unknown>;
+    const playerId = input.playerId;
+    const playerName = sanitizeUntrustedText(input.playerName, MAX_PLAYER_NAME_LENGTH).trim();
+    const virtualIp = isSafeVirtualIp(input.virtualIp) ? input.virtualIp.trim() : '';
+    if (
+      !isSafeIdentifier(playerId) ||
+      !playerName ||
+      !virtualIp ||
+      playerId === this.localPlayerId ||
+      virtualIp === this.virtualIp
+    ) {
+      return null;
+    }
+    return { player_id: playerId, player_name: playerName, virtual_ip: virtualIp };
+  }
+
+  private chatPeerSnapshot(): ChatPeerPayload[] {
+    return Array.from(this.chatPeers.values()).sort((left, right) =>
+      left.player_id.localeCompare(right.player_id),
+    );
+  }
+
+  private refreshP2PChatFrontend(): void {
+    if (!this.virtualIp || !this.localPlayerId) return;
+    const peers = this.chatPeerSnapshot();
+    p2pChatService.initialize(
+      peers.map((peer) => peer.virtual_ip),
+      this.localPlayerId,
+      this.virtualIp,
+    );
+    p2pChatService.setChatToken(this.chatToken || undefined);
+  }
+
+  private async configureChatSession(): Promise<void> {
+    if (
+      !this.chatToken ||
+      this.chatTokenEpoch <= 0 ||
+      !this.localPlayerId ||
+      !this.localPlayerName ||
+      !this.virtualIp
+    ) {
+      return;
+    }
+    const peers = this.chatPeerSnapshot();
+    await invoke('configure_p2p_chat', {
+      chatToken: this.chatToken,
+      chatTokenEpoch: this.chatTokenEpoch,
+      playerId: this.localPlayerId,
+      playerName: this.localPlayerName,
+      hostId: this.chatHostId,
+      peers,
+    });
+    this.refreshP2PChatFrontend();
+  }
+
+  private async syncChatPeers(): Promise<void> {
+    if (!this.chatToken || this.chatTokenEpoch <= 0) return;
+    await invoke('update_p2p_chat_peers', {
+      hostId: this.chatHostId,
+      peers: this.chatPeerSnapshot(),
+    });
+    this.refreshP2PChatFrontend();
+  }
+
+  private acceptChatToken(token: unknown, epoch: unknown): 'accepted' | 'unchanged' | 'stale' | 'rejected' {
+    if (!isSafeChatToken(token)) return 'rejected';
+    const numericEpoch =
+      typeof epoch === 'number' && Number.isSafeInteger(epoch) && epoch > 0 ? epoch : 0;
+    if (numericEpoch === 0) return 'rejected';
+    if (numericEpoch < this.chatTokenEpoch) return 'stale';
+    if (numericEpoch === this.chatTokenEpoch && this.chatToken && token !== this.chatToken) {
+      console.error('拒绝同一聊天 epoch 的不一致令牌');
+      return 'rejected';
+    }
+    if (numericEpoch === this.chatTokenEpoch && token === this.chatToken) return 'unchanged';
+
+    this.chatToken = token;
+    this.chatTokenEpoch = numericEpoch;
+    p2pChatService.setChatToken(token);
+    return 'accepted';
+  }
+
+  private async failClosedChatSession(context: string, error?: unknown): Promise<void> {
+    console.error(`${context}，关闭本地聊天/文件认证服务`, error);
+    this.chatToken = '';
+    this.chatTokenEpoch = 0;
+    this.chatHostId = undefined;
+    this.chatPeers.clear();
+    p2pChatService.reset();
+    try {
+      await invoke('stop_p2p_chat');
+    } catch (stopError) {
+      console.error('清理本地聊天/文件认证服务失败:', stopError);
+    }
+    if (this.websocket?.readyState === WebSocket.OPEN) {
+      this.websocket.close(1011, 'chat-auth-sync-failed');
+    }
+  }
+
   /**
    * 处理WebSocket消息
    */
   private async handleWebSocketMessage(message: any): Promise<void> {
-    console.log(`📨 收到WebSocket消息: ${message.type}`);
+    if (!message || typeof message !== 'object') return;
+    const messageType = sanitizeIdentifier(message.type, 64);
+    if (!messageType) return;
+    console.log(`📨 收到WebSocket消息: ${messageType}`);
 
     // 【健壮性】收到任何服务器消息都视为连接存活，重置 pong 超时，
     // 避免有正常流量时因 pong 偶尔延迟而误判断线重连
     this.handleWebSocketPong();
 
     try {
-      switch (message.type) {
+      switch (messageType) {
         case 'pong':
           // 收到 pong 响应（上方已重置超时，这里仅用于明确分支）
           break;
           
         case 'register-success':
           // 注册成功
-          console.log('✅ 注册成功，大厅ID:', message.lobbyId);
+          const registeredHostId = isSafeIdentifier(message.hostId) ? message.hostId : undefined;
+          this.chatHostId = registeredHostId;
+          const initialTokenStatus = this.acceptChatToken(
+            message.chatToken,
+            message.chatTokenEpoch,
+          );
+          if (initialTokenStatus === 'rejected' || initialTokenStatus === 'stale') {
+            await this.failClosedChatSession('注册响应中的聊天认证状态无效');
+            break;
+          }
+          if (this.authoritativeSnapshotVersion > 0) {
+            try {
+              await this.configureChatSession();
+            } catch (error) {
+              await this.failClosedChatSession('恢复聊天会话失败', error);
+              break;
+            }
+          }
+          console.log('✅ 注册成功');
           // 携带房主/人数上限/公开状态/禁言列表等大厅元数据
           if (this.onLobbyMetaCallback) {
+            const mutedPlayers: string[] | undefined = Array.isArray(message.mutedPlayers)
+              ? Array.from(new Set<string>((message.mutedPlayers as unknown[])
+                .filter((id: unknown): id is string => isSafeIdentifier(id))))
+              : undefined;
+            const maxPlayers = typeof message.maxPlayers === 'number' && Number.isSafeInteger(message.maxPlayers)
+              ? Math.max(1, Math.min(100_000, message.maxPlayers))
+              : null;
             this.onLobbyMetaCallback({
-              hostId: message.hostId,
-              maxPlayers: message.maxPlayers ?? null,
-              isPublic: message.isPublic,
-              mutedPlayers: message.mutedPlayers,
+              hostId: registeredHostId,
+              maxPlayers,
+              isPublic: typeof message.isPublic === 'boolean' ? message.isPublic : undefined,
+              mutedPlayers,
             });
+          }
+          break;
+
+        case 'chat-token-rotated':
+          {
+            const rotationStatus = this.acceptChatToken(message.chatToken, message.chatTokenEpoch);
+            if (rotationStatus === 'rejected') {
+              await this.failClosedChatSession('聊天令牌轮换状态无效');
+              break;
+            }
+            if (rotationStatus === 'accepted') {
+            try {
+              await this.configureChatSession();
+            } catch (error) {
+                await this.failClosedChatSession('应用聊天令牌轮换失败', error);
+                break;
+              }
+            }
           }
           break;
           
         case 'register-error':
           // 注册失败
-          console.error('❌ 注册失败:', message.message);
+          console.error('❌ 注册失败');
           // 不要抛出错误,只记录日志
           // 用户可能输入了错误的密码,应该让他们看到错误信息而不是断开连接
           break;
@@ -641,13 +902,13 @@ export class WebRTCClient {
         case 'version-too-old':
           // 版本过低
           console.error('❌ 客户端版本过低');
-          console.error('当前版本:', message.currentVersion);
-          console.error('最低要求:', message.minimumVersion);
-          console.error('下载地址:', message.downloadUrl);
-          
           // 触发版本错误回调
           if (this.onVersionErrorCallback) {
-            this.onVersionErrorCallback(message.currentVersion, message.minimumVersion, message.downloadUrl);
+            this.onVersionErrorCallback(
+              sanitizeUntrustedText(message.currentVersion, 32),
+              sanitizeUntrustedText(message.minimumVersion, 32),
+              sanitizeUntrustedText(message.downloadUrl, 512),
+            );
           }
           
           // 停止自动重连
@@ -661,31 +922,84 @@ export class WebRTCClient {
 
         case 'host-changed':
           // 房主变更
-          console.log('👑 房主变更为:', message.hostId);
-          this.onHostChangedCallback?.(message.hostId);
+          const changedHostId = message.hostId;
+          if (!isSafeIdentifier(changedHostId) || !this.isKnownPlayer(changedHostId)) break;
+          this.chatHostId = changedHostId;
+          try {
+            await this.syncChatPeers();
+          } catch (error) {
+            await this.failClosedChatSession('同步聊天房主身份失败', error);
+            break;
+          }
+          console.log('👑 房主变更');
+          this.onHostChangedCallback?.(changedHostId);
           break;
 
         case 'player-mute-changed':
           // 禁言状态变化
-          console.log(`🔇 禁言状态变化: ${message.playerId} -> ${message.muted}`);
-          this.onMuteChangedCallback?.(message.playerId, message.muted);
+          const mutedPlayerId = message.playerId;
+          if (!this.isKnownPlayer(mutedPlayerId, false) || typeof message.muted !== 'boolean') break;
+          console.log('🔇 禁言状态变化');
+          this.onMuteChangedCallback?.(mutedPlayerId, message.muted);
           break;
 
         case 'lobby-options-changed':
           // 大厅选项变化
-          console.log('⚙️ 大厅选项变化:', message.maxPlayers, message.isPublic);
-          this.onLobbyOptionsChangedCallback?.(message.maxPlayers ?? null, message.isPublic);
+          if (typeof message.isPublic !== 'boolean') break;
+          const changedMaxPlayers = message.maxPlayers == null
+            ? null
+            : (typeof message.maxPlayers === 'number' && Number.isSafeInteger(message.maxPlayers)
+              ? Math.max(1, Math.min(100_000, message.maxPlayers))
+              : null);
+          console.log('⚙️ 大厅选项变化');
+          this.onLobbyOptionsChangedCallback?.(changedMaxPlayers, message.isPublic);
           break;
 
         case 'kicked':
           // 被房主踢出
-          console.warn('👢 被房主移出大厅:', message.reason);
+          const kickReason = sanitizeUntrustedText(message.reason, MAX_ANNOUNCEMENT_LENGTH).trim();
+          console.warn('👢 被房主移出大厅');
           this.isIntentionalDisconnect = true;
-          this.onKickedCallback?.(message.reason || '你已被房主移出大厅');
+          this.chatToken = '';
+          this.chatTokenEpoch = 0;
+          this.chatHostId = undefined;
+          this.chatPeers.clear();
+          p2pChatService.reset();
+          try {
+            await invoke('stop_p2p_chat');
+          } catch (error) {
+            console.warn('停止被踢会话的聊天服务失败:', error);
+          }
+          this.onKickedCallback?.(kickReason || '你已被房主移出大厅');
           break;
           
         case 'players-list':
           // 收到当前在线玩家列表
+          if (!Array.isArray(message.players)) {
+            console.warn('⚠️ 收到无效的玩家列表，忽略');
+            break;
+          }
+          if (message.players.length > 10_000) {
+            console.warn('⚠️ 玩家列表过大，忽略');
+            break;
+          }
+          const nextChatPeers = new Map<string, ChatPeerPayload>();
+          const chatPeerIps = new Set<string>();
+          for (const rawPlayer of message.players) {
+            const peer = this.parseChatPeer(rawPlayer);
+            if (!peer || nextChatPeers.has(peer.player_id) || chatPeerIps.has(peer.virtual_ip)) {
+              continue;
+            }
+            nextChatPeers.set(peer.player_id, peer);
+            chatPeerIps.add(peer.virtual_ip);
+          }
+          this.chatPeers = nextChatPeers;
+          try {
+            await this.configureChatSession();
+          } catch (error) {
+            await this.failClosedChatSession('配置权威聊天成员快照失败', error);
+            break;
+          }
           console.log(`当前在线玩家: ${message.players.length} 人`);
           // 自我域名映射：把自己的虚拟域名也写入 hosts，使本机也能用自己的域名访问（便于测试/本机服务）
           if (this.useDomain && this.virtualDomain && this.virtualIp) {
@@ -701,9 +1015,25 @@ export class WebRTCClient {
           // 先记录处理前的已知集合与本次列表出现的 ID，循环结束后据此清理残留幽灵。
           const knownBefore = new Set(this.knownPlayers);
           const listedIds = new Set<string>();
+          const listedIps = new Set<string>();
 
-          for (const player of message.players) {
-            console.log(`  - ${player.playerName} (${player.playerId})`);
+          for (const rawPlayer of message.players) {
+            if (!rawPlayer || typeof rawPlayer !== 'object') continue;
+            const input = rawPlayer as Record<string, unknown>;
+            const playerId = input.playerId;
+            if (!isSafeIdentifier(playerId)) continue;
+            if (!playerId) continue;
+            const playerName = sanitizeUntrustedText(input.playerName, 64).trim() || tl('未知玩家', 'Unknown player');
+            const virtualIp = isSafeVirtualIp(input.virtualIp) ? input.virtualIp.trim() : undefined;
+            const virtualDomain = isSafeVirtualDomain(input.virtualDomain) ? input.virtualDomain.trim() : undefined;
+            const player = {
+              playerId,
+              playerName,
+              virtualIp,
+              virtualDomain,
+              useDomain: input.useDomain === true && !!virtualIp && !!virtualDomain,
+            };
+            console.log('  - 收到玩家条目');
 
             if (player.playerId === this.localPlayerId) {
               continue;
@@ -711,10 +1041,19 @@ export class WebRTCClient {
             // 虚拟 IP 在大厅内唯一。服务端残留旧连接或重复广播本机身份时，
             // 不把同一台设备当成远端玩家，也不向自己的 IP 建立语音连接。
             if (player.virtualIp && this.virtualIp && player.virtualIp === this.virtualIp) {
-              console.warn(`⚠️ 忽略与本机虚拟 IP 相同的玩家条目: ${player.playerName} (${player.playerId})`);
+              console.warn('⚠️ 忽略与本机虚拟 IP 相同的玩家条目');
+              continue;
+            }
+            if (listedIds.has(player.playerId)) {
+              console.warn('⚠️ 忽略重复的玩家身份条目');
+              continue;
+            }
+            if (player.virtualIp && listedIps.has(player.virtualIp)) {
+              console.warn('⚠️ 忽略重复的玩家虚拟 IP 条目');
               continue;
             }
             listedIds.add(player.playerId);
+            if (player.virtualIp) listedIps.add(player.virtualIp);
 
             const wasPendingLeave = this.clearPendingPlayerLeave(player.playerId);
             if (wasPendingLeave) {
@@ -834,34 +1173,51 @@ export class WebRTCClient {
           
         case 'player-joined':
           // 有新玩家加入
-          console.log(`🎮 新玩家加入: ${message.playerName} (${message.playerId})`);
+           const joinedPlayerId = message.playerId;
+          const joinedPlayerName = sanitizeUntrustedText(message.playerName, 64).trim() || tl('未知玩家', 'Unknown player');
+          const joinedVirtualIp = isSafeVirtualIp(message.virtualIp) ? message.virtualIp.trim() : undefined;
+          const joinedVirtualDomain = isSafeVirtualDomain(message.virtualDomain) ? message.virtualDomain.trim() : undefined;
+          const joinedUseDomain = message.useDomain === true && !!joinedVirtualIp && !!joinedVirtualDomain;
+           if (!isSafeIdentifier(joinedPlayerId)) break;
+          console.log(`🎮 新玩家加入: ${joinedPlayerName} (${joinedPlayerId})`);
 
-          if (message.playerId === this.localPlayerId) {
+          if (joinedPlayerId === this.localPlayerId) {
             break;
           }
-          if (message.virtualIp && this.virtualIp && message.virtualIp === this.virtualIp) {
-            console.warn(`⚠️ 忽略与本机虚拟 IP 相同的加入事件: ${message.playerName} (${message.playerId})`);
+          if (joinedVirtualIp && this.virtualIp && joinedVirtualIp === this.virtualIp) {
+            console.warn(`⚠️ 忽略与本机虚拟 IP 相同的加入事件: ${joinedPlayerName} (${joinedPlayerId})`);
             break;
           }
 
-          const isRecoveredPlayer = this.clearPendingPlayerLeave(message.playerId);
+          const joinedChatPeer = this.parseChatPeer(message);
+          if (joinedChatPeer) {
+            this.chatPeers.set(joinedChatPeer.player_id, joinedChatPeer);
+            try {
+              await this.syncChatPeers();
+            } catch (error) {
+              await this.failClosedChatSession('同步新聊天成员失败', error);
+              break;
+            }
+          }
+
+          const isRecoveredPlayer = this.clearPendingPlayerLeave(joinedPlayerId);
           if (isRecoveredPlayer) {
             console.log(`♻️ 玩家 ${message.playerId} 在短时断线窗口内恢复，跳过离开/加入提示音`);
           }
 
-          const alreadyKnown = this.knownPlayers.has(message.playerId);
+          const alreadyKnown = this.knownPlayers.has(joinedPlayerId);
           if (alreadyKnown) {
-            const existingPeer = this.peerConnections.get(message.playerId);
+            const existingPeer = this.peerConnections.get(joinedPlayerId);
             if (!this.isPeerConnectedOrFresh(existingPeer)) {
-              console.log(`♻️ ${message.playerId} 重新注册且语音连接异常，调度自动修复`);
-              this.schedulePeerReconnect(message.playerId, '玩家重新注册', 500);
+              console.log(`♻️ ${joinedPlayerId} 重新注册且语音连接异常，调度自动修复`);
+              this.schedulePeerReconnect(joinedPlayerId, '玩家重新注册', 500);
             } else {
-              console.log(`⏳ ${message.playerId} 已在players-list中处理过，连接正常，跳过重复加入事件`);
+              console.log(`⏳ ${joinedPlayerId} 已在players-list中处理过，连接正常，跳过重复加入事件`);
             }
             break;
           }
 
-          this.knownPlayers.add(message.playerId);
+          this.knownPlayers.add(joinedPlayerId);
           
           // 播放玩家加入音效（短时断线恢复不播放）
           if (!isRecoveredPlayer) {
@@ -874,16 +1230,16 @@ export class WebRTCClient {
           }
           
           // 如果启用了域名访问且有虚拟域名，添加到hosts文件
-          if (message.useDomain && message.virtualDomain && message.virtualIp) {
+          if (joinedUseDomain && joinedVirtualDomain && joinedVirtualIp) {
             // 记录域名，供该玩家离开时清理 hosts（player-left 只带 playerId）
-            this.playerDomains.set(message.playerId, message.virtualDomain);
+            this.playerDomains.set(joinedPlayerId, joinedVirtualDomain);
             try {
-              console.log(`📝 添加玩家域名映射: ${message.virtualDomain} -> ${message.virtualIp}`);
+              console.log(`📝 添加玩家域名映射: ${joinedVirtualDomain} -> ${joinedVirtualIp}`);
               await invoke('add_player_domain', {
-                domain: message.virtualDomain,
-                ip: message.virtualIp,
+                domain: joinedVirtualDomain,
+                ip: joinedVirtualIp,
               });
-              console.log(`✅ 玩家域名映射已添加: ${message.virtualDomain}`);
+              console.log(`✅ 玩家域名映射已添加: ${joinedVirtualDomain}`);
             } catch (error) {
               console.error(`❌ 添加玩家域名映射失败:`, error);
               // 不中断流程，继续处理玩家加入
@@ -891,50 +1247,64 @@ export class WebRTCClient {
           }
           
           // 触发回调
-          this.notifyPlayerJoined(message.playerId, message.playerName, message.virtualIp, message.virtualDomain, message.useDomain);
+          this.notifyPlayerJoined(joinedPlayerId, joinedPlayerName, joinedVirtualIp, joinedVirtualDomain, joinedUseDomain);
           
           // HTTP模式：不需要向新玩家发送共享列表，客户端直接通过HTTP API查询
           // 只有当本地玩家ID字典序大于对方时才主动发起连接
-          if (this.localPlayerId > message.playerId) {
-            console.log(`📡 主动向新玩家 ${message.playerId} 发起连接（ID字典序较大）`);
+          if (this.localPlayerId > joinedPlayerId) {
+            console.log(`📡 主动向新玩家 ${joinedPlayerId} 发起连接（ID字典序较大）`);
             
             // 等待一小段时间，让新玩家完成初始化
             await new Promise(resolve => setTimeout(resolve, 500));
             
             // 创建连接
-            await this.createPeerConnection(message.playerId);
+            await this.createPeerConnection(joinedPlayerId);
             
             // 等待ICE候选收集开始
             await new Promise(resolve => setTimeout(resolve, 100));
             
             // 创建 Offer
-            const pc = this.peerConnections.get(message.playerId);
+            const pc = this.peerConnections.get(joinedPlayerId);
             if (pc) {
               const offer = await pc.connection.createOffer();
               await pc.connection.setLocalDescription(offer);
               
               // 发送 Offer（失败自动重试一次）
-              await this.sendOfferWithRetry(message.playerId, {
+              await this.sendOfferWithRetry(joinedPlayerId, {
                 type: offer.type,
                 sdp: offer.sdp,
               }, '新玩家连接');
             }
           } else {
-            console.log(`⏳ 等待新玩家 ${message.playerId} 主动发起连接（ID字典序较小）`);
+            console.log(`⏳ 等待新玩家 ${joinedPlayerId} 主动发起连接（ID字典序较小）`);
           }
           break;
           
         case 'player-left':
           // 有玩家离开（增加短时断线缓冲，避免误报提示音）
-          console.log(`👋 玩家离开事件: ${message.playerId}`);
+           const leftPlayerId = message.playerId;
+          if (leftPlayerId) {
+            this.chatPeers.delete(leftPlayerId);
+            if (this.chatHostId === leftPlayerId) this.chatHostId = undefined;
+            try {
+              await this.syncChatPeers();
+            } catch (error) {
+              await this.failClosedChatSession('撤销离开玩家的聊天权限失败', error);
+              break;
+            }
+          }
+           if (!isSafeIdentifier(leftPlayerId) || !this.knownPlayers.has(leftPlayerId)) {
+            break;
+          }
+          console.log('👋 玩家离开事件');
 
-          if (!message.playerId || message.playerId === this.localPlayerId) {
+          if (leftPlayerId === this.localPlayerId) {
             break;
           }
 
-          this.resetRemoteControlForPeer(message.playerId);
+          this.resetRemoteControlForPeer(leftPlayerId);
 
-          if (this.schedulePlayerLeaveConfirmation(message.playerId)) {
+          if (this.schedulePlayerLeaveConfirmation(leftPlayerId)) {
             break;
           }
           break;
@@ -962,26 +1332,31 @@ export class WebRTCClient {
           // 随后由对方作为发起方送来全新的 Offer 完成重建。
           // 必须双端同时拆掉旧连接，否则一端沿用旧 PeerConnection 会因指纹/ufrag
           // 不匹配而出现"连上了但没声音"。
-          if (message.from) {
-            console.log(`🔄 收到来自 ${message.from} 的语音重连请求，拆除旧连接等待重建`);
-            this.clearPeerReconnectState(message.from);
-            this.removePeerConnection(message.from);
+          const reconnectPlayerId = message.from;
+          if (this.isKnownPlayer(reconnectPlayerId, false) && (!message.to || message.to === this.localPlayerId)) {
+            console.log('🔄 收到语音重连请求，拆除旧连接等待重建');
+            this.clearPeerReconnectState(reconnectPlayerId);
+            this.removePeerConnection(reconnectPlayerId);
           }
           break;
           
         case 'status-update':
           // 收到状态更新
-          console.log(`📢 收到状态更新 from ${message.clientId}: 麦克风${message.micEnabled ? '开启' : '关闭'}`);
-          if (this.onStatusUpdateCallback) {
-            this.onStatusUpdateCallback(message.clientId, message.micEnabled);
-          }
+          const statusPlayerId = message.clientId;
+          if (!this.isKnownPlayer(statusPlayerId, false) || typeof message.micEnabled !== 'boolean') break;
+          console.log('📢 收到状态更新');
+          this.onStatusUpdateCallback?.(statusPlayerId, message.micEnabled);
           break;
 
         case 'chat-message':
           // 收到聊天消息
-          console.log(`💬 收到聊天消息 from ${message.playerName}: ${message.content}`);
-          if (this.onChatMessageCallback && message.playerId && message.playerName && message.content && message.timestamp) {
-            this.onChatMessageCallback(message.playerId, message.playerName, message.content, message.timestamp);
+          const chatPlayerId = message.playerId;
+          const chatPlayerName = sanitizeUntrustedText(message.playerName, 64).trim();
+          const chatContent = sanitizeUntrustedText(message.content, MAX_CHAT_TEXT_LENGTH);
+          const chatTimestamp = typeof message.timestamp === 'number' ? message.timestamp : Number.NaN;
+          console.log('💬 收到聊天消息');
+          if (this.onChatMessageCallback && this.isKnownPlayer(chatPlayerId, false) && chatPlayerName && chatContent && Number.isFinite(chatTimestamp) && chatTimestamp >= 0) {
+            this.onChatMessageCallback(chatPlayerId, chatPlayerName, chatContent, chatTimestamp);
           }
           break;
           
@@ -1014,26 +1389,8 @@ export class WebRTCClient {
           break;
           
         case 'file-transfer-response':
-          // 收到文件传输响应
-          console.log(`📥 收到文件传输响应 from ${message.from}, request:`, message.request);
-          try {
-            const requestId = message.request?.requestId;
-            if (!requestId) {
-              console.error('❌ 文件传输响应缺少requestId');
-              return;
-            }
-            
-            console.log(`📥 处理文件传输响应, requestId: ${requestId}, accepted: ${message.accepted}`);
-            
-            if (message.accepted) {
-              console.log(`✅ 文件传输请求已被接受: ${requestId}`);
-            } else {
-              console.error(`❌ 文件传输请求被拒绝: ${requestId}, ${message.error}`);
-              fileTransferService.handleTransferError(requestId, message.error || '传输被拒绝');
-            }
-          } catch (error) {
-            console.error('❌ 处理文件传输响应失败:', error);
-          }
+          // Legacy WebSocket file-transfer signaling is disabled. Ignore it
+          // rather than allowing an arbitrary peer to mutate local transfer UI.
           break;
           
         case 'file-chunk':
@@ -1052,289 +1409,370 @@ export class WebRTCClient {
           break;
           
         case 'share-added':
-          // 收到远程共享添加
-          console.log(`📁 收到远程共享添加 from ${message.from}`);
-          try {
-            if (message.share) {
-              fileShareService.handleRemoteShareAdded(message.share);
-              console.log(`✅ 远程共享已添加: ${message.share.folderName}`);
-            }
-          } catch (error) {
-            console.error('❌ 处理远程共享添加失败:', error);
-          }
+          // Legacy file-share signaling is disabled; the HTTP listing is the
+          // sole source of truth for remote shares.
           break;
           
         case 'share-removed':
-          // 收到远程共享移除
-          console.log(`📁 收到远程共享移除 from ${message.from}, shareId: ${message.shareId}`);
-          try {
-            if (message.shareId) {
-              fileShareService.handleRemoteShareRemoved(message.shareId);
-              console.log(`✅ 远程共享已移除: ${message.shareId}`);
-            }
-          } catch (error) {
-            console.error('❌ 处理远程共享移除失败:', error);
-          }
           break;
           
         case 'share-updated':
-          // 收到远程共享更新
-          console.log(`📁 收到远程共享更新 from ${message.from}`);
-          try {
-            if (message.share) {
-              fileShareService.handleRemoteShareUpdated(message.share);
-              console.log(`✅ 远程共享已更新: ${message.share.folderName}`);
-            }
-          } catch (error) {
-            console.error('❌ 处理远程共享更新失败:', error);
-          }
           break;
           
         case 'screen-share-start':
           // 收到屏幕共享开始通知
-          console.log(`🖥️ 收到屏幕共享开始通知 from ${message.playerName}`);
-          try {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            // 将共享信息添加到本地列表
-            const share = {
-              id: message.shareId,
-              playerId: message.from,
-              playerName: message.playerName,
-              virtualIp: '', // 将由前端填充
-              requirePassword: message.hasPassword,
-              startTime: Date.now(),
-              status: 'active' as const,
-            };
-            // 直接添加到activeShares
-            (screenShareService as any).activeShares.set(share.id, share);
-            console.log(`✅ 屏幕共享已添加到列表: ${share.playerName}`);
-            
-            // 【事件驱动】触发自定义事件通知UI更新
-            window.dispatchEvent(new CustomEvent('screen-share-start', {
-              detail: {
-                shareId: share.id,
-                playerId: share.playerId,
-                playerName: share.playerName,
-                hasPassword: share.requirePassword,
-              }
-            }));
-          } catch (error) {
-            console.error('❌ 处理屏幕共享开始失败:', error);
+          {
+            const peerId = this.authenticatedPeerId(message, false);
+            const shareId = this.safeScreenShareId(message.shareId);
+            const playerName = sanitizeUntrustedText(message.playerName, MAX_PLAYER_NAME_LENGTH).trim();
+            if (!peerId || !shareId || !shareId.startsWith('share-') || !playerName || typeof message.hasPassword !== 'boolean') break;
+            console.log('🖥️ 收到屏幕共享开始通知');
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              const activeShares = (screenShareService as any).activeShares as Map<string, any>;
+              const existing = activeShares.get(shareId);
+              if (existing && existing.playerId !== peerId) break;
+              if (!existing && activeShares.size >= 256) break;
+              // Only the roster member that announced the share may own it.
+              const share = {
+                id: shareId,
+                playerId: peerId,
+                playerName,
+                virtualIp: '',
+                requirePassword: message.hasPassword,
+                startTime: Date.now(),
+                status: 'active' as const,
+              };
+              activeShares.set(share.id, share);
+              window.dispatchEvent(new CustomEvent('screen-share-start', {
+                detail: {
+                  shareId: share.id,
+                  playerId: share.playerId,
+                  playerName: share.playerName,
+                  hasPassword: share.requirePassword,
+                },
+              }));
+            } catch (error) {
+              console.error('❌ 处理屏幕共享开始失败:', error);
+            }
           }
           break;
           
         case 'screen-share-error':
           // 收到屏幕共享错误（例如密码错误）
-          console.log(`❌ 收到屏幕共享错误: ${message.error}`);
-          if (message.to !== this.localPlayerId || typeof message.from !== 'string' || typeof message.shareId !== 'string') {
-            break;
-          }
           {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            const share = screenShareService.getActiveShares().find((item) => item.id === message.shareId);
-            if (!share || share.playerId !== message.from) break;
+            const peerId = this.authenticatedPeerId(message);
+            const shareId = this.safeScreenShareId(message.shareId);
+            const errorText = sanitizeUntrustedText(message.error, MAX_ANNOUNCEMENT_LENGTH).trim();
+            if (!peerId || !shareId || !errorText) break;
+            console.log(`❌ 收到屏幕共享错误: ${errorText}`);
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              const share = screenShareService.getActiveShares().find((item) => item.id === shareId);
+              if (!share || share.playerId !== peerId) break;
+              // 这里可以通过事件通知前端显示错误
+              window.dispatchEvent(new CustomEvent('screen-share-error', {
+                detail: { shareId, error: errorText },
+              }));
+            } catch (error) {
+              console.error('❌ 处理屏幕共享错误失败:', error);
+            }
           }
-          // 这里可以通过事件通知前端显示错误
-          window.dispatchEvent(new CustomEvent('screen-share-error', { 
-            detail: { 
-              shareId: message.shareId, 
-              error: message.error 
-            } 
-          }));
           break;
           
         case 'screen-share-stop':
           // 收到屏幕共享停止通知
-          console.log(`🖥️ 收到屏幕共享停止通知, shareId: ${message.shareId}`);
-          try {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            if (typeof message.from !== 'string' || typeof message.shareId !== 'string' || !screenShareService.handleShareStop(message.shareId, message.from)) {
-              break;
+          {
+            const peerId = this.authenticatedPeerId(message, false);
+            const shareId = this.safeScreenShareId(message.shareId);
+            if (!peerId || !shareId) break;
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              if (!screenShareService.handleShareStop(shareId, peerId)) break;
+              console.log(`✅ 屏幕共享已从列表移除`);
+              window.dispatchEvent(new CustomEvent('screen-share-stop', { detail: { shareId } }));
+            } catch (error) {
+              console.error('❌ 处理屏幕共享停止失败:', error);
             }
-            console.log(`✅ 屏幕共享已从列表移除`);
-            
-            // 【事件驱动】触发自定义事件通知UI更新
-            window.dispatchEvent(new CustomEvent('screen-share-stop', {
-              detail: {
-                shareId: message.shareId,
-              }
-            }));
-          } catch (error) {
-            console.error('❌ 处理屏幕共享停止失败:', error);
           }
           break;
           
         case 'screen-share-offer':
           // 收到屏幕共享Offer
-          console.log(`🖥️ 收到屏幕共享Offer from ${message.from}, playerName: ${message.playerName}`);
-          if (message.to !== this.localPlayerId || typeof message.from !== 'string' || typeof message.shareId !== 'string' || !message.offer?.sdp) break;
-          try {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            await screenShareService.handleOffer({
-              shareId: message.shareId,
-              playerId: message.from,
-              playerName: message.playerName || '未知玩家', // 【修复】从消息中获取查看者名字
-              requirePassword: false,
-              password: message.password, // 【修复】传递密码字段
-              sdp: message.offer.sdp,
-              routeVersion: message.routeVersion,
-            });
-            console.log(`✅ 屏幕共享Offer已处理`);
-          } catch (error) {
-            console.error('❌ 处理屏幕共享Offer失败:', error);
+          {
+            const session = this.authenticatedSession(message);
+            const shareId = this.safeScreenShareId(message.shareId);
+            const playerName = sanitizeUntrustedText(message.playerName, MAX_PLAYER_NAME_LENGTH).trim();
+            const password = message.password === undefined
+              ? undefined
+              : typeof message.password === 'string'
+                ? sanitizeUntrustedText(message.password, 256)
+                : null;
+            const routeVersion = this.safeRouteVersion(message.routeVersion);
+            if (!session || !shareId || !playerName || password === null || !this.isSafeSessionDescription(message.offer, 'offer')) break;
+            if (message.routeVersion !== undefined && routeVersion === undefined) break;
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              const activeShares = (screenShareService as any).activeShares as Map<string, any>;
+              const share = activeShares.get(shareId);
+              // An offer is accepted only by the owner of the announced share.
+              if (!share || share.playerId !== this.localPlayerId) break;
+              await screenShareService.handleOffer({
+                shareId,
+                playerId: session.peerId,
+                playerName,
+                requirePassword: false,
+                password,
+                sdp: message.offer.sdp,
+                routeVersion,
+              });
+            } catch (error) {
+              console.error('❌ 处理屏幕共享Offer失败:', error);
+            }
           }
           break;
           
         case 'screen-share-answer':
           if (message.to !== this.localPlayerId || typeof message.from !== 'string' || typeof message.shareId !== 'string' || !message.answer?.sdp) break;
           // 收到屏幕共享Answer
-          console.log(`🖥️ 收到屏幕共享Answer from ${message.from}`);
-          try {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            await screenShareService.handleAnswer({
-              shareId: message.shareId,
-              sdp: message.answer.sdp,
-              routeVersion: message.routeVersion,
-            }, message.from);
-            console.log(`✅ 屏幕共享Answer已处理`);
-          } catch (error) {
-            console.error('❌ 处理屏幕共享Answer失败:', error);
+          {
+            const session = this.authenticatedSession(message);
+            const shareId = this.safeScreenShareId(message.shareId);
+            const routeVersion = this.safeRouteVersion(message.routeVersion);
+            if (!session || !shareId || !this.isSafeSessionDescription(message.answer, 'answer')) break;
+            if (message.routeVersion !== undefined && routeVersion === undefined) break;
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              const activeShares = (screenShareService as any).activeShares as Map<string, any>;
+              const share = activeShares.get(shareId);
+              if (!share || share.playerId !== session.peerId) break;
+              await screenShareService.handleAnswer({
+                shareId,
+                sdp: message.answer.sdp,
+                routeVersion,
+              }, session.peerId);
+            } catch (error) {
+              console.error('❌ 处理屏幕共享Answer失败:', error);
+            }
           }
           break;
           
         case 'screen-share-ice-candidate':
           if (message.to !== this.localPlayerId || typeof message.from !== 'string' || typeof message.shareId !== 'string' || !message.candidate) break;
           // 收到屏幕共享ICE候选
-          console.log(`🖥️ 收到屏幕共享ICE候选 from ${message.from}`);
-          try {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            await screenShareService.handleIceCandidate(message.shareId, message.candidate, message.from, message.connectionRole, message.routeVersion);
-            console.log(`✅ 屏幕共享ICE候选已处理`);
-          } catch (error) {
-            console.error('❌ 处理屏幕共享ICE候选失败:', error);
+          {
+            const session = this.authenticatedSession(message);
+            const shareId = this.safeScreenShareId(message.shareId);
+            const role = message.connectionRole;
+            const routeVersion = this.safeRouteVersion(message.routeVersion);
+            if (!session || !shareId || !['in', 'out'].includes(role) || !this.isSafeIceCandidate(message.candidate)) break;
+            if (message.routeVersion !== undefined && routeVersion === undefined) break;
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              const activeShares = (screenShareService as any).activeShares as Map<string, any>;
+              const share = activeShares.get(shareId);
+              if (!share) break;
+              // `out` candidates are sent to the owner; `in` candidates are
+              // sent to a viewer. Do not let a peer inject into the other role.
+              if ((role === 'out' && share.playerId !== this.localPlayerId) ||
+                  (role === 'in' && share.playerId !== session.peerId)) break;
+              await screenShareService.handleIceCandidate(
+                shareId,
+                message.candidate,
+                session.peerId,
+                role,
+                routeVersion,
+              );
+            } catch (error) {
+              console.error('❌ 处理屏幕共享ICE候选失败:', error);
+            }
           }
           break;
 
         case 'screen-share-relay':
-          try {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            await screenShareService.handleRelayControl(message);
-          } catch (error) {
-            console.error('❌ 处理屏幕共享中继控制消息失败:', error);
+          {
+            const session = this.authenticatedSession(message);
+            const shareId = this.safeScreenShareId(message.shareId);
+            const action = message.action;
+            const routeVersion = this.safeRouteVersion(message.routeVersion);
+            const upstreamId = message.upstreamId === undefined ? undefined : message.upstreamId;
+            const downstreamId = message.downstreamId === undefined ? undefined : message.downstreamId;
+            const playerName = message.playerName === undefined
+              ? undefined
+              : sanitizeUntrustedText(message.playerName, MAX_PLAYER_NAME_LENGTH).trim();
+            const password = message.password === undefined ? undefined : sanitizeUntrustedText(message.password, 256);
+            const reason = message.reason === undefined ? undefined : sanitizeUntrustedText(message.reason, MAX_ANNOUNCEMENT_LENGTH).trim();
+            const validAction = ['join', 'health', 'ready', 'failure', 'accepted', 'route', 'child', 'detach'].includes(action);
+            if (!session || !shareId || !validAction) break;
+            if (message.routeVersion !== undefined && routeVersion === undefined) break;
+            if (upstreamId !== undefined && !isSafeIdentifier(upstreamId)) break;
+            if (downstreamId !== undefined && !isSafeIdentifier(downstreamId)) break;
+            if (message.playerName !== undefined && !playerName) break;
+            if (message.password !== undefined && typeof message.password !== 'string') break;
+            if (message.reason !== undefined && !reason) break;
+            if (action === 'join' && (!playerName || (message.password !== undefined && typeof message.password !== 'string'))) break;
+            if (['ready', 'route', 'child', 'detach'].includes(action) && routeVersion === undefined) break;
+            if (action === 'route' && !isSafeIdentifier(upstreamId)) break;
+            if (['child', 'detach'] .includes(action) && !isSafeIdentifier(downstreamId)) break;
+            if (action === 'health') {
+              const sourceSequence = message.sourceSequence ?? message.sequence;
+              const sentSequence = message.sentSequence ?? message.sequence;
+              if (
+                typeof sourceSequence !== 'number' || !Number.isSafeInteger(sourceSequence) || sourceSequence < 0 || sourceSequence > 1_000_000_000 ||
+                typeof sentSequence !== 'number' || !Number.isSafeInteger(sentSequence) || sentSequence < 0 || sentSequence > 1_000_000_000 ||
+                typeof message.limited !== 'boolean'
+              ) break;
+            }
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              const activeShares = (screenShareService as any).activeShares as Map<string, any>;
+              const share = activeShares.get(shareId);
+              if (!share) break;
+              if (['join', 'ready', 'failure'].includes(action) && share.playerId !== this.localPlayerId) break;
+              if (['accepted', 'route', 'child', 'detach'].includes(action) && share.playerId !== session.peerId) break;
+              await screenShareService.handleRelayControl({
+                ...message,
+                from: session.peerId,
+                to: this.localPlayerId,
+                shareId,
+                routeVersion,
+                upstreamId,
+                downstreamId,
+                playerName,
+                password,
+                reason,
+              });
+            } catch (error) {
+              console.error('❌ 处理屏幕共享中继控制消息失败:', error);
+            }
           }
           break;
           
         case 'screen-share-viewer-left':
           // 收到查看者离开通知
-          console.log(`👋 收到查看者离开通知, shareId: ${message.shareId}, from: ${message.from}`);
-          if (typeof message.from !== 'string' || typeof message.shareId !== 'string') break;
-          try {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            screenShareService.handleViewerLeft(message.shareId, message.from);
-            console.log(`✅ 查看者离开已处理`);
-          } catch (error) {
-            console.error('❌ 处理查看者离开失败:', error);
+          {
+            const peerId = this.authenticatedPeerId(message, false);
+            const shareId = this.safeScreenShareId(message.shareId);
+            if (!peerId || !shareId) break;
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              const activeShares = (screenShareService as any).activeShares as Map<string, any>;
+              const share = activeShares.get(shareId);
+              if (!share || share.playerId !== this.localPlayerId) break;
+              screenShareService.handleViewerLeft(shareId, peerId);
+            } catch (error) {
+              console.error('❌ 处理查看者离开失败:', error);
+            }
           }
           break;
           
         case 'screen-share-list-request':
           // 收到屏幕共享列表请求
-          console.log(`📋 收到屏幕共享列表请求 from ${message.from}`);
-          try {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            // 【修复】只返回自己创建的共享，不返回别人的共享
-            const myShares = screenShareService.getMyActiveShares();
-            
-            // 如果有活跃的共享，发送给请求者
-            if (myShares.length > 0) {
-              console.log(`📤 发送 ${myShares.length} 个屏幕共享信息给 ${message.from}`);
+          {
+            const peerId = this.authenticatedPeerId(message, false);
+            if (!peerId) break;
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              const myShares = screenShareService.getMyActiveShares().slice(0, 256);
               myShares.forEach(share => {
+                const shareId = this.safeScreenShareId(share.id);
+                const playerName = sanitizeUntrustedText(share.playerName, MAX_PLAYER_NAME_LENGTH).trim();
+                if (!shareId || !shareId.startsWith('share-') || !playerName) return;
                 this.sendWebSocketMessage({
                   type: 'screen-share-list-response',
                   from: this.localPlayerId,
-                  to: message.from,
-                  shareId: share.id,
-                  playerName: share.playerName,
-                  hasPassword: share.requirePassword,
-                  viewerId: share.viewerId,
-                  viewerName: share.viewerName,
-                  viewerCount: share.viewerCount ?? 0,
+                  to: peerId,
+                  shareId,
+                  playerName,
+                  hasPassword: share.requirePassword === true,
+                  viewerId: isSafeIdentifier(share.viewerId) ? share.viewerId : undefined,
+                  viewerName: share.viewerName ? sanitizeUntrustedText(share.viewerName, MAX_PLAYER_NAME_LENGTH).trim() : undefined,
+                  viewerCount: this.safeViewerCount(share.viewerCount),
                 });
               });
-            } else {
-              console.log(`📭 我没有活跃的屏幕共享`);
+            } catch (error) {
+              console.error('❌ 处理屏幕共享列表请求失败:', error);
             }
-          } catch (error) {
-            console.error('❌ 处理屏幕共享列表请求失败:', error);
           }
           break;
           
         case 'screen-share-list-response':
           // 收到屏幕共享列表响应
-          console.log(`📥 收到屏幕共享列表响应 from ${message.from}`);
-          try {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            // 将共享信息添加到本地列表
-            const share = {
-              id: message.shareId,
-              playerId: message.from,
-              playerName: message.playerName,
-              virtualIp: '', // 将由前端填充
-              requirePassword: message.hasPassword,
-              startTime: Date.now(),
-              status: 'active' as const,
-              viewerId: message.viewerId,
-              viewerName: message.viewerName,
-              viewerCount: message.viewerCount ?? 0,
-            };
-            // 直接添加到activeShares
-            (screenShareService as any).activeShares.set(share.id, share);
-            console.log(`✅ 屏幕共享已添加到列表: ${share.playerName}`);
-            
-            // 【事件驱动】触发自定义事件通知UI更新
-            window.dispatchEvent(new CustomEvent('screen-share-start', {
-              detail: {
-                shareId: share.id,
-                playerId: share.playerId,
-                playerName: share.playerName,
-                hasPassword: share.requirePassword,
-                viewerId: share.viewerId,
-                viewerName: share.viewerName,
-                viewerCount: share.viewerCount,
-              }
-            }));
-          } catch (error) {
-            console.error('❌ 处理屏幕共享列表响应失败:', error);
+          {
+            const peerId = this.authenticatedPeerId(message);
+            const shareId = this.safeScreenShareId(message.shareId);
+            const playerName = sanitizeUntrustedText(message.playerName, MAX_PLAYER_NAME_LENGTH).trim();
+            const viewerId = message.viewerId === undefined ? undefined : message.viewerId;
+            const viewerName = message.viewerName === undefined ? undefined : sanitizeUntrustedText(message.viewerName, MAX_PLAYER_NAME_LENGTH).trim();
+            if (!peerId || !shareId || !shareId.startsWith('share-') || !playerName || typeof message.hasPassword !== 'boolean') break;
+            if (viewerId !== undefined && !isSafeIdentifier(viewerId)) break;
+            if (message.viewerName !== undefined && !viewerName) break;
+            if (message.viewerCount !== undefined && (typeof message.viewerCount !== 'number' || !Number.isSafeInteger(message.viewerCount) || message.viewerCount < 0 || message.viewerCount > 100_000)) break;
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              const activeShares = (screenShareService as any).activeShares as Map<string, any>;
+              const existing = activeShares.get(shareId);
+              if (existing && existing.playerId !== peerId) break;
+              if (!existing && activeShares.size >= 256) break;
+              const share = {
+                id: shareId,
+                playerId: peerId,
+                playerName,
+                virtualIp: '',
+                requirePassword: message.hasPassword,
+                startTime: Date.now(),
+                status: 'active' as const,
+                viewerId,
+                viewerName,
+                viewerCount: this.safeViewerCount(message.viewerCount),
+              };
+              activeShares.set(share.id, share);
+              window.dispatchEvent(new CustomEvent('screen-share-start', {
+                detail: {
+                  shareId: share.id,
+                  playerId: share.playerId,
+                  playerName: share.playerName,
+                  hasPassword: share.requirePassword,
+                  viewerId: share.viewerId,
+                  viewerName: share.viewerName,
+                  viewerCount: share.viewerCount,
+                },
+              }));
+            } catch (error) {
+              console.error('❌ 处理屏幕共享列表响应失败:', error);
+            }
           }
           break;
           
         case 'screen-share-update':
           // 收到共享状态更新
-          console.log(`🔄 收到共享状态更新, shareId: ${message.shareId}, viewerId: ${message.viewerId}, viewerName: ${message.viewerName}`);
-          try {
-            const { screenShareService } = await import('../screenShare/ScreenShareService');
-            // 更新本地共享列表中的查看者信息
-            const share = (screenShareService as any).activeShares.get(message.shareId);
-            if (share && share.playerId === message.from) {
-              share.viewerId = message.viewerId;
-              share.viewerName = message.viewerName;
-              share.viewerCount = message.viewerCount ?? (message.viewerId ? 1 : 0);
-              (screenShareService as any).activeShares.set(message.shareId, share);
-               screenShareService.handleShareUpdate(message.shareId, message.viewerId, message.viewerName, message.viewerCount, message.from);
-              console.log(`✅ 共享状态已更新:`, { viewerId: message.viewerId, viewerName: message.viewerName });
-              
-              // 【事件驱动】触发自定义事件通知UI更新
+          {
+            const peerId = this.authenticatedPeerId(message, false);
+            const shareId = this.safeScreenShareId(message.shareId);
+            const viewerId = message.viewerId === undefined ? undefined : message.viewerId;
+            const viewerName = message.viewerName === undefined ? undefined : sanitizeUntrustedText(message.viewerName, MAX_PLAYER_NAME_LENGTH).trim();
+            const viewerCount = message.viewerCount === undefined
+              ? (viewerId ? 1 : 0)
+              : this.safeViewerCount(message.viewerCount);
+            if (!peerId || !shareId || (viewerId !== undefined && !isSafeIdentifier(viewerId))) break;
+            if (message.viewerName !== undefined && !viewerName) break;
+            if (message.viewerCount !== undefined && (typeof message.viewerCount !== 'number' || !Number.isSafeInteger(message.viewerCount) || message.viewerCount < 0 || message.viewerCount > 100_000)) break;
+            try {
+              const { screenShareService } = await import('../screenShare/ScreenShareService');
+              const activeShares = (screenShareService as any).activeShares as Map<string, any>;
+              const share = activeShares.get(shareId);
+              if (!share || share.playerId !== peerId) break;
+              share.viewerId = viewerId;
+              share.viewerName = viewerName;
+              share.viewerCount = viewerCount;
+              activeShares.set(shareId, share);
+              screenShareService.handleShareUpdate(shareId, viewerId, viewerName, viewerCount, peerId);
               window.dispatchEvent(new CustomEvent('screen-share-update', {
-                detail: {
-                  shareId: message.shareId,
-                  viewerId: message.viewerId,
-                  viewerName: message.viewerName,
-                  viewerCount: message.viewerCount,
-                }
+                detail: { shareId, viewerId, viewerName, viewerCount },
               }));
+            } catch (error) {
+              console.error('❌ 处理共享状态更新失败:', error);
             }
-          } catch (error) {
-            console.error('❌ 处理共享状态更新失败:', error);
           }
           break;
 
@@ -1350,31 +1788,47 @@ export class WebRTCClient {
               break;
             }
             const { remoteControlService } = await import('../remoteControl/RemoteControlService');
+            const session = this.authenticatedSession(message);
             switch (message.type) {
-              case 'remote-control-request':
-                remoteControlService.handleRequest(message.sessionId, message.from, message.fromName || '玩家', message.to);
+              case 'remote-control-request': {
+                const request = session;
+                const fromName = sanitizeUntrustedText(message.fromName, MAX_PLAYER_NAME_LENGTH).trim();
+                if (!request || !fromName) break;
+                remoteControlService.handleRequest(request.sessionId, request.peerId, fromName, this.localPlayerId);
                 break;
+              }
               case 'remote-control-accept':
-                await remoteControlService.handleAccept(message.sessionId, message.from, message.to);
+              {
+                if (!session || !remoteControlService.isSessionForPeer(session.sessionId, session.peerId)) break;
+                await remoteControlService.handleAccept(session.sessionId, session.peerId, this.localPlayerId);
                 break;
-              case 'remote-control-reject':
-                remoteControlService.handleReject(message.sessionId, message.from, message.to, message.reason || 'rejected');
+              }
+              case 'remote-control-reject': {
+                if (!session || !remoteControlService.isSessionForPeer(session.sessionId, session.peerId)) break;
+                const reason = sanitizeUntrustedText(message.reason, MAX_ANNOUNCEMENT_LENGTH).trim();
+                remoteControlService.handleReject(session.sessionId, session.peerId, this.localPlayerId, reason || 'rejected');
                 break;
-              case 'remote-control-offer':
-                if (!message.offer || typeof message.offer.sdp !== 'string') break;
-                await remoteControlService.handleOffer(message.sessionId, message.from, message.to, message.offer.sdp);
+              }
+              case 'remote-control-offer': {
+                if (!session || !remoteControlService.isSessionForPeer(session.sessionId, session.peerId) || !this.isSafeSessionDescription(message.offer, 'offer')) break;
+                await remoteControlService.handleOffer(session.sessionId, session.peerId, this.localPlayerId, message.offer.sdp);
                 break;
-              case 'remote-control-answer':
-                if (!message.answer || typeof message.answer.sdp !== 'string') break;
-                await remoteControlService.handleAnswer(message.sessionId, message.from, message.to, message.answer.sdp);
+              }
+              case 'remote-control-answer': {
+                if (!session || !remoteControlService.isSessionForPeer(session.sessionId, session.peerId) || !this.isSafeSessionDescription(message.answer, 'answer')) break;
+                await remoteControlService.handleAnswer(session.sessionId, session.peerId, this.localPlayerId, message.answer.sdp);
                 break;
-              case 'remote-control-ice':
-                if (!message.candidate || typeof message.candidate.candidate !== 'string') break;
-                await remoteControlService.handleIce(message.sessionId, message.from, message.to, message.candidate);
+              }
+              case 'remote-control-ice': {
+                if (!session || !remoteControlService.isSessionForPeer(session.sessionId, session.peerId) || !this.isSafeIceCandidate(message.candidate)) break;
+                await remoteControlService.handleIce(session.sessionId, session.peerId, this.localPlayerId, message.candidate);
                 break;
-              case 'remote-control-stop':
-                remoteControlService.handleStop(message.sessionId, message.from, message.to);
+              }
+              case 'remote-control-stop': {
+                if (!session || !remoteControlService.isSessionForPeer(session.sessionId, session.peerId)) break;
+                remoteControlService.handleStop(session.sessionId, session.peerId, this.localPlayerId);
                 break;
+              }
             }
           } catch (error) {
             console.error('❌ 处理远程控制消息失败:', error);
@@ -1383,100 +1837,81 @@ export class WebRTCClient {
           
         case 'file-share-added':
           // 收到文件共享添加通知
-          console.log(`📁 收到文件共享添加通知 from ${message.playerName}`);
-          try {
-            // 【事件驱动】触发自定义事件通知UI更新
+          {
+            const peerId = this.authenticatedPeerId(message, false);
+            const shareId = this.safeFileShareId(message.shareId);
+            const shareName = sanitizeUntrustedText(message.shareName, MAX_PATH_SEGMENT_LENGTH).trim();
+            const playerName = sanitizeUntrustedText(message.playerName, MAX_PLAYER_NAME_LENGTH).trim();
+            if (!peerId || !shareId || !shareName || !playerName || typeof message.hasPassword !== 'boolean') break;
             window.dispatchEvent(new CustomEvent('file-share-added', {
-              detail: {
-                shareId: message.shareId,
-                shareName: message.shareName,
-                playerId: message.from,
-                playerName: message.playerName,
-                hasPassword: message.hasPassword,
-              }
+              detail: { shareId, shareName, playerId: peerId, playerName, hasPassword: message.hasPassword },
             }));
-            console.log(`✅ 文件共享添加事件已触发`);
-          } catch (error) {
-            console.error('❌ 处理文件共享添加失败:', error);
           }
           break;
           
         case 'file-share-removed':
           // 收到文件共享删除通知
-          console.log(`📁 收到文件共享删除通知, shareId: ${message.shareId}`);
-          try {
-            // 【事件驱动】触发自定义事件通知UI更新
+          {
+            const peerId = this.authenticatedPeerId(message, false);
+            const shareId = this.safeFileShareId(message.shareId);
+            if (!peerId || !shareId) break;
             window.dispatchEvent(new CustomEvent('file-share-removed', {
-              detail: {
-                shareId: message.shareId,
-                playerId: message.from,
-              }
+              detail: { shareId, playerId: peerId },
             }));
-            console.log(`✅ 文件共享删除事件已触发`);
-          } catch (error) {
-            console.error('❌ 处理文件共享删除失败:', error);
           }
           break;
           
         case 'file-share-list-request':
           // 收到文件共享列表请求
-          console.log(`📋 收到文件共享列表请求 from ${message.from}`);
-          try {
-            // 获取本地共享列表
-            const localShares = await invoke<any[]>('get_local_shares');
-            
-            if (localShares && localShares.length > 0) {
-              console.log(`📤 发送 ${localShares.length} 个文件共享信息给 ${message.from}`);
-              
-              // 转换为前端格式
-              const shares = localShares.map(share => ({
-                shareId: share.id,
-                shareName: share.name,
-                playerName: this.localPlayerName,
-                hasPassword: !!share.password,
-              }));
-              
-              // 发送响应
-              this.sendWebSocketMessage({
-                type: 'file-share-list-response',
-                from: this.localPlayerId,
-                to: message.from,
-                shares: shares,
-              });
-            } else {
-              console.log(`📭 我没有活跃的文件共享`);
+          {
+            const peerId = this.authenticatedPeerId(message, false);
+            if (!peerId) break;
+            try {
+              const localShares = await invoke<any[]>('get_local_shares');
+              const shares = Array.isArray(localShares)
+                ? localShares.slice(0, 256).flatMap((share) => {
+                    if (!share || typeof share !== 'object') return [];
+                    const shareId = this.safeFileShareId(share.id);
+                    const shareName = sanitizeUntrustedText(share.name, MAX_PATH_SEGMENT_LENGTH).trim();
+                    if (!shareId || !shareName) return [];
+                    return [{ shareId, shareName, playerName: this.localPlayerName, hasPassword: !!share.password }];
+                  })
+                : [];
+              if (shares.length > 0) {
+                this.sendWebSocketMessage({
+                  type: 'file-share-list-response',
+                  from: this.localPlayerId,
+                  to: peerId,
+                  shares,
+                });
+              }
+            } catch (error) {
+              console.error('❌ 处理文件共享列表请求失败:', error);
             }
-          } catch (error) {
-            console.error('❌ 处理文件共享列表请求失败:', error);
           }
           break;
           
         case 'file-share-list-response':
           // 收到文件共享列表响应
-          console.log(`📥 收到文件共享列表响应 from ${message.from}, shares: ${message.shares?.length || 0}`);
-          try {
-            if (message.shares && Array.isArray(message.shares)) {
-              // 为每个共享触发添加事件
-              message.shares.forEach((share: any) => {
-                window.dispatchEvent(new CustomEvent('file-share-added', {
-                  detail: {
-                    shareId: share.shareId,
-                    shareName: share.shareName,
-                    playerId: message.from,
-                    playerName: share.playerName,
-                    hasPassword: share.hasPassword,
-                  }
-                }));
-              });
-              console.log(`✅ 文件共享列表已添加到UI`);
+          {
+            const peerId = this.authenticatedPeerId(message);
+            if (!peerId || !Array.isArray(message.shares) || message.shares.length > 256) break;
+            for (const rawShare of message.shares) {
+              if (!rawShare || typeof rawShare !== 'object') continue;
+              const share = rawShare as Record<string, unknown>;
+              const shareId = this.safeFileShareId(share.shareId);
+              const shareName = sanitizeUntrustedText(share.shareName, MAX_PATH_SEGMENT_LENGTH).trim();
+              const playerName = sanitizeUntrustedText(share.playerName, MAX_PLAYER_NAME_LENGTH).trim();
+              if (!shareId || !shareName || !playerName || typeof share.hasPassword !== 'boolean') continue;
+              window.dispatchEvent(new CustomEvent('file-share-added', {
+                detail: { shareId, shareName, playerId: peerId, playerName, hasPassword: share.hasPassword },
+              }));
             }
-          } catch (error) {
-            console.error('❌ 处理文件共享列表响应失败:', error);
           }
           break;
           
         default:
-          console.warn(`未知消息类型: ${message.type}`);
+           console.warn(`未知消息类型: ${messageType}`);
       }
     } catch (error) {
       console.error(`❌ 处理WebSocket消息失败:`, error);
@@ -1488,7 +1923,11 @@ export class WebRTCClient {
    */
   private async handleWebSocketOffer(message: any): Promise<void> {
     try {
-      const peerId = message.from;
+      const peerId = this.authenticatedPeerId(message);
+      if (!peerId || !this.isSafeSessionDescription(message.offer, 'offer')) {
+        console.warn('⚠️ 忽略未认证或格式无效的 Offer');
+        return;
+      }
       
       console.log(`📥 处理 Offer from ${peerId}`);
       
@@ -1660,7 +2099,11 @@ export class WebRTCClient {
    */
   private async handleWebSocketAnswer(message: any): Promise<void> {
     try {
-      const peerId = message.from;
+      const peerId = this.authenticatedPeerId(message);
+      if (!peerId || !this.isSafeSessionDescription(message.answer, 'answer')) {
+        console.warn('⚠️ 忽略未认证或格式无效的 Answer');
+        return;
+      }
       const peer = this.peerConnections.get(peerId);
       
       if (!peer) {
@@ -1696,7 +2139,11 @@ export class WebRTCClient {
    */
   private async handleWebSocketIceCandidate(message: any): Promise<void> {
     try {
-      const peerId = message.from;
+      const peerId = this.authenticatedPeerId(message);
+      if (!peerId || !this.isSafeIceCandidate(message.candidate)) {
+        console.warn('⚠️ 忽略未认证或格式无效的 ICE Candidate');
+        return;
+      }
       const peer = this.peerConnections.get(peerId);
       
       if (!peer) {
@@ -1726,24 +2173,51 @@ export class WebRTCClient {
    * 发送WebSocket消息（公开方法，供外部调用）
    */
   public sendWebSocketMessage(message: any): boolean {
+    if (!message || typeof message !== 'object' || Array.isArray(message)) {
+      return false;
+    }
+    const messageType = message.type;
+    if (!isSafeIdentifier(messageType, 64)) return false;
+    if (message.from !== undefined && message.from !== this.localPlayerId) {
+      console.warn('⚠️ 拒绝发送伪造发送者身份的信令消息');
+      return false;
+    }
+    if (message.to !== undefined && (!isSafeIdentifier(message.to) || message.to === this.localPlayerId || !this.knownPlayers.has(message.to))) {
+      console.warn('⚠️ 拒绝发送给未知信令目标');
+      return false;
+    }
+    if (messageType === 'status-update' && message.clientId !== this.localPlayerId) {
+      console.warn('⚠️ 拒绝发送伪造客户端身份的状态消息');
+      return false;
+    }
+    if (messageType === 'chat-message' && message.playerId !== this.localPlayerId) {
+      console.warn('⚠️ 拒绝发送伪造玩家身份的聊天消息');
+      return false;
+    }
+
     if (!this.websocket) {
-      console.error('❌ WebSocket实例不存在，无法发送消息:', message.type);
+      console.error('❌ WebSocket实例不存在，无法发送消息:', messageType);
       return false;
     }
 
     if (this.websocket.readyState === WebSocket.OPEN) {
       try {
-        this.websocket.send(JSON.stringify(message));
+        const serialized = JSON.stringify(message);
+        if (serialized.length > 512 * 1024) {
+          console.warn('⚠️ 拒绝发送过大的信令消息');
+          return false;
+        }
+        this.websocket.send(serialized);
         return true;
       } catch (error) {
-        console.error('❌ 发送WebSocket消息失败:', error, message.type);
+        console.error('❌ 发送WebSocket消息失败:', error, messageType);
         return false;
       }
     }
 
     const stateNames = ['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED'];
     const stateName = stateNames[this.websocket.readyState] || 'UNKNOWN';
-    console.error(`❌ WebSocket未就绪(${stateName})，无法发送消息:`, message.type);
+    console.error(`❌ WebSocket未就绪(${stateName})，无法发送消息:`, messageType);
     return false;
   }
 
@@ -2927,11 +3401,21 @@ export class WebRTCClient {
     virtualDomain?: string,
     useDomain?: boolean,
   ): void {
+    if (!isSafeIdentifier(playerId) || playerId === this.localPlayerId || !this.knownPlayers.has(playerId)) return;
+    const safePlayerName = sanitizeUntrustedText(playerName, MAX_PLAYER_NAME_LENGTH).trim() || tl('未知玩家', 'Unknown player');
+    const safeVirtualIp = isSafeVirtualIp(virtualIp) ? virtualIp.trim() : undefined;
+    const safeVirtualDomain = isSafeVirtualDomain(virtualDomain) ? virtualDomain.trim() : undefined;
+    const safeUseDomain = useDomain === true && !!safeVirtualIp && !!safeVirtualDomain;
     if (this.onPlayerJoinedCallback) {
-      this.onPlayerJoinedCallback(playerId, playerName, virtualIp, virtualDomain, useDomain);
+      this.onPlayerJoinedCallback(playerId, safePlayerName, safeVirtualIp, safeVirtualDomain, safeUseDomain);
       return;
     }
-    this.pendingPlayerJoined.set(playerId, { playerName, virtualIp, virtualDomain, useDomain });
+    this.pendingPlayerJoined.set(playerId, {
+      playerName: safePlayerName,
+      virtualIp: safeVirtualIp,
+      virtualDomain: safeVirtualDomain,
+      useDomain: safeUseDomain,
+    });
   }
 
   onPlayerLeft(callback: (playerId: string) => void): void {
@@ -2995,7 +3479,9 @@ export class WebRTCClient {
 
   /** 踢出玩家（仅房主有效） */
   kickPlayer(targetId: string): boolean {
-    return this.sendWebSocketMessage({ type: 'kick-player', from: this.localPlayerId, target: targetId });
+    const safeTargetId = sanitizeIdentifier(targetId);
+    if (!this.knownPlayers.has(safeTargetId) || safeTargetId === this.localPlayerId) return false;
+    return this.sendWebSocketMessage({ type: 'kick-player', from: this.localPlayerId, target: safeTargetId });
   }
 
   /**
@@ -3014,59 +3500,78 @@ export class WebRTCClient {
    * @returns 是否成功启动重连流程
    */
   async reconnectPeerVoice(peerId: string): Promise<boolean> {
-    if (!peerId || peerId === this.localPlayerId) {
+    const safePeerId = sanitizeIdentifier(peerId);
+    if (!this.knownPlayers.has(safePeerId) || safePeerId === this.localPlayerId) {
       return false;
     }
 
-    if (this.manualReconnectingPeers.has(peerId)) {
-      console.log(`⏳ 已在对 ${peerId} 进行语音重连，忽略重复请求`);
+    if (this.manualReconnectingPeers.has(safePeerId)) {
+      console.log('⏳ 已在进行语音重连，忽略重复请求');
       return false;
     }
 
-    this.manualReconnectingPeers.add(peerId);
+    this.manualReconnectingPeers.add(safePeerId);
     try {
-      console.log(`🔄 [语音重连] 开始重建与 ${peerId} 的语音连接`);
+      console.log('🔄 [语音重连] 开始重建语音连接');
 
       // 通知对方拆除旧连接（对端不识别该消息时会被忽略，此时退化为单端重建）
       this.sendWebSocketMessage({
         type: 'voice-reconnect',
         from: this.localPlayerId,
-        to: peerId,
+        to: safePeerId,
       });
 
       // 取消可能存在的自动重连调度，避免与手动重连冲突
-      this.clearPeerReconnectState(peerId);
+      this.clearPeerReconnectState(safePeerId);
 
       // 给对端一点时间完成拆除，再发起新的 Offer
       await new Promise(resolve => setTimeout(resolve, 300));
 
-      await this.handleReconnect(peerId, true);
-      console.log(`✅ [语音重连] 已向 ${peerId} 发起新的连接协商`);
+      await this.handleReconnect(safePeerId, true);
+      console.log('✅ [语音重连] 已发起新的连接协商');
       return true;
     } catch (error) {
-      console.error(`❌ [语音重连] 失败 (${peerId}):`, error);
+      console.error('❌ [语音重连] 失败:', error);
       return false;
     } finally {
       // 释放并发闸门，留出足够时间避免用户狂点
-      setTimeout(() => this.manualReconnectingPeers.delete(peerId), 3000);
+      setTimeout(() => this.manualReconnectingPeers.delete(safePeerId), 3000);
     }
   }
 
   /** 指定玩家当前是否正在进行手动语音重连 */
   isManualReconnecting(peerId: string): boolean {
-    return this.manualReconnectingPeers.has(peerId);
+    return this.manualReconnectingPeers.has(sanitizeIdentifier(peerId));
   }
   /** 禁言/解除禁言玩家（仅房主有效） */
   setPlayerMuted(targetId: string, muted: boolean): boolean {
-    return this.sendWebSocketMessage({ type: 'mute-player', from: this.localPlayerId, target: targetId, muted });
+    const safeTargetId = sanitizeIdentifier(targetId);
+    if (!this.knownPlayers.has(safeTargetId) || safeTargetId === this.localPlayerId || typeof muted !== 'boolean') return false;
+    return this.sendWebSocketMessage({ type: 'mute-player', from: this.localPlayerId, target: safeTargetId, muted });
   }
   /** 转让房主（仅房主有效） */
   transferHost(targetId: string): boolean {
-    return this.sendWebSocketMessage({ type: 'transfer-host', from: this.localPlayerId, target: targetId });
+    const safeTargetId = sanitizeIdentifier(targetId);
+    if (!this.knownPlayers.has(safeTargetId) || safeTargetId === this.localPlayerId) return false;
+    return this.sendWebSocketMessage({ type: 'transfer-host', from: this.localPlayerId, target: safeTargetId });
   }
   /** 设置大厅选项（仅房主有效），maxPlayers 传 0 表示取消上限 */
-  setLobbyOptions(opts: { maxPlayers?: number; isPublic?: boolean; description?: string; password?: string; serverNode?: string }): boolean {
-    return this.sendWebSocketMessage({ type: 'set-lobby-options', from: this.localPlayerId, ...opts });
+  setLobbyOptions(opts: { maxPlayers?: number; isPublic?: boolean; description?: string; serverNode?: string }): boolean {
+    const next: Record<string, unknown> = { type: 'set-lobby-options', from: this.localPlayerId };
+    if (opts.maxPlayers !== undefined) {
+      if (!Number.isSafeInteger(opts.maxPlayers) || opts.maxPlayers < 0 || opts.maxPlayers > 100_000) return false;
+      next.maxPlayers = opts.maxPlayers;
+    }
+    if (opts.isPublic !== undefined) {
+      if (typeof opts.isPublic !== 'boolean') return false;
+      next.isPublic = opts.isPublic;
+    }
+    if (opts.description !== undefined) next.description = sanitizeUntrustedText(opts.description, 200);
+    if (opts.serverNode !== undefined) {
+      if (!isSafeServerNode(opts.serverNode) || opts.serverNode === 'custom') return false;
+      next.serverNode = opts.serverNode;
+    }
+    return this.sendWebSocketMessage(next);
   }
 
   /**
@@ -3078,17 +3583,19 @@ export class WebRTCClient {
         throw new Error('WebSocket未连接');
       }
 
+      const safeContent = sanitizeUntrustedText(content, MAX_CHAT_TEXT_LENGTH);
+      if (!safeContent.trim()) throw new Error('消息内容不能为空');
       const message = {
         type: 'chat-message',
         from: this.localPlayerId,
         playerId: this.localPlayerId,
         playerName: this.localPlayerName,
-        content: content,
+        content: safeContent,
         timestamp: Date.now(),
       };
 
       this.sendWebSocketMessage(message);
-      console.log('📤 聊天消息已发送:', content);
+      console.log('📤 聊天消息已发送');
     } catch (error) {
       console.error('❌ 发送聊天消息失败:', error);
       throw error;
@@ -3134,6 +3641,16 @@ export class WebRTCClient {
         remoteControlService.handleSignalingDisconnected();
       } catch (error) {
         console.error('清理远程控制会话失败:', error);
+      }
+      this.chatToken = '';
+      this.chatTokenEpoch = 0;
+      this.chatHostId = undefined;
+      this.chatPeers.clear();
+      p2pChatService.reset();
+      try {
+        await invoke('stop_p2p_chat');
+      } catch (error) {
+        console.warn('停止聊天服务失败:', error);
       }
       
       // 清理重连定时器

--- a/src/stores/devtools.ts
+++ b/src/stores/devtools.ts
@@ -10,10 +10,17 @@ import { useAppStore } from './appStore';
  */
 export const printStoreState = (): void => {
   const state = useAppStore.getState();
+  const safeLobby = state.lobby ? { ...state.lobby, password: state.lobby.password ? '[redacted]' : undefined } : null;
+  const safeConfig = {
+    ...state.config,
+    autoLobby: state.config.autoLobby
+      ? { ...state.config.autoLobby, lobbyPassword: state.config.autoLobby.lobbyPassword ? '[redacted]' : undefined }
+      : state.config.autoLobby,
+  };
   console.group('📊 MCTier Store 状态');
   console.log('应用状态:', state.appState);
   console.log('错误信息:', state.errorMessage);
-  console.log('大厅信息:', state.lobby);
+  console.log('大厅信息:', safeLobby);
   console.log('玩家列表:', state.players);
   console.log('麦克风状态:', state.micEnabled);
   console.log('静音玩家:', Array.from(state.mutedPlayers));
@@ -21,7 +28,7 @@ export const printStoreState = (): void => {
   console.log('状态窗口收起:', state.statusWindowCollapsed);
   console.log('状态窗口位置:', state.statusWindowPosition);
   console.log('主窗口可见:', state.mainWindowVisible);
-  console.log('用户配置:', state.config);
+  console.log('用户配置:', safeConfig);
   console.groupEnd();
 };
 
@@ -131,11 +138,18 @@ export const createTestLobby = (): void => {
  */
 export const exportStoreState = (): string => {
   const state = useAppStore.getState();
+  const safeLobby = state.lobby ? { ...state.lobby, password: state.lobby.password ? '[redacted]' : undefined } : null;
+  const safeConfig = {
+    ...state.config,
+    autoLobby: state.config.autoLobby
+      ? { ...state.config.autoLobby, lobbyPassword: state.config.autoLobby.lobbyPassword ? '[redacted]' : undefined }
+      : state.config.autoLobby,
+  };
   return JSON.stringify(
     {
       appState: state.appState,
       errorMessage: state.errorMessage,
-      lobby: state.lobby,
+      lobby: safeLobby,
       players: state.players,
       micEnabled: state.micEnabled,
       mutedPlayers: Array.from(state.mutedPlayers),
@@ -143,7 +157,7 @@ export const exportStoreState = (): string => {
       statusWindowCollapsed: state.statusWindowCollapsed,
       statusWindowPosition: state.statusWindowPosition,
       mainWindowVisible: state.mainWindowVisible,
-      config: state.config,
+      config: safeConfig,
     },
     null,
     2

--- a/src/stores/persistence.ts
+++ b/src/stores/persistence.ts
@@ -5,6 +5,12 @@
 
 import { useAppStore } from './appStore';
 import type { UserConfig, WindowPosition } from '../types';
+import {
+  isSafeImageDataUrl,
+  isSafeServerNode,
+  isSafeVirtualDomain,
+  sanitizeUntrustedText,
+} from '../security/trustBoundary';
 
 /**
  * 本地存储键名
@@ -14,12 +20,117 @@ const STORAGE_KEYS = {
   WINDOW_POSITION: 'mctier_window_position',
 } as const;
 
+const MAX_CONFIG_FILE_BYTES = 256 * 1024;
+const MAX_CONFIG_LIST_ITEMS = 64;
+
+const finiteNumberInRange = (value: unknown, min: number, max: number): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? Math.max(min, Math.min(max, value)) : undefined;
+
+const safeString = (value: unknown, maxLength: number): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const sanitized = sanitizeUntrustedText(value, maxLength).trim();
+  return sanitized || undefined;
+};
+
+const normalizeWindowPosition = (value: unknown): WindowPosition | undefined => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const input = value as Record<string, unknown>;
+  const x = finiteNumberInRange(input.x, -100_000, 100_000);
+  const y = finiteNumberInRange(input.y, -100_000, 100_000);
+  const width = finiteNumberInRange(input.width, 100, 20_000);
+  const height = finiteNumberInRange(input.height, 100, 20_000);
+  if (x === undefined || y === undefined) return undefined;
+  return {
+    x: Math.trunc(x),
+    y: Math.trunc(y),
+    ...(width === undefined ? {} : { width: Math.trunc(width) }),
+    ...(height === undefined ? {} : { height: Math.trunc(height) }),
+  };
+};
+
+const normalizeStringList = (value: unknown, maxLength: number): string[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  const values = value
+    .slice(0, MAX_CONFIG_LIST_ITEMS)
+    .map((item) => safeString(item, maxLength))
+    .filter((item): item is string => !!item);
+  return values;
+};
+
+/**
+ * Import/storage data is untrusted JSON. Keep only fields understood by the
+ * frontend and deliberately drop lobby passwords; localStorage is not a
+ * secret store and old records are migrated by omission.
+ */
+export const sanitizePersistedConfig = (value: unknown): UserConfig => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const input = value as Record<string, unknown>;
+  const result: UserConfig = {};
+
+  if (input.language === 'system' || input.language === 'zh' || input.language === 'en') result.language = input.language;
+  const playerName = safeString(input.playerName, 64);
+  if (playerName) result.playerName = playerName;
+  if (isSafeImageDataUrl(input.avatarData)) result.avatarData = input.avatarData;
+  if (input.preferredServer === 'custom' || isSafeServerNode(input.preferredServer)) {
+    result.preferredServer = input.preferredServer;
+  }
+  const micHotkey = safeString(input.micHotkey, 64);
+  const globalMuteHotkey = safeString(input.globalMuteHotkey, 64);
+  const pushToTalkHotkey = safeString(input.pushToTalkHotkey, 64);
+  if (micHotkey) result.micHotkey = micHotkey;
+  if (globalMuteHotkey) result.globalMuteHotkey = globalMuteHotkey;
+  if (pushToTalkHotkey) result.pushToTalkHotkey = pushToTalkHotkey;
+  const windowPosition = normalizeWindowPosition(input.windowPosition);
+  if (windowPosition) result.windowPosition = windowPosition;
+  const audioDeviceId = safeString(input.audioDeviceId, 512);
+  if (audioDeviceId) result.audioDeviceId = audioDeviceId;
+  const opacity = finiteNumberInRange(input.opacity, 0, 1);
+  const voiceVolume = finiteNumberInRange(input.voiceVolume, 0, 1);
+  if (opacity !== undefined) result.opacity = opacity;
+  if (voiceVolume !== undefined) result.voiceVolume = voiceVolume;
+  if (typeof input.enableGpuRendering === 'boolean') result.enableGpuRendering = input.enableGpuRendering;
+  if (typeof input.autoStartup === 'boolean') result.autoStartup = input.autoStartup;
+
+  if (input.advancedNetwork && typeof input.advancedNetwork === 'object' && !Array.isArray(input.advancedNetwork)) {
+    const virtualDomain = (input.advancedNetwork as Record<string, unknown>).virtualDomain;
+    if (isSafeVirtualDomain(virtualDomain)) result.advancedNetwork = { virtualDomain: virtualDomain.trim() };
+  }
+
+  if (input.autoLobby && typeof input.autoLobby === 'object' && !Array.isArray(input.autoLobby)) {
+    const autoLobbyInput = input.autoLobby as Record<string, unknown>;
+    const autoLobby: NonNullable<UserConfig['autoLobby']> = {
+      enabled: typeof autoLobbyInput.enabled === 'boolean' ? autoLobbyInput.enabled : false,
+    };
+    const lobbyName = safeString(autoLobbyInput.lobbyName, 64);
+    const autoPlayerName = safeString(autoLobbyInput.playerName, 64);
+    if (lobbyName) autoLobby.lobbyName = lobbyName;
+    if (autoPlayerName) autoLobby.playerName = autoPlayerName;
+    if (typeof autoLobbyInput.useDomain === 'boolean') autoLobby.useDomain = autoLobbyInput.useDomain;
+    // Intentionally omit autoLobbyInput.lobbyPassword.
+    result.autoLobby = autoLobby;
+  }
+
+  if (input.exitNodeConfig && typeof input.exitNodeConfig === 'object' && !Array.isArray(input.exitNodeConfig)) {
+    const exitInput = input.exitNodeConfig as Record<string, unknown>;
+    const exitNodeConfig: NonNullable<UserConfig['exitNodeConfig']> = {};
+    if (typeof exitInput.enableExitNode === 'boolean') exitNodeConfig.enableExitNode = exitInput.enableExitNode;
+    if (typeof exitInput.enableAsExitNode === 'boolean') exitNodeConfig.enableAsExitNode = exitInput.enableAsExitNode;
+    const proxyCidrs = normalizeStringList(exitInput.proxyCidrs, 128);
+    const exitNodes = normalizeStringList(exitInput.exitNodes, 128);
+    if (proxyCidrs) exitNodeConfig.proxyCidrs = proxyCidrs;
+    if (exitNodes) exitNodeConfig.exitNodes = exitNodes;
+    result.exitNodeConfig = exitNodeConfig;
+  }
+
+  return result;
+};
+
 /**
  * 保存用户配置到本地存储
  */
 export const saveConfigToStorage = (config: UserConfig): void => {
   try {
-    const configJson = JSON.stringify(config);
+    const configJson = JSON.stringify(sanitizePersistedConfig(config));
     localStorage.setItem(STORAGE_KEYS.CONFIG, configJson);
   } catch (error) {
     console.error('保存配置失败:', error);
@@ -35,7 +146,7 @@ export const loadConfigFromStorage = (): UserConfig | null => {
     if (!configJson) {
       return null;
     }
-    return JSON.parse(configJson) as UserConfig;
+    return sanitizePersistedConfig(JSON.parse(configJson));
   } catch (error) {
     console.error('加载配置失败:', error);
     return null;
@@ -49,7 +160,9 @@ export const saveWindowPositionToStorage = (
   position: WindowPosition
 ): void => {
   try {
-    const positionJson = JSON.stringify(position);
+    const safePosition = normalizeWindowPosition(position);
+    if (!safePosition) return;
+    const positionJson = JSON.stringify(safePosition);
     localStorage.setItem(STORAGE_KEYS.WINDOW_POSITION, positionJson);
   } catch (error) {
     console.error('保存窗口位置失败:', error);
@@ -65,7 +178,7 @@ export const loadWindowPositionFromStorage = (): WindowPosition | null => {
     if (!positionJson) {
       return null;
     }
-    return JSON.parse(positionJson) as WindowPosition;
+    return normalizeWindowPosition(JSON.parse(positionJson)) ?? null;
   } catch (error) {
     console.error('加载窗口位置失败:', error);
     return null;
@@ -94,6 +207,9 @@ export const initializeStorePersistence = (): void => {
     const savedConfig = loadConfigFromStorage();
     if (savedConfig) {
       useAppStore.getState().updateConfig(savedConfig);
+      // Rewrite legacy entries so dropped secrets are removed immediately,
+      // even when the user does not change any setting this session.
+      saveConfigToStorage(savedConfig);
     }
 
     // 加载窗口位置
@@ -130,7 +246,7 @@ export const initializeStorePersistence = (): void => {
 export const exportConfigToFile = (): void => {
   try {
     const config = useAppStore.getState().config;
-    const configJson = JSON.stringify(config, null, 2);
+    const configJson = JSON.stringify(sanitizePersistedConfig(config), null, 2);
     const blob = new Blob([configJson], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -149,11 +265,18 @@ export const exportConfigToFile = (): void => {
 export const importConfigFromFile = (file: File): Promise<void> => {
   return new Promise((resolve, reject) => {
     try {
+      if (!file || typeof file.size !== 'number' || file.size > MAX_CONFIG_FILE_BYTES) {
+        reject(new Error('配置文件过大'));
+        return;
+      }
       const reader = new FileReader();
       reader.onload = (e) => {
         try {
-          const configJson = e.target?.result as string;
-          const config = JSON.parse(configJson) as UserConfig;
+          const configJson = e.target?.result;
+          if (typeof configJson !== 'string' || configJson.length > MAX_CONFIG_FILE_BYTES) {
+            throw new Error('配置文件过大');
+          }
+          const config = sanitizePersistedConfig(JSON.parse(configJson));
           useAppStore.getState().updateConfig(config);
           saveConfigToStorage(config);
           resolve();

--- a/tests/android-security.test.mjs
+++ b/tests/android-security.test.mjs
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const read = (relativePath) => fs.readFileSync(path.resolve(here, '..', relativePath), 'utf8');
+
+const manifest = read('MCTier-Android/app/src/main/AndroidManifest.xml');
+const networkSecurity = read('MCTier-Android/app/src/main/res/xml/network_security_config.xml');
+const mainActivity = read('MCTier-Android/app/src/main/java/top/pmh13/mctier/MainActivity.kt');
+const mctierApp = read('MCTier-Android/app/src/main/java/top/pmh13/mctier/ui/MctierApp.kt');
+const inviteCodec = read('MCTier-Android/app/src/main/java/top/pmh13/mctier/network/LobbyInviteCodec.kt');
+const vpnService = read('MCTier-Android/app/src/main/java/com/easytier/jni/EasyTierVpnService.kt');
+const voiceService = read('MCTier-Android/app/src/main/java/top/pmh13/mctier/service/VoiceForegroundService.kt');
+const repository = read('MCTier-Android/app/src/main/java/top/pmh13/mctier/MctierRepository.kt');
+const secureStore = read('MCTier-Android/app/src/main/java/top/pmh13/mctier/SecurePreferenceStore.kt');
+const models = read('MCTier-Android/app/src/main/java/top/pmh13/mctier/data/Models.kt');
+const chatServer = read('MCTier-Android/app/src/main/java/top/pmh13/mctier/network/ChatHttpServer.kt');
+const chatClient = read('MCTier-Android/app/src/main/java/top/pmh13/mctier/network/ChatP2PClient.kt');
+
+test('Android manifest keeps non-entry components private and disables global cleartext', () => {
+  assert.match(manifest, /android:usesCleartextTraffic="false"/);
+  assert.match(manifest, /android:name="\.PortraitCaptureActivity"[\s\S]*?android:exported="false"/);
+  assert.match(manifest, /android:name="\.service\.ScreenCaptureService"[\s\S]*?android:exported="false"/);
+  assert.match(manifest, /android:name="\.service\.VoiceForegroundService"[\s\S]*?android:exported="false"/);
+  assert.match(manifest, /android:name="com\.easytier\.jni\.EasyTierVpnService"[\s\S]*?android:exported="false"/);
+  assert.match(manifest, /android:name="\.service\.MctierAccessibilityService"[\s\S]*?android:exported="true"[\s\S]*?android:permission="android\.permission\.BIND_ACCESSIBILITY_SERVICE"/);
+  assert.doesNotMatch(manifest, /androidx\.core\.content\.FileProvider/);
+});
+
+test('network security allows cleartext only through explicit scoped exceptions', () => {
+  assert.match(networkSecurity, /<base-config\s+cleartextTrafficPermitted="false"\s*\/>/);
+  assert.match(networkSecurity, /<domain-config\s+cleartextTrafficPermitted="true">/);
+  assert.doesNotMatch(networkSecurity, /cleartextTrafficPermitted="true"[^>]*>\s*<\/base-config>/);
+});
+
+test('deep links require the registered VIEW route and clear URI credentials after handling', () => {
+  assert.match(mainActivity, /intent\?\.action\s*!=\s*Intent\.ACTION_VIEW/);
+  assert.match(mainActivity, /data\.host\.equals\("join",\s*ignoreCase\s*=\s*true\)/);
+  assert.match(mainActivity, /data\.path\.orEmpty\(\)\s*!in\s*setOf\("",\s*"\/"\)/);
+  assert.match(mainActivity, /intent\?\.let\s*\{\s*if\s*\(it\.data\s*==\s*data\)\s*it\.data\s*=\s*null\s*\}/);
+  assert.match(inviteCodec, /fun isValidLobbyPassword/);
+  assert.match(inviteCodec, /isUnsafeControl/);
+  assert.match(inviteCodec, /fun isValidEasyTierNode/);
+  assert.match(inviteCodec, /fun isValidSignalingServer/);
+  assert.match(mctierApp, /if \(state\.pendingJoin == null\) repository\.maybeAutoJoin\(\)/);
+});
+
+test('foreground services fail closed on invalid input or missing permission', () => {
+  assert.doesNotMatch(vpnService, /arrayListOf\("10\.0\.0\.0\/8"\)/);
+  assert.match(vpnService, /Rejecting invalid VPN start request/);
+  assert.match(manifest, /android\.permission\.FOREGROUND_SERVICE_SYSTEM_EXEMPTED/);
+  assert.match(manifest, /android:name="com\.easytier\.jni\.EasyTierVpnService"[\s\S]*?android:foregroundServiceType="systemExempted"/);
+  assert.match(vpnService, /ServiceInfo\.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED/);
+  assert.match(vpnService, /Build\.VERSION_CODES\.UPSIDE_DOWN_CAKE/);
+  assert.match(voiceService, /RECORD_AUDIO/);
+  assert.match(voiceService, /Rejecting voice foreground service without microphone permission/);
+  assert.match(voiceService, /Failed to start voice foreground service/);
+});
+
+test('lobby credentials use Keystore-backed encryption and no new plaintext writes', () => {
+  assert.match(secureStore, /AndroidKeyStore/);
+  assert.match(secureStore, /AES\/GCM\/NoPadding/);
+  assert.match(repository, /SecureAutoLobbyPasswordKey/);
+  assert.match(repository, /saveSecurePreference\(/);
+  assert.match(secureStore, /fun putStringRemoving/);
+  assert.match(secureStore, /\.remove\(legacyKey\)[\s\S]{0,80}\.commit\(\)/);
+  assert.match(repository, /securePrefs\.putStringRemoving/);
+  assert.doesNotMatch(repository, /putString\("autoLobbyPassword"/);
+  assert.doesNotMatch(repository, /putString\("favorites"/);
+  assert.doesNotMatch(repository, /putString\("recentLobbies"/);
+});
+
+test('Android P2P chat is gated by signaling token, epoch, and source IP identity', () => {
+  assert.match(models, /val chatToken: String\? = null/);
+  assert.match(models, /val chatTokenEpoch: Long\? = null/);
+  assert.match(repository, /"register-success"[\s\S]{0,1800}chatTokenEpoch/);
+  assert.match(repository, /"chat-token-rotated"[\s\S]{0,1400}rotateToken/);
+  assert.match(repository, /"player-left"[\s\S]{0,900}currentChatPeers\(setOf\(id\)\)/);
+  assert.doesNotMatch(repository, /ChatP2PClient\([^\n]+\)\.also\s*\{\s*it\.start/);
+
+  assert.match(chatServer, /ChatTokenHeader/);
+  assert.match(chatServer, /session\.remoteIpAddress/);
+  assert.match(chatServer, /snapshot\.identities\[source\]/);
+  assert.match(chatServer, /it is Inet4Address/);
+  assert.match(chatServer, /byteArrayOf\(10, 126, 126\)/);
+  assert.match(chatServer, /isMessageIdForPlayer/);
+  assert.match(chatServer, /messages\.any \{ it\.id == message\.id \}/);
+
+  assert.match(chatClient, /followRedirects\(false\)/);
+  assert.match(chatClient, /followSslRedirects\(false\)/);
+  assert.match(chatClient, /\.header\(ChatTokenHeader, token\)/);
+  assert.match(chatClient, /Chat send suppressed before authenticated session/);
+});
+
+test('public lobbies are passwordless and plaza metadata has no credential field', () => {
+  const publicLobbyWire = models.slice(
+    models.indexOf('data class PublicLobbyWire'),
+    models.indexOf('/** 收藏大厅'),
+  );
+  assert.doesNotMatch(publicLobbyWire, /val password/);
+  assert.match(inviteCodec, /if \(text\.isEmpty\(\)\) return true/);
+  assert.match(mctierApp, /onFill\(lobby\.lobbyName, "", lobby\.serverNode\)/);
+  assert.match(mctierApp, /Public lobbies must not have a password/);
+  assert.match(repository, /if \(isPublic && !_state\.value\.lobby\?\.password\.isNullOrEmpty\(\)\)/);
+  assert.doesNotMatch(repository, /password = publicPassword/);
+});

--- a/tests/file-transfer-security.test.mjs
+++ b/tests/file-transfer-security.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const rustServer = fs.readFileSync(new URL('../src-tauri/src/modules/file_transfer.rs', import.meta.url), 'utf8');
+const rustCommands = fs.readFileSync(new URL('../src-tauri/src/modules/tauri_commands.rs', import.meta.url), 'utf8');
+const androidServer = fs.readFileSync(new URL('../MCTier-Android/app/src/main/java/top/pmh13/mctier/network/FileShareHttpServer.kt', import.meta.url), 'utf8');
+const androidClient = fs.readFileSync(new URL('../MCTier-Android/app/src/main/java/top/pmh13/mctier/network/RemoteFileClient.kt', import.meta.url), 'utf8');
+const androidRepository = fs.readFileSync(new URL('../MCTier-Android/app/src/main/java/top/pmh13/mctier/MctierRepository.kt', import.meta.url), 'utf8');
+const fileShareManager = fs.readFileSync(new URL('../src/components/FileShareManager/FileShareManagerNew.tsx', import.meta.url), 'utf8');
+const tauriConfig = fs.readFileSync(new URL('../src-tauri/tauri.conf.json', import.meta.url), 'utf8');
+
+test('range handlers reject malformed intervals and clamp valid oversized ends', () => {
+  assert.match(rustServer, /fn resolve_range\(/);
+  assert.match(rustServer, /end\.unwrap_or\(file_size - 1\)\.min\(file_size - 1\)/);
+  assert.match(rustServer, /ByteRange::Suffix/);
+  assert.match(rustServer, /parse_range\(value\)\.ok_or\(StatusCode::RANGE_NOT_SATISFIABLE\)/);
+  assert.match(androidServer, /Regex\("\^bytes=.*RegexOption\.IGNORE_CASE\)/);
+  assert.match(rustServer, /status\(StatusCode::RANGE_NOT_SATISFIABLE\)/);
+  assert.match(androidServer, /if \(fileLen <= 0\) return rangeNotSatisfiable\(fileLen\)/);
+  assert.match(androidServer, /rangeEnd < rangeStart/);
+  assert.match(androidServer, /coerceAtMost\(fileLen - 1\)/);
+  assert.match(androidServer, /newChunkedResponse\(Response\.Status\.OK/);
+});
+
+test('downloads use unique exclusive temporary files and no-replace commit', () => {
+  assert.match(rustCommands, /create_new\(true\)/);
+  assert.match(rustCommands, /commit_download_part_noreplace\(&candidate, &destination\)\.await/);
+  assert.match(rustCommands, /tokio::fs::hard_link\(part_path, destination\)/);
+  assert.match(rustCommands, /status == reqwest::StatusCode::PARTIAL_CONTENT/);
+  assert.match(rustCommands, /status\.as_u16\(\) == 410/);
+  assert.match(rustCommands, /downloaded != limit/);
+  assert.match(androidClient, /UUID\.randomUUID\(\)/);
+  assert.match(androidClient, /StandardOpenOption\.CREATE_NEW/);
+  assert.match(androidClient, /if \(resp\.code == 206\) error/);
+  assert.match(androidClient, /Files\.move\(partFile\.toPath\(\), outFile\.toPath\(\)\)/);
+  assert.match(androidClient, /expectedSize/);
+  assert.match(androidClient, /if \(expectedLength != null && downloaded != expectedLength\)/);
+});
+
+test('public metadata and verification stay bounded', () => {
+  const androidDto = androidServer.slice(androidServer.indexOf('private data class ShareDto'), androidServer.indexOf('private data class VerifyPasswordRequest'));
+  assert.match(rustServer, /pub has_password: bool/);
+  assert.match(androidServer, /MaxVerifyBodyBytes = 16 \* 1024/);
+  assert.doesNotMatch(androidDto, /val password/);
+  assert.match(androidServer, /hasPassword = !password\.isNullOrBlank\(\).*password\.isNotBlank\(\)/s);
+  assert.doesNotMatch(rustServer, /legacy_password|normalized\(/);
+});
+
+test('file servers stay on the overlay and batch responses stream from disk', () => {
+  assert.match(androidServer, /NanoHTTPD\(requireOverlayBindIp\(bindIp\), FileSharePort\)/);
+  assert.doesNotMatch(androidServer, /NanoHTTPD\("0\.0\.0\.0", FileSharePort\)/);
+  assert.match(rustServer, /spawn_blocking[\s\S]*build_batch_zip\([\s\S]*permit/);
+  assert.match(rustServer, /create_temp_file_stream\(zip_file, zip_path, zip_size, permit\)/);
+  assert.match(rustServer, /struct PreparedBatchZip/);
+  assert.match(rustServer, /struct ShareValidityReader/);
+  assert.match(rustServer, /ensure_share_current\(&self\.shared_folders/);
+  assert.match(rustServer, /MAX_BATCH_FILES/);
+  assert.match(rustServer, /MAX_BATCH_SOURCE_BYTES/);
+  assert.doesNotMatch(rustServer, /tokio::fs::read\(&zip_path\)/);
+});
+
+test('file clients only contact current routed lobby peers through native commands', () => {
+  assert.match(rustCommands, /fn require_file_peer_host/);
+  assert.match(rustCommands, /allowed_peer_ips/);
+  assert.match(rustCommands, /local\.octets\(\)\[\.\.3\] != target\.octets\(\)\[\.\.3\]/);
+  assert.match(fileShareManager, /invoke<unknown>\('get_remote_files'/);
+  assert.doesNotMatch(fileShareManager, /fetch\([\s\S]{0,240}:14539/);
+  assert.doesNotMatch(tauriConfig, /http:\/\/\*:14539/);
+  assert.match(androidClient, /contentEquals\(byteArrayOf\(10, 126, 126\)\)/);
+  assert.match(androidRepository, /isAuthoritativePeer/);
+  assert.match(androidRepository, /networkController\.peerConnectionTypes\(\)/);
+});
+
+test('file access is revoked by the signaling-issued lobby token', () => {
+  assert.match(rustServer, /LOBBY_TOKEN_HEADER/);
+  assert.match(rustServer, /fn authenticate_lobby/);
+  assert.match(rustServer, /pub fn set_lobby_token/);
+  assert.match(rustCommands, /set_lobby_token\(file_token\)/);
+  assert.match(rustCommands, /LOBBY_TOKEN_HEADER[\s\S]{0,160}&target\.token/);
+  assert.match(androidServer, /fun configureLobbyToken/);
+  assert.match(androidServer, /private fun authenticateLobby/);
+  assert.match(androidServer, /byteArrayOf\(10, 126, 126\)/);
+  assert.match(androidClient, /fun listShares[\s\S]{0,500}authorizeLobby\(lobbyToken\)/);
+  assert.match(androidClient, /fun listFiles[\s\S]{0,900}authorizeLobby\(lobbyToken\)/);
+  assert.match(androidClient, /fun download[\s\S]{0,3000}authorizeLobby\(lobbyToken\)/);
+  assert.match(androidRepository, /fileServer\?\.configureLobbyToken/);
+});
+
+test('ZIP extraction normalizes paths and enforces rollback budgets', () => {
+  assert.match(rustCommands, /safe_zip_entry_path/);
+  assert.match(rustCommands, /MAX_ZIP_ENTRIES/);
+  assert.match(rustCommands, /MAX_ZIP_ENTRY_UNCOMPRESSED_BYTES/);
+  assert.match(rustCommands, /MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES/);
+  assert.match(rustCommands, /entry\.is_symlink\(\)/);
+  assert.match(rustCommands, /拒绝ZIP中的重复条目/);
+  assert.match(rustCommands, /max_total_bytes: Option<u64>/);
+  assert.match(rustCommands, /created_files\.iter\(\)\.rev\(\)/);
+  assert.match(rustCommands, /created_dirs\.iter\(\)\.rev\(\)/);
+});

--- a/tests/supply-chain-update.test.mjs
+++ b/tests/supply-chain-update.test.mjs
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+test('desktop update metadata is bounded and cannot follow redirects', () => {
+  const service = read('src/services/version/VersionCheckService.ts');
+  assert.match(service, /redirect:\s*'error'/);
+  assert.match(service, /MAX_VERSION_RESPONSE_BYTES\s*=\s*256\s*\*\s*1024/);
+  assert.match(service, /getReader\(\)/);
+  assert.match(service, /\^\[0-9a-f\]\{40\}\$/i);
+  assert.match(service, /per_page=100&page=1/);
+});
+
+test('Android update metadata is bounded and rejects redirects', () => {
+  const checker = read('MCTier-Android/app/src/main/java/top/pmh13/mctier/network/UpdateChecker.kt');
+  assert.match(checker, /followRedirects\(false\)/);
+  assert.match(checker, /followSslRedirects\(false\)/);
+  assert.match(checker, /MaxVersionResponseBytes\s*=\s*256\s*\*\s*1024L/);
+  assert.match(checker, /readLimitedBody/);
+  assert.match(checker, /CommitShaPattern/);
+});
+
+test('binary fetch script constrains network, archive, and publication paths', () => {
+  const script = read('scripts/fetch-binaries.ps1');
+  assert.match(script, /AllowAutoRedirect\s*=\s*\$false/);
+  assert.match(script, /MaximumArchiveBytes\s*=\s*128MB/);
+  assert.match(script, /MaximumExtractedBytes\s*=\s*128MB/);
+  assert.match(script, /MaximumEntryCount\s*=\s*1000/);
+  assert.match(script, /totalExtractedBytes/);
+  assert.match(script, /Test-AllowedDownloadUri/);
+  assert.match(script, /Test-ZipArchive/);
+  assert.match(script, /Copy-VerifiedZipEntries/);
+  assert.match(script, /Assert-SafeTargetDirectory/);
+  assert.match(script, /ReparsePoint/);
+  assert.doesNotMatch(script, /New-Item[^\n]*-LiteralPath/);
+  assert.doesNotMatch(script, /\$host\s*=/i);
+  assert.doesNotMatch(script, /ContentLength\.Value/);
+  assert.doesNotMatch(script, /Expand-Archive/);
+});
+
+test('EasyTier JNI build pins source and locks Cargo dependencies', () => {
+  const script = read('MCTier-Android/scripts/build-easytier-jni.ps1');
+  assert.match(script, /Test-OfficialEasyTierRepo/);
+  assert.match(script, /Test-ImmutableRevision/);
+  assert.match(script, /Assert-CleanGitWorkTree/);
+  assert.match(script, /status --porcelain=v1 --untracked-files=all/);
+  assert.match(script, /github\.com\/EasyTier\/EasyTier\.git/);
+  assert.match(script, /cargo build --target \$rustTarget --release --locked/);
+  assert.match(script, /git -C \$EasyTierRoot fetch --no-tags origin \$Rev/);
+});
+
+test('CI actions and Gradle distribution use immutable or verified sources', () => {
+  const workflow = read('.github/workflows/ci.yml');
+  for (const line of workflow.split(/\r?\n/).filter((entry) => entry.includes('uses:'))) {
+    assert.match(line, /@[0-9a-f]{40}/i, `mutable action reference: ${line}`);
+  }
+  assert.equal((workflow.match(/persist-credentials:\s*false/g) ?? []).length, 5);
+  assert.match(workflow, /cargo-audit --version 0\.22\.2 --locked/);
+  assert.match(workflow, /cargo-deny --version 0\.20\.2 --locked/);
+
+  const wrapper = read('MCTier-Android/gradle/wrapper/gradle-wrapper.properties');
+  assert.match(wrapper, /distributionUrl=https\\:\/\/services\.gradle\.org\/distributions\//);
+  assert.match(wrapper, /distributionSha256Sum=[0-9a-f]{64}/i);
+});

--- a/tests/tauri-command-security.test.mjs
+++ b/tests/tauri-command-security.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+const commands = read('src-tauri/src/modules/tauri_commands.rs');
+const configManager = read('src-tauri/src/modules/config_manager.rs');
+const cargoManifest = read('src-tauri/Cargo.toml');
+const capability = JSON.parse(read('src-tauri/capabilities/default.json'));
+const config = JSON.parse(read('src-tauri/tauri.conf.json'));
+
+test('desktop capabilities keep opener disabled and shell URLs narrowly scoped', () => {
+  assert.doesNotMatch(capability.permissions.join('\n'), /^opener:/m);
+  assert.ok(capability.permissions.includes('shell:allow-open'));
+  assert.equal(
+    config.plugins.shell.open,
+    'https://(?:mctier\\.pmhs\\.top|www\\.mcmod\\.cn|github\\.com|gitee\\.com|webrtc\\.googlesource\\.com|www\\.wintun\\.net|reqrypt\\.org|npcap\\.com)(?:[/?#][^\\s]*)?\\z',
+  );
+  assert.doesNotMatch(config.plugins.shell.open, /file:|javascript:|mailto:|tel:/i);
+});
+
+test('generic filesystem commands require scoped grants and reject link/path tricks', () => {
+  assert.match(commands, /fn normalize_local_path[\s\S]{0,5000}symlink_metadata/);
+  assert.match(commands, /fn normalize_local_path[\s\S]{0,5000}validate_local_path_component/);
+  assert.match(commands, /pub async fn read_file_bytes[\s\S]{0,900}require_existing_file_grant/);
+  assert.match(commands, /pub async fn write_file_bytes[\s\S]{0,1000}require_path_grant/);
+  assert.match(commands, /pub async fn read_file\([\s\S]{0,900}require_existing_file_grant/);
+  assert.match(commands, /pub async fn save_file\([\s\S]{0,1000}require_path_grant/);
+  assert.match(commands, /pub async fn delete_file\([\s\S]{0,500}require_existing_file_grant/);
+  assert.match(commands, /pub async fn open_file_location[\s\S]{0,700}require_existing_file_grant/);
+  assert.match(commands, /pub async fn open_folder[\s\S]{0,700}require_existing_directory_grant/);
+  assert.match(commands, /value\.contains\(':'\)/);
+  assert.match(commands, /create_new\(true\)/);
+});
+
+test('system process launches avoid PATH and shell-script interpolation in Tauri commands', () => {
+  for (const executable of ['taskkill', 'tasklist', 'ipconfig', 'netsh', 'reg', 'explorer', 'notepad', 'powershell']) {
+    assert.doesNotMatch(commands, new RegExp(`Command::new\\(\\"${executable}\\"\\)`));
+    assert.doesNotMatch(commands, new RegExp(`process::Command::new\\(\\"${executable}\\"\\)`));
+  }
+  assert.match(commands, /windows_system_command\("WindowsPowerShell\\\\v1\.0\\\\powershell\.exe"\)/);
+  assert.match(commands, /Start-Process -FilePath \$env:MCTIER_EXE -Verb RunAs/);
+  assert.doesNotMatch(commands, /Start-Process[^\n]*format!\(/);
+});
+
+test('ping command validates an IP before passing it as one process argument', () => {
+  assert.match(commands, /parse::<std::net::IpAddr>\(\)/);
+  assert.match(commands, /\.args\(\["-n", "2", "-w", "1000", &target\]\)/);
+  assert.match(commands, /\.args\(\["-c", "2", "-W", "1", &target\]\)/);
+});
+
+test('P2P chat commands use signaling-issued sessions and authoritative peers', () => {
+  assert.match(commands, /pub async fn configure_p2p_chat[\s\S]{0,1600}set_session\(/);
+  assert.match(commands, /pub async fn configure_p2p_chat[\s\S]{0,2200}start_server\(\)/);
+  assert.match(commands, /pub async fn stop_p2p_chat[\s\S]{0,700}stop_server\(\)/);
+  assert.match(commands, /pub async fn send_p2p_chat_message[\s\S]{0,4200}authoritative_peers\(\)/);
+  assert.match(commands, /pub async fn send_p2p_chat_message[\s\S]{0,7000}CHAT_TOKEN_HEADER/);
+  assert.match(commands, /pub async fn get_p2p_chat_messages[\s\S]{0,1800}authoritative_peers\(\)/);
+  assert.match(commands, /pub async fn get_p2p_chat_messages[\s\S]{0,5000}read_remote_body_limited/);
+  assert.match(commands, /redirect\(reqwest::redirect::Policy::none\(\)\)/);
+});
+
+test('desktop auto-lobby password stays in the OS credential store', () => {
+  assert.match(cargoManifest, /Win32_Security_Credentials/);
+  assert.match(commands, /CredReadW/);
+  assert.match(commands, /CredWriteW/);
+  assert.match(commands, /CRED_PERSIST_LOCAL_MACHINE/);
+  assert.match(commands, /auto_lobby_session_secret/);
+  assert.match(commands, /spawn_blocking\(read_auto_lobby_secret\)/);
+  assert.match(commands, /lobby_password:\s*None/);
+  assert.match(commands, /"lobbyPassword": lobby_password/);
+  assert.match(configManager, /#\[serde\(default, skip_serializing\)\][\s\S]{0,100}pub lobby_password/);
+});

--- a/tests/trust-boundary.test.mjs
+++ b/tests/trust-boundary.test.mjs
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isSafeHttpUrl,
+  isSafeIdentifier,
+  isSafeChatToken,
+  isSafeImageDataUrl,
+  isSafePathSegment,
+  isSafeRelativePath,
+  isSafeResourceId,
+  isSafeSessionId,
+  isSafeServerNode,
+  isSafeSignalingServer,
+  isSafeVirtualDomain,
+  isSafeVirtualIp,
+  sanitizeTodoItems,
+  sanitizeUntrustedText,
+} from '../src/security/trustBoundary.ts';
+import fs from 'node:fs';
+
+const publicLobbiesSource = fs.readFileSync(new URL('../src/services/lobby/publicLobbies.ts', import.meta.url), 'utf8');
+const hostPanelSource = fs.readFileSync(new URL('../src/components/HostPanel/HostPanel.tsx', import.meta.url), 'utf8');
+const lobbyFormSource = fs.readFileSync(new URL('../src/components/LobbyForm/LobbyForm.tsx', import.meta.url), 'utf8');
+const webRtcSource = fs.readFileSync(new URL('../src/services/webrtc/WebRTCClient.ts', import.meta.url), 'utf8');
+
+test('endpoint validation rejects executable schemes, credentials, and control characters', () => {
+  assert.equal(isSafeSignalingServer('wss://mctier.pmhs.top/signaling'), true);
+  assert.equal(isSafeSignalingServer('https://mctier.pmhs.top/signaling'), false);
+  assert.equal(isSafeSignalingServer('wss://user:password@example.com/signaling'), false);
+  assert.equal(isSafeSignalingServer('wss://example.com/\nattack'), false);
+
+  assert.equal(isSafeServerNode('udp://us01.225284.xyz:11010'), true);
+  assert.equal(isSafeServerNode('javascript://example.com'), false);
+  assert.equal(isSafeServerNode('udp://user:password@example.com:11010'), false);
+  assert.equal(isSafeServerNode('custom'), true);
+});
+
+test('external link and image validation use narrow allowlists', () => {
+  assert.equal(isSafeHttpUrl('https://example.com/path?q=1'), true);
+  assert.equal(isSafeHttpUrl('javascript:alert(1)'), false);
+  assert.equal(isSafeHttpUrl('file:///C:/secrets.txt'), false);
+  assert.equal(isSafeImageDataUrl('data:image/jpeg;base64,AAECAwQ='), true);
+  assert.equal(isSafeImageDataUrl('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4='), false);
+  assert.equal(isSafeImageDataUrl('https://example.com/avatar.png'), false);
+});
+
+test('remote text and collaboration items are bounded and typed', () => {
+  assert.equal(sanitizeUntrustedText('<script>\u0000hello', 100), '<script>hello');
+  assert.equal(isSafeVirtualIp('10.126.126.1'), true);
+  assert.equal(isSafeVirtualIp('10.126.126.254'), true);
+  assert.equal(isSafeVirtualIp('10.126.126.0'), false);
+  assert.equal(isSafeVirtualIp('10.126.126.255'), false);
+  assert.equal(isSafeVirtualIp('10.126.125.1'), false);
+  assert.equal(isSafeVirtualIp('192.168.1.10'), false);
+  assert.equal(isSafeVirtualIp('0.0.0.0'), false);
+  assert.equal(isSafeVirtualIp('127.0.0.1'), false);
+  assert.equal(isSafeVirtualIp('169.254.1.1'), false);
+  assert.equal(isSafeVirtualIp('224.0.0.1'), false);
+  assert.equal(isSafeVirtualIp('255.255.255.255'), false);
+  assert.equal(isSafeVirtualIp('999.1.1.1'), false);
+  assert.equal(isSafeVirtualDomain('player-1.mctier'), true);
+  assert.equal(isSafeVirtualDomain('player..mctier'), false);
+
+  const safe = sanitizeTodoItems([
+    { id: 'todo-1', text: '<b>build</b>', done: false, assignee: '', creator: 'alice', ts: 1 },
+    { id: 'bad', text: 42, done: false, assignee: '', creator: 'mallory', ts: 2 },
+  ]);
+  assert.deepEqual(safe, [{ id: 'todo-1', text: '<b>build</b>', done: false, assignee: '', creator: 'alice', ts: 1 }]);
+});
+
+test('chat credentials are fixed-size hexadecimal values', () => {
+  assert.equal(isSafeChatToken('a'.repeat(64)), true);
+  assert.equal(isSafeChatToken('A'.repeat(64)), true);
+  assert.equal(isSafeChatToken('a'.repeat(63)), false);
+  assert.equal(isSafeChatToken(`${'a'.repeat(63)}g`), false);
+});
+
+test('desktop chat and file authorization fail closed when session synchronization fails', () => {
+  assert.match(webRtcSource, /failClosedChatSession[\s\S]{0,900}invoke\('stop_p2p_chat'\)/);
+  assert.match(webRtcSource, /chat-token-rotated[\s\S]{0,1200}failClosedChatSession/);
+  assert.match(webRtcSource, /撤销离开玩家的聊天权限失败[\s\S]{0,120}break/);
+});
+
+test('resource identifiers and relative file paths cannot change addressing', () => {
+  assert.equal(isSafeIdentifier('player-1234-a1'), true);
+  assert.equal(isSafeIdentifier('player/../other'), false);
+  assert.equal(isSafeResourceId('share-player-1234'), true);
+  assert.equal(isSafeResourceId('share/player'), false);
+  assert.equal(isSafeSessionId('rc-player-1234'), true);
+  assert.equal(isSafeSessionId('rc player'), false);
+  assert.equal(isSafePathSegment('maps'), true);
+  assert.equal(isSafePathSegment('..'), false);
+  assert.equal(isSafeRelativePath('maps/world.zip'), true);
+  assert.equal(isSafeRelativePath('../secrets.txt'), false);
+  assert.equal(isSafeRelativePath('maps\\world.zip'), false);
+});
+
+test('public plaza never transports a lobby password', () => {
+  assert.doesNotMatch(publicLobbiesSource, /^\s*password\??:/m);
+  assert.match(hostPanelSource, /Public lobbies must not have a password/);
+  assert.match(lobbyFormSource, /password:\s*''/);
+});

--- a/tests/version-policy.test.mjs
+++ b/tests/version-policy.test.mjs
@@ -1,6 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { DOWNLOAD_WEBSITE, compareVersions, newestVersionTag } from '../src/services/version/versionPolicy.ts';
+import {
+  DOWNLOAD_WEBSITE,
+  compareVersions,
+  isReleaseVersion,
+  newestVersionTag,
+  normalizeReleaseVersion,
+} from '../src/services/version/versionPolicy.ts';
 
 test('manual updates always target the official MCTier website', () => {
   assert.equal(DOWNLOAD_WEBSITE, 'https://mctier.pmhs.top');
@@ -15,4 +21,13 @@ test('version comparison is numeric rather than lexical', () => {
 test('newest tag does not depend on the Gitee response order', () => {
   const newest = newestVersionTag([{ name: 'v2.5.0' }, { name: 'v2.10.0' }, { name: 'v2.6.0' }]);
   assert.equal(newest?.name, 'v2.10.0');
+});
+
+test('release metadata accepts only bounded numeric x.y.z tags', () => {
+  assert.equal(normalizeReleaseVersion('v2.8.0'), '2.8.0');
+  assert.equal(isReleaseVersion('2.8.0'), true);
+  assert.equal(normalizeReleaseVersion('2.8.0.exe'), null);
+  assert.equal(normalizeReleaseVersion('2.8.0-rc1'), null);
+  assert.equal(normalizeReleaseVersion('999999999999.0.0'), null);
+  assert.equal(newestVersionTag([{ name: 'v999999999999.0.0' }, { name: 'v2.8.0' }])?.name, 'v2.8.0');
 });


### PR DESCRIPTION
## 概要

配套信令服务器 PR：[MCTier-Signaling-Server#2](https://github.com/pmh1314520/MCTier-Signaling-Server/pull/2)。两者需要一起部署，不兼容旧的未认证 P2P 协议。

这次安全修复覆盖 Desktop、Android 与两者共享的 P2P 服务边界，并已基于当前 `master` 重新审查上游已有修复。

- 使用信令签发的 32-byte token + epoch 认证聊天与文件 HTTP 服务；成员变更、踢出、离开和重连时轮换/撤销，认证状态同步失败时 fail closed
- 将成员身份绑定到权威 playerId/name/virtualIp 名册，并把所有原生 HTTP 目标限制在固定 EasyTier 网段 `10.126.126.1-254`，阻断自报地址造成的 SSRF
- 加固文件共享的路径授权、symlink/reparse、ZIP 解压预算与回滚、Range、响应体/下载上限、原子 no-replace、临时文件与并发压缩生命周期
- 保留并加强上游屏幕共享/远程控制的 session/peer/request 绑定，同时校验成员、目标、SDP/ICE、资源 ID 与事件 payload
- 收紧 Tauri 文件命令与外链能力：一次性路径授权、移除通用 opener、shell URL 使用明确域名白名单
- Android 加固 Intent/deep link、Keystore 偏好存储、VPN/前台服务/Accessibility、FileProvider 暴露面与 P2P 服务绑定
- 更新存在 RustSec 漏洞的依赖，并收紧二进制下载、JNI 构建、Gradle wrapper 与 CI 供应链
- 公开大厅固定为无密码：带密码大厅不能发布，广场列表与加入流程不存储、传输或索取密码
- 不兼容旧的未认证 P2P 协议；需要与信令服务器配套 PR 一起部署

## 验证

- `npm test`: 67/67
- `npm run build`: 通过
- `cargo fmt --all -- --check`: 通过
- `cargo check --locked --offline`: 通过
- `cargo test --locked --offline --lib`: 152/152
- `cargo audit --no-fetch`: 无未允许漏洞；剩余 23 条上游维护性/unsound 警告
- `MCTier-Android\\gradlew.bat :app:compileDebugKotlin --no-daemon`: 通过

## 残余风险

- `mctier://` 自定义 scheme 仍可能被其他应用抢注；完整修复需 HTTPS App Links、assetlinks 与邀请 token 设计
- 共享根目录父路径的 symlink/junction TOCTOU 无法仅靠路径复核完全消除
- SAF DocumentProvider 无法保证所有实现都提供真正原子 no-replace
- 更新元数据目前依赖 TLS、重定向/大小/格式约束，尚无发布清单数字签名
- Gradle wrapper JAR 尚未增加仓库外独立哈希信任根

EasyTier 内核本身不在本次审计范围内。