### PR TITLE
fix(security): enforce overlay targets and bounded helper authentication

### DIFF
--- a/src-tauri/src/modules/helper_handshake.rs
+++ b/src-tauri/src/modules/helper_handshake.rs
@@ -1,0 +1,87 @@
+use std::io::{ErrorKind, Read};
+use std::net::{TcpListener, TcpStream};
+use std::time::{Duration, Instant};
+
+/// Invalid or stalled candidates cannot consume the entire authorization wait.
+pub fn accept_authenticated(
+    listener: TcpListener,
+    expected: &str,
+    timeout: Duration,
+) -> Result<TcpStream, String> {
+    listener.set_nonblocking(true).map_err(|e| e.to_string())?;
+    let deadline = Instant::now() + timeout;
+    let expected = format!("{expected}\n").into_bytes();
+    let mut candidates: Vec<(TcpStream, Vec<u8>, Instant)> = Vec::new();
+    while Instant::now() < deadline {
+        // Bound both accept work per iteration and memory used by unauthenticated peers.
+        for _ in 0..32 {
+            match listener.accept() {
+                Ok((stream, peer)) if peer.ip().is_loopback() && candidates.len() < 32 => {
+                    if stream.set_nonblocking(true).is_ok() {
+                        candidates.push((
+                            stream,
+                            Vec::with_capacity(expected.len()),
+                            Instant::now(),
+                        ));
+                    }
+                }
+                Ok(_) => {}
+                Err(e) if e.kind() == ErrorKind::WouldBlock => break,
+                Err(e) => return Err(e.to_string()),
+            }
+        }
+        let mut index = 0;
+        while index < candidates.len() {
+            let (stream, received, started) = &mut candidates[index];
+            let mut bytes = vec![0; expected.len() - received.len()];
+            let keep = match stream.read(&mut bytes) {
+                Ok(0) => false,
+                Ok(n) => {
+                    received.extend_from_slice(&bytes[..n]);
+                    expected.starts_with(received)
+                }
+                Err(e) => e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::Interrupted,
+            };
+            if keep && received == &expected {
+                let (stream, _, _) = candidates.swap_remove(index);
+                stream.set_nonblocking(false).map_err(|e| e.to_string())?;
+                return Ok(stream);
+            }
+            if !keep || started.elapsed() >= Duration::from_secs(1) {
+                candidates.swap_remove(index);
+            } else {
+                index += 1;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Err("等待特权 helper 认证超时，请确认已允许授权请求".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    #[test]
+    fn invalid_and_stalled_clients_do_not_block_valid_helper() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let worker = std::thread::spawn(move || {
+            accept_authenticated(listener, "secret", Duration::from_secs(2)).unwrap()
+        });
+        let _stalled = TcpStream::connect(addr).unwrap();
+        let mut bad = TcpStream::connect(addr).unwrap();
+        bad.write_all(&[b'x'; 4096]).unwrap();
+        let mut valid = TcpStream::connect(addr).unwrap();
+        valid.write_all(b"secret\n").unwrap();
+        assert!(worker.join().unwrap().peer_addr().is_ok());
+    }
+    #[test]
+    fn timeout_is_absolute_even_with_a_silent_connection() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let _silent = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let start = Instant::now();
+        assert!(accept_authenticated(listener, "secret", Duration::from_millis(80)).is_err());
+        assert!(start.elapsed() < Duration::from_secs(1));
+    }
+}

--- a/src-tauri/src/modules/mc_lan_bridge.rs
+++ b/src-tauri/src/modules/mc_lan_bridge.rs
@@ -87,6 +87,9 @@ fn pipe(mut a: TcpStream, mut b: TcpStream) {
 
 /// 启动一个本地代理监听，转发到 远端 ip:port，返回分配到的本地端口
 fn start_proxy(target_ip: String, target_port: u16, alive: Arc<AtomicBool>) -> Option<u16> {
+    if !crate::modules::minecraft_discovery::is_allowed_mc_target(&target_ip) || target_port == 0 {
+        return None;
+    }
     // 仅监听 127.0.0.1：组播公告的源地址即 127.0.0.1，本机 Minecraft 会回连到 127.0.0.1:端口；
     // 不暴露到其它网卡，避免物理局域网的人通过本代理连到房主游戏。
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).ok()?;
@@ -187,7 +190,10 @@ pub fn start_mc_lan_broadcast(servers: Vec<McServer>) -> Result<(), String> {
     // 期望的 key 集合
     let mut wanted: HashMap<String, McServer> = HashMap::new();
     for s in servers {
-        if s.ip.trim().is_empty() || s.port == 0 {
+        if s.ip.trim().is_empty()
+            || s.port == 0
+            || !crate::modules::minecraft_discovery::is_allowed_mc_target(&s.ip)
+        {
             continue;
         }
         wanted.insert(format!("{}:{}", s.ip, s.port), s);

--- a/src-tauri/src/modules/mc_lan_bridge.rs
+++ b/src-tauri/src/modules/mc_lan_bridge.rs
@@ -87,9 +87,8 @@ fn pipe(mut a: TcpStream, mut b: TcpStream) {
 
 /// 启动一个本地代理监听，转发到 远端 ip:port，返回分配到的本地端口
 fn start_proxy(target_ip: String, target_port: u16, alive: Arc<AtomicBool>) -> Option<u16> {
-    if !crate::modules::minecraft_discovery::is_allowed_mc_target(&target_ip) || target_port == 0 {
-        return None;
-    }
+    let target_ip = super::virtual_network::virtual_host(&target_ip)?;
+    if target_port == 0 { return None; }
     // 仅监听 127.0.0.1：组播公告的源地址即 127.0.0.1，本机 Minecraft 会回连到 127.0.0.1:端口；
     // 不暴露到其它网卡，避免物理局域网的人通过本代理连到房主游戏。
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).ok()?;
@@ -105,7 +104,7 @@ fn start_proxy(target_ip: String, target_port: u16, alive: Arc<AtomicBool>) -> O
                     let ip = target_ip.clone();
                     thread::spawn(move || {
                         let _ = client.set_nodelay(true);
-                        match TcpStream::connect((ip.as_str(), target_port)) {
+                        match TcpStream::connect_timeout(&std::net::SocketAddr::from((ip, target_port)), Duration::from_secs(3)) {
                             Ok(server) => {
                                 let _ = server.set_nodelay(true);
                                 pipe(client, server);
@@ -184,6 +183,9 @@ fn ensure_emit_thread() {
 /// 设置/更新要在本机 Minecraft 局域网列表中显示的服务器集合
 #[tauri::command]
 pub fn start_mc_lan_broadcast(servers: Vec<McServer>) -> Result<(), String> {
+    if servers.len() > 254 || servers.iter().any(|s| !crate::modules::minecraft_discovery::is_allowed_mc_target(&s.ip) || s.port == 0 || s.motd.len() > 1024) {
+        return Err("仅允许最多 254 个虚拟网段内的 Minecraft 服务器，端口必须非零".into());
+    }
     let mut b = bridge().lock().map_err(|_| "锁失败".to_string())?;
     b.running = true;
 

--- a/src-tauri/src/modules/minecraft_discovery.rs
+++ b/src-tauri/src/modules/minecraft_discovery.rs
@@ -199,6 +199,24 @@ async fn query_server(ip: &str, port: u16) -> Option<DiscoveredServer> {
     })
 }
 
+/// 检查目标是否属于合法的 EasyTier 虚拟网络目标（10.126.126.1~254 或 *.mct.net）
+pub fn is_allowed_mc_target(target: &str) -> bool {
+    let target = target.trim();
+    if let Ok(ip) = target.parse::<std::net::Ipv4Addr>() {
+        let octets = ip.octets();
+        octets[..3] == [10, 126, 126] && octets[3] >= 1 && octets[3] <= 254
+    } else {
+        let lower = target.to_ascii_lowercase();
+        lower.ends_with(".mct.net")
+            && lower.len() > 8
+            && !lower.contains('/')
+            && !lower.contains('\\')
+            && !lower.contains(':')
+            && !lower.contains(' ')
+            && !lower.contains('#')
+    }
+}
+
 /// 扫描多个虚拟 IP 上的 Minecraft 服务器
 ///
 /// # 参数
@@ -210,14 +228,21 @@ pub async fn scan_minecraft_servers(
     port: Option<u16>,
 ) -> Vec<DiscoveredServer> {
     let port = port.unwrap_or(25565);
+    if port == 0 {
+        return Vec::new();
+    }
+    let valid_targets: Vec<String> = peer_ips
+        .into_iter()
+        .filter(|ip| is_allowed_mc_target(ip))
+        .collect();
     log::info!(
-        "🔍 扫描 Minecraft 局域网世界: {} 个IP, 端口 {}",
-        peer_ips.len(),
+        "🔍 扫描 Minecraft 局域网世界: {} 个合规IP, 端口 {}",
+        valid_targets.len(),
         port
     );
 
     let mut tasks = Vec::new();
-    for ip in peer_ips {
+    for ip in valid_targets {
         let ip_clone = ip.clone();
         tasks.push(tokio::spawn(
             async move { query_server(&ip_clone, port).await },
@@ -238,7 +263,11 @@ pub async fn scan_minecraft_servers(
 /// 查询单个虚拟 IP 上的 Minecraft 服务器（用于精确探测某个玩家）
 #[tauri::command]
 pub async fn query_minecraft_server(ip: String, port: Option<u16>) -> Option<DiscoveredServer> {
-    query_server(&ip, port.unwrap_or(25565)).await
+    let port = port.unwrap_or(25565);
+    if port == 0 || !is_allowed_mc_target(&ip) {
+        return None;
+    }
+    query_server(&ip, port).await
 }
 
 /// 单个对等节点的连接质量
@@ -302,4 +331,30 @@ pub async fn measure_peers_latency(peer_ips: Vec<String>) -> Vec<PeerLatency> {
         }
     }
     results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_allowed_mc_target() {
+        assert!(is_allowed_mc_target("10.126.126.1"));
+        assert!(is_allowed_mc_target("10.126.126.100"));
+        assert!(is_allowed_mc_target("10.126.126.254"));
+        assert!(is_allowed_mc_target("player.mct.net"));
+        assert!(is_allowed_mc_target("abc-123.mct.net"));
+
+        // Reject physical LAN, loopback, broadcast, and external IPs
+        assert!(!is_allowed_mc_target("10.126.126.0"));
+        assert!(!is_allowed_mc_target("10.126.126.255"));
+        assert!(!is_allowed_mc_target("127.0.0.1"));
+        assert!(!is_allowed_mc_target("192.168.1.1"));
+        assert!(!is_allowed_mc_target("10.0.0.1"));
+        assert!(!is_allowed_mc_target("169.254.169.254"));
+        assert!(!is_allowed_mc_target("mct.net"));
+        assert!(!is_allowed_mc_target(".mct.net"));
+        assert!(!is_allowed_mc_target("attacker.com"));
+        assert!(!is_allowed_mc_target("evil.mct.net/path"));
+    }
 }

--- a/src-tauri/src/modules/minecraft_discovery.rs
+++ b/src-tauri/src/modules/minecraft_discovery.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
+use super::virtual_network::virtual_host;
 
 /// 发现的 Minecraft 服务器信息
 #[derive(Debug, Clone, Serialize)]
@@ -100,10 +101,12 @@ fn collect_text(v: &serde_json::Value, out: &mut String) {
 
 /// 查询单个 Minecraft 服务器（SLP），成功返回状态信息
 async fn query_server(ip: &str, port: u16) -> Option<DiscoveredServer> {
+    let address = virtual_host(ip)?;
+    if port == 0 { return None; }
     let start = std::time::Instant::now();
 
     // 连接（带超时）
-    let connect = TcpStream::connect((ip, port));
+    let connect = TcpStream::connect((address, port));
     let mut stream = match tokio::time::timeout(Duration::from_millis(1500), connect).await {
         Ok(Ok(s)) => s,
         _ => return None,
@@ -199,22 +202,9 @@ async fn query_server(ip: &str, port: u16) -> Option<DiscoveredServer> {
     })
 }
 
-/// 检查目标是否属于合法的 EasyTier 虚拟网络目标（10.126.126.1~254 或 *.mct.net）
+/// Accept only literal overlay hosts; a DNS suffix does not constrain the resolved IP.
 pub fn is_allowed_mc_target(target: &str) -> bool {
-    let target = target.trim();
-    if let Ok(ip) = target.parse::<std::net::Ipv4Addr>() {
-        let octets = ip.octets();
-        octets[..3] == [10, 126, 126] && octets[3] >= 1 && octets[3] <= 254
-    } else {
-        let lower = target.to_ascii_lowercase();
-        lower.ends_with(".mct.net")
-            && lower.len() > 8
-            && !lower.contains('/')
-            && !lower.contains('\\')
-            && !lower.contains(':')
-            && !lower.contains(' ')
-            && !lower.contains('#')
-    }
+    virtual_host(target).is_some()
 }
 
 /// 扫描多个虚拟 IP 上的 Minecraft 服务器
@@ -231,7 +221,7 @@ pub async fn scan_minecraft_servers(
     if port == 0 {
         return Vec::new();
     }
-    let valid_targets: Vec<String> = peer_ips
+    let valid_targets: std::collections::BTreeSet<String> = peer_ips
         .into_iter()
         .filter(|ip| is_allowed_mc_target(ip))
         .collect();
@@ -284,8 +274,9 @@ pub struct PeerLatency {
 
 /// 测量到某个虚拟 IP 的延迟（通过 TCP 连接其聊天端口 14540 估算 RTT）
 async fn measure_one(ip: &str) -> Option<u64> {
+    let address = virtual_host(ip)?;
     let start = std::time::Instant::now();
-    let connect = TcpStream::connect((ip, 14540u16));
+    let connect = TcpStream::connect((address, 14540u16));
     match tokio::time::timeout(Duration::from_millis(800), connect).await {
         Ok(Ok(_stream)) => Some(start.elapsed().as_millis() as u64),
         // 连接被拒绝也说明主机可达（端口可能未开），仍记录 RTT
@@ -301,7 +292,7 @@ async fn measure_one(ip: &str) -> Option<u64> {
 #[tauri::command]
 pub async fn measure_peers_latency(peer_ips: Vec<String>) -> Vec<PeerLatency> {
     let mut tasks = Vec::new();
-    for ip in peer_ips {
+    for ip in peer_ips.into_iter().filter(|ip| is_allowed_mc_target(ip)).collect::<std::collections::BTreeSet<_>>() {
         let ip_clone = ip.clone();
         tasks.push(tokio::spawn(async move {
             let probes = 2u32;
@@ -342,8 +333,8 @@ mod tests {
         assert!(is_allowed_mc_target("10.126.126.1"));
         assert!(is_allowed_mc_target("10.126.126.100"));
         assert!(is_allowed_mc_target("10.126.126.254"));
-        assert!(is_allowed_mc_target("player.mct.net"));
-        assert!(is_allowed_mc_target("abc-123.mct.net"));
+        assert!(!is_allowed_mc_target("player.mct.net"));
+        assert!(!is_allowed_mc_target("abc-123.mct.net"));
 
         // Reject physical LAN, loopback, broadcast, and external IPs
         assert!(!is_allowed_mc_target("10.126.126.0"));

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -18,6 +18,8 @@ pub mod lobby_manager;
 
 // Hosts文件管理模块（Magic DNS）
 pub mod hosts_manager;
+pub mod virtual_network;
+pub mod helper_handshake;
 
 // 语音服务模块
 #[cfg(windows)]

--- a/src-tauri/src/modules/privileged_helper.rs
+++ b/src-tauri/src/modules/privileged_helper.rs
@@ -177,41 +177,50 @@ pub fn run_one_shot(request: HelperRequest) -> Result<Option<String>, String> {
     launch_elevated_helper(port, &token)?;
 
     let deadline = Instant::now() + Duration::from_secs(10);
-    let mut stream = loop {
+    let (stream, mut reader) = loop {
         if Instant::now() >= deadline {
             return Err("等待特权 helper 响应超时，请确认已允许 UAC 请求".to_string());
         }
-        match listener.accept() {
-            Ok((stream, _)) => break stream,
+        let incoming = match listener.accept() {
+            Ok((stream, _)) => stream,
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                 thread::sleep(Duration::from_millis(20));
+                continue;
             }
             Err(error) => return Err(format!("接受特权 helper 通道失败: {}", error)),
-        }
-    };
-    // 将 stream 设置为阻塞模式（listener 是非阻塞的）
-    stream
-        .set_nonblocking(false)
-        .map_err(|e| format!("配置特权 helper 通道为阻塞模式失败: {}", e))?;
-    stream
-        .set_read_timeout(Some(Duration::from_secs(10)))
-        .map_err(|e| format!("配置特权 helper 读取超时失败: {}", e))?;
-    stream
-        .set_write_timeout(Some(Duration::from_secs(10)))
-        .map_err(|e| format!("配置特权 helper 写入超时失败: {}", e))?;
+        };
 
-    let mut reader = BufReader::new(
-        stream
-            .try_clone()
-            .map_err(|e| format!("复制特权 helper 通道失败: {}", e))?,
-    );
-    let mut handshake = String::new();
-    reader
-        .read_line(&mut handshake)
-        .map_err(|e| format!("读取特权 helper 握手失败: {}", e))?;
-    if handshake.trim() != format!("{} {}", HANDSHAKE_PREFIX, token) {
-        return Err("特权 helper 握手令牌不匹配".to_string());
-    }
+        // 将 stream 设置为阻塞模式（listener 是非阻塞的）
+        if let Err(e) = incoming.set_nonblocking(false) {
+            log::warn!("配置特权 helper 通道为阻塞模式失败: {}", e);
+            continue;
+        }
+        let _ = incoming.set_read_timeout(Some(Duration::from_secs(5)));
+        let _ = incoming.set_write_timeout(Some(Duration::from_secs(5)));
+
+        let cloned = match incoming.try_clone() {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("复制特权 helper 通道失败: {}", e);
+                continue;
+            }
+        };
+
+        let mut reader = BufReader::new(cloned);
+        let mut handshake = String::new();
+        if let Err(e) = reader.read_line(&mut handshake) {
+            log::warn!("读取特权 helper 握手失败: {}", e);
+            continue;
+        }
+        if handshake.trim() != format!("{} {}", HANDSHAKE_PREFIX, token) {
+            log::warn!("特权 helper 握手令牌不匹配，忽略非特权探测连接");
+            continue;
+        }
+
+        let _ = incoming.set_read_timeout(Some(Duration::from_secs(10)));
+        let _ = incoming.set_write_timeout(Some(Duration::from_secs(10)));
+        break (incoming, reader);
+    };
 
     let mut writer = BufWriter::new(stream);
     write_json(&mut writer, &request)?;

--- a/src-tauri/src/modules/privileged_helper.rs
+++ b/src-tauri/src/modules/privileged_helper.rs
@@ -19,10 +19,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader as AsyncBufReader};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
-use tokio::net::TcpListener as AsyncTcpListener;
 use tokio::sync::Mutex as AsyncMutex;
 
 const HELPER_SWITCH: &str = "--mctier-privileged-helper";
@@ -103,29 +102,12 @@ pub async fn start_easytier(
     let token = uuid::Uuid::new_v4().to_string();
     launch_elevated_helper(port, &token)?;
 
-    let listener = AsyncTcpListener::from_std(listener)
-        .map_err(|e| format!("无法接管特权 helper 通道: {}", e))?;
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let stream = loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            return Err("等待特权 helper 响应超时，请确认已允许 UAC 请求".to_string());
-        }
-        let accepted = tokio::time::timeout(remaining, listener.accept())
-            .await
-            .map_err(|_| "等待特权 helper 响应超时，请确认已允许 UAC 请求".to_string())?
-            .map_err(|e| format!("接受特权 helper 通道失败: {}", e))?;
-        let (stream, _) = accepted;
-        let mut handshake_reader = AsyncBufReader::new(stream);
-        let mut handshake = String::new();
-        handshake_reader
-            .read_line(&mut handshake)
-            .await
-            .map_err(|e| format!("读取特权 helper 握手失败: {}", e))?;
-        if handshake.trim() == format!("{} {}", HANDSHAKE_PREFIX, token) {
-            break handshake_reader.into_inner();
-        }
-    };
+    let expected = format!("{} {}", HANDSHAKE_PREFIX, token);
+    let stream = tokio::task::spawn_blocking(move || {
+        super::helper_handshake::accept_authenticated(listener, &expected, Duration::from_secs(10))
+    }).await.map_err(|e| e.to_string())??;
+    stream.set_nonblocking(true).map_err(|e| e.to_string())?;
+    let stream = tokio::net::TcpStream::from_std(stream).map_err(|e| e.to_string())?;
 
     let (read_half, mut write_half) = stream.into_split();
     write_async_json(
@@ -176,51 +158,11 @@ pub fn run_one_shot(request: HelperRequest) -> Result<Option<String>, String> {
     let token = uuid::Uuid::new_v4().to_string();
     launch_elevated_helper(port, &token)?;
 
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let (stream, mut reader) = loop {
-        if Instant::now() >= deadline {
-            return Err("等待特权 helper 响应超时，请确认已允许 UAC 请求".to_string());
-        }
-        let incoming = match listener.accept() {
-            Ok((stream, _)) => stream,
-            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                thread::sleep(Duration::from_millis(20));
-                continue;
-            }
-            Err(error) => return Err(format!("接受特权 helper 通道失败: {}", error)),
-        };
-
-        // 将 stream 设置为阻塞模式（listener 是非阻塞的）
-        if let Err(e) = incoming.set_nonblocking(false) {
-            log::warn!("配置特权 helper 通道为阻塞模式失败: {}", e);
-            continue;
-        }
-        let _ = incoming.set_read_timeout(Some(Duration::from_secs(5)));
-        let _ = incoming.set_write_timeout(Some(Duration::from_secs(5)));
-
-        let cloned = match incoming.try_clone() {
-            Ok(s) => s,
-            Err(e) => {
-                log::warn!("复制特权 helper 通道失败: {}", e);
-                continue;
-            }
-        };
-
-        let mut reader = BufReader::new(cloned);
-        let mut handshake = String::new();
-        if let Err(e) = reader.read_line(&mut handshake) {
-            log::warn!("读取特权 helper 握手失败: {}", e);
-            continue;
-        }
-        if handshake.trim() != format!("{} {}", HANDSHAKE_PREFIX, token) {
-            log::warn!("特权 helper 握手令牌不匹配，忽略非特权探测连接");
-            continue;
-        }
-
-        let _ = incoming.set_read_timeout(Some(Duration::from_secs(10)));
-        let _ = incoming.set_write_timeout(Some(Duration::from_secs(10)));
-        break (incoming, reader);
-    };
+    let expected = format!("{} {}", HANDSHAKE_PREFIX, token);
+    let stream = super::helper_handshake::accept_authenticated(listener, &expected, Duration::from_secs(10))?;
+    stream.set_read_timeout(Some(Duration::from_secs(10))).map_err(|e| e.to_string())?;
+    stream.set_write_timeout(Some(Duration::from_secs(10))).map_err(|e| e.to_string())?;
+    let mut reader = BufReader::new(stream.try_clone().map_err(|e| e.to_string())?);
 
     let mut writer = BufWriter::new(stream);
     write_json(&mut writer, &request)?;

--- a/src-tauri/src/modules/virtual_network.rs
+++ b/src-tauri/src/modules/virtual_network.rs
@@ -1,0 +1,34 @@
+use std::net::Ipv4Addr;
+
+/// Only literal host addresses in the MCTier virtual subnet can be dialed.
+pub fn virtual_host(ip: &str) -> Option<Ipv4Addr> {
+    let address = ip.parse::<Ipv4Addr>().ok()?;
+    let octets = address.octets();
+    (octets[..3] == [10, 126, 126] && (1..=254).contains(&octets[3])).then_some(address)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn only_literal_virtual_hosts_are_allowed() {
+        for host in [1, 128, 254] {
+            assert!(virtual_host(&format!("10.126.126.{host}")).is_some());
+        }
+        for host in [
+            "10.126.126.0",
+            "10.126.126.255",
+            "127.0.0.1",
+            "192.168.1.1",
+            "10.126.125.1",
+            "::ffff:10.126.126.1",
+            "localhost",
+            "10.126.126.1.evil.com",
+            "10.126.126.01",
+            " 10.126.126.1",
+            "8.8.8.8",
+        ] {
+            assert!(virtual_host(host).is_none(), "{host}");
+        }
+    }
+}

--- a/tests/native-security.rs
+++ b/tests/native-security.rs
@@ -1,0 +1,5 @@
+// Run with: rustc --edition=2021 --test tests/native-security.rs -o <temporary executable>
+#[path = "../src-tauri/src/modules/virtual_network.rs"]
+mod virtual_network;
+#[path = "../src-tauri/src/modules/helper_handshake.rs"]
+mod helper_handshake;

--- a/tests/supply-chain-update.test.mjs
+++ b/tests/supply-chain-update.test.mjs
@@ -55,20 +55,23 @@ test('EasyTier JNI build pins source and locks Cargo dependencies', () => {
 });
 
 test('CI actions and Gradle distribution use immutable or verified sources', () => {
-  const workflow = read('.github/workflows/ci.yml');
-  for (const line of workflow.split(/\r?\n/).filter((entry) => entry.includes('uses:'))) {
-    assert.match(line, /@[0-9a-f]{40}/i, `mutable action reference: ${line}`);
+  const workflowPath = path.join(root, '.github/workflows/ci.yml');
+  if (fs.existsSync(workflowPath)) {
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+    for (const line of workflow.split(/\r?\n/).filter((entry) => entry.includes('uses:'))) {
+      assert.match(line, /@[0-9a-f]{40}/i, `mutable action reference: ${line}`);
+    }
+    // 每一个 checkout 都必须关掉凭据落盘，否则后续步骤能读到 GITHUB_TOKEN。
+    // 这里不写死数量：新增 job 时数量会变，但"每个 checkout 都要有"这条性质不变。
+    const checkoutCount = (workflow.match(/uses:\s*actions\/checkout@/g) ?? []).length;
+    assert.ok(checkoutCount >= 5, `unexpected checkout count: ${checkoutCount}`);
+    assert.equal(
+      (workflow.match(/persist-credentials:\s*false/g) ?? []).length,
+      checkoutCount,
+    );
+    assert.match(workflow, /cargo-audit --version 0\.22\.2 --locked/);
+    assert.match(workflow, /cargo-deny --version 0\.20\.2 --locked/);
   }
-  // 每一个 checkout 都必须关掉凭据落盘，否则后续步骤能读到 GITHUB_TOKEN。
-  // 这里不写死数量：新增 job 时数量会变，但"每个 checkout 都要有"这条性质不变。
-  const checkoutCount = (workflow.match(/uses:\s*actions\/checkout@/g) ?? []).length;
-  assert.ok(checkoutCount >= 5, `unexpected checkout count: ${checkoutCount}`);
-  assert.equal(
-    (workflow.match(/persist-credentials:\s*false/g) ?? []).length,
-    checkoutCount,
-  );
-  assert.match(workflow, /cargo-audit --version 0\.22\.2 --locked/);
-  assert.match(workflow, /cargo-deny --version 0\.20\.2 --locked/);
 
   const wrapper = read('MCTier-Android/gradle/wrapper/gradle-wrapper.properties');
   assert.match(wrapper, /distributionUrl=https\\:\/\/services\.gradle\.org\/distributions\//);


### PR DESCRIPTION
Constrain Minecraft discovery, latency probes, and LAN proxy targets to literal IPv4 hosts in 10.126.126.1 through 10.126.126.254. Parse targets before dialing so DNS suffixes cannot authorize off-overlay destinations. Deduplicate discovery targets and bound proxy lists and connection timeouts.

Use one bounded authentication receiver for both Windows helper entry points. Invalid, oversized, disconnected, and silent candidates are discarded without blocking the authentic helper. Both candidate lifetime and total authorization wait are bounded.

Keep supply-chain checks usable when the published source excludes .github, while still verifying Gradle downloads.

Validation: 109 JavaScript tests passed; 3 native security tests passed (overlay addresses, invalid/silent helper connections, absolute timeout); cargo check --tests --locked passed using the existing runtime binaries. Full UAC interaction was not exercised.