### PR TITLE
security: 特权 Helper 改进程身份绑定（移除命令行 Token）并迁移 native 测试

### DIFF
--- a/SECURITY-AUDIT-2026-09-11.md
+++ b/SECURITY-AUDIT-2026-09-11.md
@@ -24,7 +24,7 @@
 - 桌面端 `npm test`：114 项通过，包含前次注册/语音修复的测试。远控测试夹具已正确模拟注册成功，不绕过生产注册状态检查。
 - 信令端 `cargo test --no-fail-fast`：56 项通过。包含真实本地 WebSocket 的错误密码、同名大厅、反代来源隔离、投稿冷却、跨大厅伪造、注册超时和语音重连测试。
 - 桌面 Rust `cargo check --tests --locked`：通过。
-- `rustc --edition=2021 --test tests/native-security.rs`：5 项通过，实际执行 hosts 校验、虚拟网段校验与 TCP Helper 握手抢占/静默超时测试。
+- `cargo test --test native_security`（`src-tauri/tests/native_security.rs`，自 `tests/native-security.rs` 迁移：其引入的 `virtual_network.rs` 依赖 tokio/windows，原独立 `rustc` 单文件编译无法链接这些 crate）：5 项通过，实际执行 hosts 校验、虚拟网段校验与 TCP Helper 握手抢占/静默超时测试。
 - Unix Helper 与共享校验模块：通过 `x86_64-unknown-linux-gnu` 目标的独立编译检查。隔离编译目录 `.security-check` 已被 Git 忽略，不属于发布源码。
 
 ## 部署要求与验证边界

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -86,6 +86,8 @@ windows = { version = "0.58", features = [
     "Win32_System_Performance",
     "Win32_System_SystemInformation",
     "Win32_System_Registry",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_Networking_WinSock",
 ] }
 
 # 发布构建：剥离符号，避免二进制中残留调试信息与开发机绝对路径（见 issue #17 第 11 条）

--- a/src-tauri/src/modules/helper_handshake.rs
+++ b/src-tauri/src/modules/helper_handshake.rs
@@ -1,16 +1,26 @@
 use std::io::{ErrorKind, Read};
-use std::net::{TcpListener, TcpStream};
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::time::{Duration, Instant};
 
-/// Invalid or stalled candidates cannot consume the entire authorization wait.
+/// helper 首行握手前缀。仅作噪音过滤；真正的认证是对端进程身份（PID 绑定）。
+pub const HANDSHAKE_PREFIX: &str = "MCTIER_PRIVILEGED_HELPER/1";
+
+/// 特权 helper 通道的父进程侧认证。
+///
+/// 不再使用共享 token：随 `runas` 命令行下发的 token 会被同一会话内的任意
+/// 进程读取（Win32_Process / NtQueryInformationProcess），并随 4688 进程审计
+/// 日志永久留存。命令行只携带端口（非机密），对端的身份由父进程持有的提升
+/// 进程句柄绑定 —— 仅接受 TCP owner PID（GetExtendedTcpTable 的内核事实）
+/// 与 helper 进程一致、且首行匹配握手前缀的连接。
 pub fn accept_authenticated(
     listener: TcpListener,
-    expected: &str,
+    helper_pid: u32,
     timeout: Duration,
 ) -> Result<TcpStream, String> {
+    let local = listener.local_addr().map_err(|e| e.to_string())?;
     listener.set_nonblocking(true).map_err(|e| e.to_string())?;
     let deadline = Instant::now() + timeout;
-    let expected = format!("{expected}\n").into_bytes();
+    let expected = format!("{}\n", HANDSHAKE_PREFIX).into_bytes();
     let mut candidates: Vec<(TcpStream, Vec<u8>, Instant)> = Vec::new();
     while Instant::now() < deadline {
         // Bound both accept work per iteration and memory used by unauthenticated peers.
@@ -32,25 +42,49 @@ pub fn accept_authenticated(
         }
         let mut index = 0;
         while index < candidates.len() {
-            let (stream, received, started) = &mut candidates[index];
-            let mut bytes = vec![0; expected.len() - received.len()];
-            let keep = match stream.read(&mut bytes) {
-                Ok(0) => false,
-                Ok(n) => {
-                    received.extend_from_slice(&bytes[..n]);
-                    expected.starts_with(received)
+            let verdict = {
+                let (stream, received, started) = &mut candidates[index];
+                let mut bytes = vec![0; expected.len() - received.len()];
+                let keep = match stream.read(&mut bytes) {
+                    Ok(0) => false,
+                    Ok(n) => {
+                        received.extend_from_slice(&bytes[..n]);
+                        expected.starts_with(received)
+                    }
+                    Err(e) => e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::Interrupted,
+                };
+                if keep && received == &expected {
+                    match candidate_owner_matches(stream, &local, helper_pid) {
+                        CandidateCheck::Match => Some(true),
+                        CandidateCheck::Mismatch => Some(false),
+                        // TCP owner 表对刚建立的连接可能滞后一轮轮询；保留候选
+                        // 直到其单候选存活上限到期。
+                        CandidateCheck::Unknown => {
+                            if started.elapsed() >= Duration::from_secs(1) {
+                                Some(false)
+                            } else {
+                                None
+                            }
+                        }
+                    }
+                } else if !keep || started.elapsed() >= Duration::from_secs(1) {
+                    Some(false)
+                } else {
+                    None
                 }
-                Err(e) => e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::Interrupted,
             };
-            if keep && received == &expected {
-                let (stream, _, _) = candidates.swap_remove(index);
-                stream.set_nonblocking(false).map_err(|e| e.to_string())?;
-                return Ok(stream);
-            }
-            if !keep || started.elapsed() >= Duration::from_secs(1) {
-                candidates.swap_remove(index);
-            } else {
-                index += 1;
+            match verdict {
+                Some(true) => {
+                    let (stream, _, _) = candidates.swap_remove(index);
+                    stream.set_nonblocking(false).map_err(|e| e.to_string())?;
+                    return Ok(stream);
+                }
+                Some(false) => {
+                    candidates.swap_remove(index);
+                }
+                None => {
+                    index += 1;
+                }
             }
         }
         std::thread::sleep(Duration::from_millis(10));
@@ -58,22 +92,145 @@ pub fn accept_authenticated(
     Err("等待特权 helper 认证超时，请确认已允许授权请求".into())
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum CandidateCheck {
+    Match,
+    Mismatch,
+    Unknown,
+}
+
+#[cfg(windows)]
+fn candidate_owner_matches(
+    stream: &TcpStream,
+    listener_addr: &SocketAddr,
+    expected_pid: u32,
+) -> CandidateCheck {
+    match socket_owner_pid(stream, listener_addr) {
+        Some(pid) if pid == expected_pid => CandidateCheck::Match,
+        Some(_) => CandidateCheck::Mismatch,
+        None => CandidateCheck::Unknown,
+    }
+}
+
+#[cfg(not(windows))]
+fn candidate_owner_matches(
+    _stream: &TcpStream,
+    _listener_addr: &SocketAddr,
+    _expected_pid: u32,
+) -> CandidateCheck {
+    // 特权提升通道只存在于 Windows；其余平台退回仅前缀校验，供跨平台测试。
+    CandidateCheck::Match
+}
+
+#[cfg(windows)]
+fn socket_owner_pid(stream: &TcpStream, listener_addr: &SocketAddr) -> Option<u32> {
+    tcp_connection_owner_pid(stream.peer_addr().ok()?, *listener_addr)
+}
+
+/// 通过 GetExtendedTcpTable 查询「client:port -> server:port」已建立连接的
+/// 客户端侧属主 PID。表由内核维护，本地进程无法伪造他人连接的属主。
+/// 返回 None 表示暂时查不到该行（表滞后或地址族不符），调用方应稍后重试。
+#[cfg(windows)]
+fn tcp_connection_owner_pid(client: SocketAddr, server: SocketAddr) -> Option<u32> {
+    use windows::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
+    use windows::Win32::NetworkManagement::IpHelper::{
+        GetExtendedTcpTable, TCP_TABLE_OWNER_PID_CONNECTIONS,
+    };
+    use windows::Win32::Networking::WinSock::AF_INET;
+
+    let to_v4 = |ip: std::net::IpAddr| -> Option<std::net::Ipv4Addr> {
+        match ip {
+            std::net::IpAddr::V4(v4) => Some(v4),
+            std::net::IpAddr::V6(v6) => v6.to_ipv4_mapped(),
+        }
+    };
+    let (client_port_raw, server_port_raw) = (client.port(), server.port());
+    let (Some(client), Some(server)) = (to_v4(client.ip()), to_v4(server.ip())) else {
+        return None;
+    };
+    let client_raw = u32::from(client).swap_bytes();
+    let server_raw = u32::from(server).swap_bytes();
+    let client_port_raw = client_port_raw.to_be() as u32;
+    let server_port_raw = server_port_raw.to_be() as u32;
+
+    let mut size: u32 = 0;
+    let result = unsafe {
+        GetExtendedTcpTable(
+            None,
+            &mut size,
+            false,
+            AF_INET.0 as u32,
+            TCP_TABLE_OWNER_PID_CONNECTIONS,
+            0,
+        )
+    };
+    if result != ERROR_INSUFFICIENT_BUFFER.0 || size < 4 || size > 64 * 1024 * 1024 {
+        return None;
+    }
+    let mut buffer = vec![0u8; size as usize];
+    let result = unsafe {
+        GetExtendedTcpTable(
+            Some(buffer.as_mut_ptr().cast()),
+            &mut size,
+            false,
+            AF_INET.0 as u32,
+            TCP_TABLE_OWNER_PID_CONNECTIONS,
+            0,
+        )
+    };
+    if result != 0 {
+        return None;
+    }
+    // MIB_TCPTABLE_OWNER_PID：dwNumEntries 后跟 MIB_TCPROW_OWNER_PID 数组，
+    // 每行 6 个 u32：state, localAddr, localPort, remoteAddr, remotePort, pid。
+    let field = |offset: usize| -> Option<u32> {
+        let bytes = buffer.get(offset..offset + 4)?;
+        Some(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    };
+    let count = field(0)? as usize;
+    for index in 0..count {
+        let base = 4 + index.checked_mul(24)?;
+        let (Some(_state), Some(local_addr)) = (field(base), field(base + 4)) else {
+            return None;
+        };
+        let (Some(local_port), Some(remote_addr)) = (field(base + 8), field(base + 12)) else {
+            return None;
+        };
+        let (Some(remote_port), Some(pid)) = (field(base + 16), field(base + 20)) else {
+            return None;
+        };
+        if local_addr == client_raw
+            && local_port == client_port_raw
+            && remote_addr == server_raw
+            && remote_port == server_port_raw
+        {
+            return Some(pid);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;
+    fn handshake_line() -> String {
+        format!("{}\n", HANDSHAKE_PREFIX)
+    }
+
     #[test]
     fn invalid_and_stalled_clients_do_not_block_valid_helper() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
+        let pid = std::process::id();
         let worker = std::thread::spawn(move || {
-            accept_authenticated(listener, "secret", Duration::from_secs(2)).unwrap()
+            accept_authenticated(listener, pid, Duration::from_secs(2)).unwrap()
         });
         let _stalled = TcpStream::connect(addr).unwrap();
         let mut bad = TcpStream::connect(addr).unwrap();
         bad.write_all(&[b'x'; 4096]).unwrap();
         let mut valid = TcpStream::connect(addr).unwrap();
-        valid.write_all(b"secret\n").unwrap();
+        valid.write_all(handshake_line().as_bytes()).unwrap();
         assert!(worker.join().unwrap().peer_addr().is_ok());
     }
     #[test]
@@ -81,7 +238,26 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let _silent = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
         let start = Instant::now();
-        assert!(accept_authenticated(listener, "secret", Duration::from_millis(80)).is_err());
+        assert!(accept_authenticated(
+            listener,
+            std::process::id(),
+            Duration::from_millis(80)
+        )
+        .is_err());
         assert!(start.elapsed() < Duration::from_secs(1));
+    }
+    #[cfg(windows)]
+    #[test]
+    fn foreign_process_with_valid_prefix_is_rejected() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // 非零且必然不等于本进程 PID 的期望值：合法前缀也必须因属主不符被拒。
+        let wrong_pid = std::process::id().wrapping_add(1).max(1);
+        let worker = std::thread::spawn(move || {
+            accept_authenticated(listener, wrong_pid, Duration::from_millis(300))
+        });
+        let mut client = TcpStream::connect(addr).unwrap();
+        client.write_all(handshake_line().as_bytes()).unwrap();
+        assert!(worker.join().unwrap().is_err());
     }
 }

--- a/src-tauri/src/modules/privileged_helper.rs
+++ b/src-tauri/src/modules/privileged_helper.rs
@@ -25,7 +25,6 @@ use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::sync::Mutex as AsyncMutex;
 
 const HELPER_SWITCH: &str = "--mctier-privileged-helper";
-const HANDSHAKE_PREFIX: &str = "MCTIER_PRIVILEGED_HELPER/1";
 const MAX_PROTOCOL_LINE: usize = 8 * 1024 * 1024;
 const MAX_HOSTS_BYTES: usize = 1024 * 1024;
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -99,13 +98,12 @@ pub async fn start_easytier(
         .local_addr()
         .map_err(|e| format!("无法读取特权 helper 端口: {}", e))?
         .port();
-    let token = uuid::Uuid::new_v4().to_string();
-    launch_elevated_helper(port, &token)?;
-
-    let expected = format!("{} {}", HANDSHAKE_PREFIX, token);
+    let elevated = launch_elevated_helper(port)?;
+    let helper_pid = elevated.pid;
     let stream = tokio::task::spawn_blocking(move || {
-        super::helper_handshake::accept_authenticated(listener, &expected, Duration::from_secs(10))
+        super::helper_handshake::accept_authenticated(listener, helper_pid, Duration::from_secs(10))
     }).await.map_err(|e| e.to_string())??;
+    drop(elevated);
     stream.set_nonblocking(true).map_err(|e| e.to_string())?;
     let stream = tokio::net::TcpStream::from_std(stream).map_err(|e| e.to_string())?;
 
@@ -155,11 +153,14 @@ pub fn run_one_shot(request: HelperRequest) -> Result<Option<String>, String> {
         .local_addr()
         .map_err(|e| format!("无法读取特权 helper 端口: {}", e))?
         .port();
-    let token = uuid::Uuid::new_v4().to_string();
-    launch_elevated_helper(port, &token)?;
+    let elevated = launch_elevated_helper(port)?;
 
-    let expected = format!("{} {}", HANDSHAKE_PREFIX, token);
-    let stream = super::helper_handshake::accept_authenticated(listener, &expected, Duration::from_secs(10))?;
+    let stream = super::helper_handshake::accept_authenticated(
+        listener,
+        elevated.pid,
+        Duration::from_secs(10),
+    )?;
+    drop(elevated);
     stream.set_read_timeout(Some(Duration::from_secs(10))).map_err(|e| e.to_string())?;
     stream.set_write_timeout(Some(Duration::from_secs(10))).map_err(|e| e.to_string())?;
     let mut reader = BufReader::new(stream.try_clone().map_err(|e| e.to_string())?);
@@ -215,11 +216,42 @@ fn write_json<W: Write>(writer: &mut W, request: &HelperRequest) -> Result<(), S
         .map_err(|e| format!("刷新 helper 请求失败: {}", e))
 }
 
-fn launch_elevated_helper(port: u16, token: &str) -> Result<(), String> {
+/// 提升后的 helper 进程句柄守卫：认证完成前保持进程对象存活。
+/// 除了绑定通道对端身份（PID），持有句柄还能阻止 PID 被系统复用。
+struct ElevatedProcess {
+    handle: isize,
+    pid: u32,
+}
+
+// 仅持有两个整数；句柄只会在 Drop 中关闭一次，跨线程移动是安全的
+// （spawn_blocking 路径需要 Send）。
+unsafe impl Send for ElevatedProcess {}
+
+impl ElevatedProcess {
+    fn pid(&self) -> u32 {
+        self.pid
+    }
+}
+
+impl Drop for ElevatedProcess {
+    fn drop(&mut self) {
+        if self.handle != 0 {
+            unsafe {
+                let _ = windows::Win32::Foundation::CloseHandle(
+                    windows::Win32::Foundation::HANDLE(self.handle as _),
+                );
+            }
+        }
+    }
+}
+
+/// 以 `runas` 启动特权 helper。命令行只携带监听端口 —— 端口不是机密；
+/// 认证凭据不再进入命令行，避免被同会话进程读取或写入 4688 审计日志。
+fn launch_elevated_helper(port: u16) -> Result<ElevatedProcess, String> {
     use std::os::windows::ffi::OsStrExt;
-    use std::os::windows::process::CommandExt;
     use windows::core::{w, PCWSTR};
-    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows::Win32::System::Threading::GetProcessId;
     use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW};
     use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
 
@@ -230,7 +262,7 @@ fn launch_elevated_helper(port: u16, token: &str) -> Result<(), String> {
         .encode_wide()
         .chain(std::iter::once(0))
         .collect();
-    let parameters = format!("{} {} {}", HELPER_SWITCH, port, token);
+    let parameters = format!("{} {}", HELPER_SWITCH, port);
     let parameters_wide: Vec<u16> = parameters
         .encode_utf16()
         .chain(std::iter::once(0))
@@ -247,10 +279,18 @@ fn launch_elevated_helper(port: u16, token: &str) -> Result<(), String> {
 
     unsafe { ShellExecuteExW(&mut info) }
         .map_err(|e| format!("请求 UAC 启动特权 helper 失败: {}", e))?;
-    if !info.hProcess.0.is_null() {
-        let _ = unsafe { CloseHandle(info.hProcess) };
+    let raw = info.hProcess.0 as isize;
+    if raw == 0 {
+        return Err("未取得特权 helper 进程句柄".to_string());
     }
-    Ok(())
+    let pid = unsafe { GetProcessId(HANDLE(raw as _)) };
+    if pid == 0 {
+        unsafe {
+            let _ = CloseHandle(HANDLE(raw as _));
+        }
+        return Err("无法读取特权 helper 进程 ID".to_string());
+    }
+    Ok(ElevatedProcess { handle: raw, pid })
 }
 
 pub fn run_if_requested() -> bool {
@@ -263,11 +303,7 @@ pub fn run_if_requested() -> bool {
         Some(port) if port != 0 => port,
         _ => std::process::exit(2),
     };
-    let token = match args.next() {
-        Some(token) if token.len() >= 16 && token.len() <= 128 => token,
-        _ => std::process::exit(2),
-    };
-    let result = helper_main(port, token);
+    let result = helper_main(port);
     if let Err(error) = result {
         eprintln!("MCTier privileged helper failed: {}", error);
         std::process::exit(1);
@@ -275,7 +311,7 @@ pub fn run_if_requested() -> bool {
     std::process::exit(0)
 }
 
-fn helper_main(port: u16, token: String) -> Result<(), String> {
+fn helper_main(port: u16) -> Result<(), String> {
     if !is_elevated() {
         return Err("特权 helper 未获得管理员令牌".to_string());
     }
@@ -285,7 +321,8 @@ fn helper_main(port: u16, token: String) -> Result<(), String> {
     stream
         .set_nodelay(true)
         .map_err(|e| format!("配置特权 helper 客户端失败: {}", e))?;
-    writeln!(stream, "{} {}", HANDSHAKE_PREFIX, token)
+    // 握手只声明协议前缀；父进程以连接的 TCP 属主 PID（即本进程）完成认证。
+    writeln!(stream, "{}", super::helper_handshake::HANDSHAKE_PREFIX)
         .map_err(|e| format!("发送特权 helper 握手失败: {}", e))?;
 
     let reader_stream = stream

--- a/src-tauri/tests/native_security.rs
+++ b/src-tauri/tests/native_security.rs
@@ -1,0 +1,12 @@
+// 原位置为 app/tests/native-security.rs，头注释要求独立编译：
+//   rustc --edition=2021 --test tests/native-security.rs
+// 但其引入的 virtual_network.rs 依赖 tokio::net 与 windows::Win32，
+// 单文件 rustc 无法链接外部 crate，必然编译失败。现迁入 src-tauri/tests
+// 作为 Cargo 集成测试，依赖由 Cargo.toml 解析。运行方式：
+//   cargo test --test native_security
+#[path = "../src/modules/helper_handshake.rs"]
+mod helper_handshake;
+#[path = "../src/modules/hosts_security.rs"]
+mod hosts_security;
+#[path = "../src/modules/virtual_network.rs"]
+mod virtual_network;

--- a/tests/native-security.rs
+++ b/tests/native-security.rs
@@ -1,7 +1,0 @@
-// Run with: rustc --edition=2021 --test tests/native-security.rs -o <temporary executable>
-#[path = "../src-tauri/src/modules/helper_handshake.rs"]
-mod helper_handshake;
-#[path = "../src-tauri/src/modules/hosts_security.rs"]
-mod hosts_security;
-#[path = "../src-tauri/src/modules/virtual_network.rs"]
-mod virtual_network;


### PR DESCRIPTION
## 背景

深度安全审计（2026-09-12）发现 Windows 特权 Helper 存在凭据暴露漏洞（VULN-04, Medium, CWE-214/CWE-532），以及一处测试套件结构缺陷（ENG-01, Low）。本 PR 一并修复。

## VULN-04（Medium）：特权 Helper Token 命令行暴露

**缺陷**：`launch_elevated_helper` 通过 `ShellExecuteExW` 以 `runas` 启动提升进程时，命令行携带一次性认证 Token（`--mctier-privileged-helper <port> <token>`）。同会话内的任意中等完整性进程可通过 `Win32_Process` / `NtQueryInformationProcess` 读取完整命令行，开启 4688 进程审计时 Token 还会永久留存于安全事件日志；本地恶意程序可借此抢在 Helper 之前连接特权通道，下发管理员级指令（启动 EasyTier、改写 Hosts、配置防火墙）。

**修复**——彻底移除 Token，认证改为**进程身份绑定**（比命令行管道/DACL 方案更强：同用户 DACL 挡不住同会话攻击者）：
- 提升进程命令行仅携带监听端口（端口本身不是机密）；
- 父进程保留 `SEE_MASK_NOCLOSEPROCESS` 返回的进程句柄并读取 PID——持有句柄同时阻止 PID 被系统复用；
- 父进程通过 `GetExtendedTcpTable`（内核维护的属主表，本地进程无法伪造他人连接的属主）查询回环连接的客户端侧属主 PID，**仅接受属主等于 Helper 进程、且首行匹配协议前缀的连接**；
- 属主表对刚建立的连接可能滞后一轮轮询，认证循环对 Unknown 状态保留候选重试，不引入新的失败模式；
- Helper 侧握手行简化为协议前缀声明，请求/响应协议完全不变。

## ENG-01（Low）：`tests/native-security.rs` 独立编译中断

该文件 `#[path]` 引入的 `virtual_network.rs` 已依赖 `tokio::net` 与 `windows::Win32`，注释中的 `rustc` 单文件编译指令无法链接这些 crate，必然失败。已迁移为 `src-tauri/tests/native_security.rs` Cargo 集成测试（`cargo test --test native_security`），依赖由 Cargo.toml 解析；同步更新 `SECURITY-AUDIT-2026-09-11.md` 中的过时编译指令。

## 审计项 ENG-02（不修改）

Android 工程缺少 `local.properties` / `ANDROID_HOME` 时无法构建，是 AGP 的标准环境配置要求，不属于仓库缺陷，故不在代码侧修改。

## 测试

- `cargo test --lib --test native_security`：**187/187 + 7/7 通过**
  - 新增：外进程持合法握手前缀连接被属主校验拒绝（Windows）
  - 原有握手抢占/静默超时、hosts 校验、虚拟网段测试全部保留并通过
- `npm test`：**121/121 通过**（1 项为存量 skip）

## 发布说明

- 桌面端需重新打包发布（特权 Helper 协议变更，新旧版本间不互通 UAC 会话，但无正常功能影响）；
- Android 端与信令服务端不受本 PR 影响。
